### PR TITLE
feat: UX polish, live status counts, stat tooltips (v0.8)

### DIFF
--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -14,7 +14,8 @@
       background: #0f1117;
       color: #e0e0e0;
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-      font-size: 13px;
+      font-size: 15px;
+      line-height: 1.5;
     }
 
     .page { max-width: 960px; margin: 0 auto; padding-bottom: 60px; }
@@ -28,8 +29,8 @@
       gap: 10px;
       border-bottom: 1px solid #2a2d3a;
     }
-    header h1 { font-size: 18px; font-weight: 700; color: #fff; }
-    header span { font-size: 22px; }
+    header h1 { font-size: 22px; font-weight: 700; color: #fff; }
+    header span { font-size: 24px; }
 
     /* ── Controls ── */
     .controls {
@@ -44,12 +45,12 @@
       flex: 1;
       min-width: 160px;
       max-width: 260px;
-      padding: 9px 14px;
+      padding: 10px 14px;
       border-radius: 6px;
       border: 1px solid #2a2d3a;
       background: #1a1d27;
       color: #fff;
-      font-size: 13px;
+      font-size: 14px;
       outline: none;
       transition: opacity 0.15s, border-color 0.15s;
     }
@@ -62,13 +63,14 @@
     }
 
     .ctrl-btn {
-      padding: 9px 18px;
+      padding: 10px 18px;
       border-radius: 6px;
       border: 1px solid transparent;
-      font-size: 13px;
+      font-size: 14px;
       font-weight: 600;
       cursor: pointer;
       white-space: nowrap;
+      min-height: 40px;
     }
     #fetchBtn  { background: #4a9eff; color: #fff; border-color: #4a9eff; }
     #fetchBtn:hover    { background: #3a8eef; }
@@ -86,9 +88,9 @@
     /* ── Status ── */
     #status {
       padding: 10px 24px;
-      font-size: 12px;
-      color: #8a9bb0;
-      min-height: 32px;
+      font-size: 13px;
+      color: #a0afc0;
+      min-height: 34px;
       display: flex;
       align-items: center;
       gap: 6px;
@@ -126,8 +128,8 @@
       text-align: center;
       position: relative;
     }
-    .stat-box .val { font-size: 22px; font-weight: 700; color: #4a9eff; }
-    .stat-box .lbl { font-size: 10px; color: #666; margin-top: 4px; text-transform: uppercase; letter-spacing: 0.5px; }
+    .stat-box .val { font-size: 26px; font-weight: 700; color: #4a9eff; }
+    .stat-box .lbl { font-size: 12px; color: #777; margin-top: 5px; text-transform: uppercase; letter-spacing: 0.5px; }
     .stat-box.clickable { cursor: pointer; user-select: none; }
     .stat-box.clickable:hover { border-color: #4a9eff; background: #1e2235; }
     .stat-box.active-filter { border-color: #4a9eff; }
@@ -179,14 +181,15 @@
 
     #viewToggle { display: flex; flex-direction: column; gap: 6px; flex-shrink: 0; }
     .view-btn {
-      padding: 7px 14px;
+      padding: 8px 16px;
       border-radius: 6px;
       border: 1px solid #2a2d3a;
       background: #1a1d27;
-      color: #666;
-      font-size: 11px;
+      color: #777;
+      font-size: 13px;
       cursor: pointer;
       white-space: nowrap;
+      min-height: 36px;
     }
     .view-btn.active { background: #1e3a5f; border-color: #4a9eff; color: #4a9eff; }
 
@@ -205,9 +208,9 @@
       margin-bottom: 12px;
     }
     .chart-section h3 {
-      font-size: 11px;
+      font-size: 12px;
       font-weight: 600;
-      color: #555;
+      color: #666;
       text-transform: uppercase;
       letter-spacing: 0.8px;
       margin-bottom: 0;
@@ -221,9 +224,9 @@
       user-select: none;
     }
     #classifiersToggleWrap .toggle-lbl {
-      font-size: 11px;
+      font-size: 12px;
       font-weight: 600;
-      color: #555;
+      color: #666;
       text-transform: uppercase;
       letter-spacing: 0.8px;
     }
@@ -263,19 +266,19 @@
     #matchHistory { display: none; margin: 24px 24px 0; }
     #matchHistory.visible { display: block; }
     #matchHistory h2 {
-      font-size: 11px;
+      font-size: 12px;
       font-weight: 600;
-      color: #555;
+      color: #666;
       text-transform: uppercase;
       letter-spacing: 0.8px;
-      margin-bottom: 10px;
+      margin-bottom: 12px;
     }
 
     .match-row {
       display: flex;
       align-items: center;
       gap: 12px;
-      padding: 10px 14px;
+      padding: 12px 16px;
       background: #1a1d27;
       border: 1px solid #2a2d3a;
       border-radius: 8px;
@@ -299,23 +302,24 @@
       overflow: hidden;
       text-overflow: ellipsis;
     }
-    .match-meta { font-size: 11px; color: #555; margin-top: 2px; }
+    .match-meta { font-size: 12px; color: #666; margin-top: 3px; }
 
-    .match-score { font-size: 13px; font-weight: 600; color: #4a9eff; white-space: nowrap; flex-shrink: 0; }
-    .match-score.none { color: #444; font-weight: 400; font-size: 12px; }
+    .match-score { font-size: 14px; font-weight: 600; color: #4a9eff; white-space: nowrap; flex-shrink: 0; }
+    .match-score.none { color: #555; font-weight: 400; font-size: 13px; }
 
     .refresh-btn, .expand-btn {
-      padding: 4px 8px;
+      padding: 6px 10px;
       border-radius: 4px;
       border: 1px solid #2a2d3a;
       background: none;
-      color: #555;
-      font-size: 14px;
+      color: #666;
+      font-size: 15px;
       line-height: 1;
       cursor: pointer;
       flex-shrink: 0;
+      min-height: 32px;
     }
-    .expand-btn { font-size: 11px; }
+    .expand-btn { font-size: 12px; }
     .refresh-btn:hover, .expand-btn:hover { color: #4a9eff; border-color: #4a9eff; }
     .refresh-btn:disabled { opacity: 0.3; cursor: default; }
     .refresh-btn.spinning { display: inline-block; animation: spin 0.8s linear infinite; }
@@ -338,12 +342,12 @@
     .stage-table {
       width: 100%;
       border-collapse: collapse;
-      font-size: 11px;
+      font-size: 12px;
       min-width: 480px;
     }
     .stage-table th {
-      padding: 6px 10px;
-      color: #444;
+      padding: 7px 10px;
+      color: #555;
       font-weight: 600;
       text-transform: uppercase;
       letter-spacing: 0.5px;
@@ -353,7 +357,7 @@
     }
     .stage-table th:first-child { text-align: left; }
     .stage-table td {
-      padding: 5px 10px;
+      padding: 6px 10px;
       color: #8a9bb0;
       text-align: right;
       border-top: 1px solid #1a1d27;
@@ -381,8 +385,8 @@
       display: flex;
       justify-content: space-between;
       gap: 8px;
-      padding: 2px 0;
-      font-size: 10px;
+      padding: 3px 0;
+      font-size: 12px;
     }
     .tt-stage-name { color: #ccc; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .tt-stage-hf   { color: #4a9eff; flex-shrink: 0; }
@@ -396,8 +400,8 @@
       background: #111;
       border: 1px solid #2a2d3a;
       border-radius: 6px;
-      font-size: 10px;
-      color: #555;
+      font-size: 11px;
+      color: #666;
       max-height: 120px;
       overflow-y: auto;
       white-space: pre-wrap;
@@ -411,7 +415,7 @@
       border: 1px solid #5a2a2a;
       border-radius: 8px;
       color: #ff9090;
-      font-size: 12px;
+      font-size: 14px;
       line-height: 1.6;
     }
 
@@ -421,8 +425,8 @@
       background: #1a1d27;
       border: 1px solid #2a2d3a;
       border-radius: 8px;
-      padding: 10px 14px;
-      font-size: 12px;
+      padding: 12px 16px;
+      font-size: 13px;
       color: #e0e0e0;
       pointer-events: none;
       z-index: 1000;
@@ -430,10 +434,10 @@
       box-shadow: 0 4px 16px rgba(0,0,0,0.5);
       line-height: 1.5;
     }
-    #tooltip .tt-name  { font-weight: 600; margin-bottom: 2px; }
-    #tooltip .tt-date  { font-size: 11px; color: #666; }
-    #tooltip .tt-score { font-size: 16px; font-weight: 700; color: #4a9eff; margin: 4px 0 2px; }
-    #tooltip .tt-meta  { font-size: 11px; color: #888; }
+    #tooltip .tt-name  { font-weight: 600; margin-bottom: 2px; font-size: 14px; }
+    #tooltip .tt-date  { font-size: 12px; color: #777; }
+    #tooltip .tt-score { font-size: 18px; font-weight: 700; color: #4a9eff; margin: 4px 0 2px; }
+    #tooltip .tt-meta  { font-size: 12px; color: #999; }
 
     a { color: #4a9eff; text-decoration: none; }
     a:hover { text-decoration: underline; }
@@ -442,12 +446,12 @@
     #updateBanner {
       display: none;
       margin: 0 24px 8px;
-      padding: 10px 14px;
+      padding: 12px 16px;
       background: rgba(74,158,255,0.08);
       border: 1px solid rgba(74,158,255,0.35);
       border-radius: 6px;
       color: #4a9eff;
-      font-size: 12px;
+      font-size: 13px;
       line-height: 1.5;
       align-items: center;
       gap: 10px;
@@ -483,12 +487,12 @@
     .login-warning {
       display: none;
       margin: 0 24px 8px;
-      padding: 10px 14px;
+      padding: 12px 16px;
       background: rgba(244,67,54,0.08);
       border: 1px solid rgba(244,67,54,0.3);
       border-radius: 6px;
       color: #f44336;
-      font-size: 12px;
+      font-size: 13px;
       line-height: 1.5;
     }
     .login-warning a { color: #f44336; }
@@ -509,19 +513,19 @@
     #noMemberWarning {
       display: none;
       margin: 0 24px 8px;
-      padding: 10px 14px;
+      padding: 12px 16px;
       background: rgba(255,152,0,0.08);
       border: 1px solid rgba(255,152,0,0.35);
       border-radius: 6px;
       color: #ff9800;
-      font-size: 12px;
+      font-size: 13px;
       line-height: 1.5;
     }
 
     /* ── Match type badge ── */
     .match-type-badge {
-      font-size: 10px;
-      padding: 2px 7px;
+      font-size: 11px;
+      padding: 3px 8px;
       border-radius: 3px;
       font-weight: 600;
       flex-shrink: 0;
@@ -548,15 +552,16 @@
 
     /* ── Delete button ── */
     .delete-btn {
-      padding: 4px 7px;
+      padding: 6px 9px;
       border-radius: 4px;
       border: 1px solid #2a2d3a;
       background: none;
-      color: #555;
-      font-size: 12px;
+      color: #666;
+      font-size: 13px;
       line-height: 1;
       cursor: pointer;
       flex-shrink: 0;
+      min-height: 32px;
     }
     .delete-btn:hover { color: #f44336; border-color: #f44336; }
   </style>
@@ -639,7 +644,7 @@
   <div class="chart-section" id="chartNonClfSection" style="display:none">
     <div class="chart-section-header">
       <h3>Non-Classifier Stage Trend</h3>
-      <span style="font-size:10px;color:#555;text-transform:uppercase;letter-spacing:0.5px">Avg HF% across non-classifier stages per match</span>
+      <span style="font-size:12px;color:#666;text-transform:uppercase;letter-spacing:0.5px">Avg HF% across non-classifier stages per match</span>
     </div>
     <canvas id="chartNonClf" height="180"></canvas>
   </div>

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -131,6 +131,31 @@
     .stat-box.clickable { cursor: pointer; user-select: none; }
     .stat-box.clickable:hover { border-color: #4a9eff; background: #1e2235; }
     .stat-box.active-filter { border-color: #4a9eff; }
+    /* Stat box tooltip — shown on hover when data-tip is set */
+    .stat-box[data-tip] { cursor: help; }
+    .stat-box[data-tip]:hover::after {
+      content: attr(data-tip);
+      position: absolute;
+      bottom: calc(100% + 6px);
+      left: 50%;
+      transform: translateX(-50%);
+      background: #1a1d27;
+      border: 1px solid #3a3d4a;
+      border-radius: 6px;
+      padding: 7px 10px;
+      font-size: 11px;
+      color: #ccc;
+      white-space: pre-line;
+      text-align: left;
+      text-transform: none;
+      letter-spacing: 0;
+      font-weight: 400;
+      min-width: 200px;
+      max-width: 280px;
+      z-index: 300;
+      box-shadow: 0 4px 16px rgba(0,0,0,0.5);
+      pointer-events: none;
+    }
     .div-dropdown {
       position: absolute; top: calc(100% + 4px); left: 0;
       min-width: 100%; background: #1a1d27;
@@ -580,8 +605,8 @@
 <div class="summary-bar" id="summaryBar">
   <div id="stats">
     <div class="stat-box"><div class="val" id="statMatches">—</div><div class="lbl">Matches</div></div>
-    <div class="stat-box"><div class="val" id="statAvg">—</div><div class="lbl">Avg %</div></div>
-    <div class="stat-box"><div class="val" id="statBest">—</div><div class="lbl">Best %</div></div>
+    <div class="stat-box" id="statAvgBox"><div class="val" id="statAvg">—</div><div class="lbl" id="statAvgLbl">Avg %</div></div>
+    <div class="stat-box" id="statBestBox"><div class="val" id="statBest">—</div><div class="lbl" id="statBestLbl">Best %</div></div>
     <div class="stat-box"><div class="val" id="statDiv">—</div><div class="lbl">Division</div></div>
     <div class="stat-box" id="statClassBox" style="display:none"><div class="val" id="statClass">—</div><div class="lbl">Class</div></div>
   </div>

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -515,12 +515,7 @@ fetchBtn.addEventListener('click', async () => {
 
     renderAll();
     renderMatchList();
-
-    const uspsa  = allResults.filter(r => isLikelyUSPSA(r.match_type || 'Unknown')).length;
-    const nonUspsa = allResults.length - uspsa;
-    const scored = allResults.filter(r => r.overall_pct != null).length;
-    const skippedNote = nonUspsa > 0 ? ` · ${nonUspsa} non-USPSA match(es) excluded from charts` : '';
-    setStatus(`Loaded ${uspsa} USPSA match(es) — ${scored} with scores.${skippedNote}`, 'success');
+    updateStatusCounts('Loaded');
 
   } catch (err) {
     setStatus(`Error: ${err.message}`, 'error');
@@ -646,6 +641,17 @@ function renderAll() {
   document.getElementById('statBest').textContent    = best.toFixed(1) + '%';
   document.getElementById('statBest').style.color    = bestBand?.text.replace('0.55','1') || '#4a9eff';
 
+  // Stat box tooltips — explain what each metric measures
+  const divLabel = selectedDiv ? ` in ${selectedDiv}` : '';
+  document.getElementById('statAvgBox').dataset.tip =
+    `Your average match score${divLabel}.\n` +
+    `Calculated as your points ÷ the match winner's points × 100,\n` +
+    `averaged across all checked matches in the current view.`;
+  document.getElementById('statBestBox').dataset.tip =
+    `Your highest single-match score${divLabel}.\n` +
+    `Match score = your points ÷ match winner's points × 100.\n` +
+    `Color indicates the USPSA classification band for that score.`;
+
   // Division stat box — opens a dropdown
   const divStatBox = document.getElementById('statDiv').closest('.stat-box');
   const divStatVal = document.getElementById('statDiv');
@@ -748,6 +754,17 @@ function renderAll() {
     document.getElementById('statBest').textContent = clfBest.toFixed(1) + '%';
     document.getElementById('statBest').style.color = bestBandC?.text.replace('0.55','1') || '#4a9eff';
     if (avgLbl) avgLbl.textContent = avgBandC ? `Avg % · ${avgBandC.label} Class` : 'Avg %';
+
+    // Classifier-mode tooltips
+    const clfSource = officialPcts.length ? 'official USPSA % vs national HHF' : 'match % vs match top HF';
+    document.getElementById('statAvgBox').dataset.tip =
+      `Your average classifier score (${clfSource}),\n` +
+      `averaged across all classifier stages in the current view.\n` +
+      `USPSA uses your best 6 classifiers to set your classification.`;
+    document.getElementById('statBestBox').dataset.tip =
+      `Your highest single classifier score (${clfSource}).\n` +
+      `Color indicates the USPSA classification band for that score.\n` +
+      `GM = 95%+, M = 85–95%, A = 75–85%, B = 60–75%, C = 40–60%.`;
 
     // Build series grouped by division — gives continuous lines over time
     const DIV_PALETTE = ['#4a9eff','#4caf50','#ff9800','#e91e63','#9c27b0','#00bcd4','#ffeb3b','#ff5722'];
@@ -1122,6 +1139,7 @@ function renderMatchList() {
         saveDeselected();
         item.classList.toggle('excluded', !e.target.checked);
         renderAll();
+        updateStatusCounts();
       });
     }
 
@@ -1238,6 +1256,23 @@ async function refreshSingleMatch(match, btn) {
 function setStatus(msg, type = '', loading = false) {
   statusEl.className = type;
   statusEl.innerHTML = loading ? `<div class="spinner"></div>${msg}` : msg;
+}
+
+// Recompute and display the status line from current allResults + deselectedMatches.
+// verb = 'Loaded' on first fetch, omitted (defaults to 'Showing') on checkbox changes.
+function updateStatusCounts(verb) {
+  if (!allResults.length) return;
+  const uspsa    = allResults.filter(r => isLikelyUSPSA(r.match_type || 'Unknown')).length;
+  const nonUspsa = allResults.length - uspsa;
+  const checked  = allResults.filter(r =>
+    isLikelyUSPSA(r.match_type || 'Unknown') && !deselectedMatches.has(r.match_id)
+  ).length;
+  const scored   = allResults.filter(r => r.overall_pct != null).length;
+
+  const prefix      = verb || 'Showing';
+  const checkedNote = checked < uspsa ? ` · ${checked} checked` : '';
+  const skippedNote = nonUspsa > 0   ? ` · ${nonUspsa} non-USPSA excluded` : '';
+  setStatus(`${prefix} ${uspsa} USPSA match(es) — ${scored} with scores${checkedNote}.${skippedNote}`, 'success');
 }
 
 function parseDate(str) {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "PScharts",
-  "version": "0.7",
-  "description": "PScharts 0.7-beta — Chart your USPSA match scores from PractiScore",
+  "version": "0.8",
+  "description": "PScharts 0.8 — Chart your USPSA match scores from PractiScore",
   "permissions": ["tabs", "scripting", "storage"],
   "host_permissions": ["https://practiscore.com/*", "https://s3.amazonaws.com/*", "https://api.github.com/*", "https://uspsa.org/*"],
   "content_security_policy": {


### PR DESCRIPTION
## Summary

- **Live status counts** — status line now updates when match checkboxes are toggled, showing how many matches are checked vs total
- **Stat box tooltips** — hover over Avg % and Best % cards to see exactly what each metric measures (context-aware: different text in normal vs classifiers-only mode)
- **UI/UX type scale overhaul** — every sub-13px font size brought up to readable minimums per web design best practices:
  - Base font 13px → 15px
  - Stat box labels 10px → 12px, values 22px → 26px
  - Section headers/toggles 11px → 12px
  - Match meta 11px → 12px
  - Stage table 11px → 12px
  - Tooltip text bumped throughout
  - Status line contrast improved (#8a9bb0 → #a0afc0)
  - Warning/banner blocks 12px → 13px
- **Touch targets** — buttons given min-height (40px ctrl, 36px view toggle, 32px row actions)
- **Version bump** 0.7 → 0.8