### PR TITLE
feat: improved update banner with step-by-step install guide (v0.9)

### DIFF
--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -445,38 +445,124 @@
     /* ── Update banner ── */
     #updateBanner {
       display: none;
-      margin: 0 24px 8px;
-      padding: 12px 16px;
-      background: rgba(74,158,255,0.08);
-      border: 1px solid rgba(74,158,255,0.35);
-      border-radius: 6px;
-      color: #4a9eff;
-      font-size: 13px;
-      line-height: 1.5;
-      align-items: center;
-      gap: 10px;
-      flex-wrap: wrap;
+      margin: 0 24px 12px;
+      background: #111827;
+      border: 1px solid rgba(74,158,255,0.4);
+      border-left: 4px solid #4a9eff;
+      border-radius: 8px;
+      overflow: hidden;
     }
-    #updateBanner.visible { display: flex; }
-    #updateBanner a { color: #4a9eff; font-weight: 600; }
-    #updateNotesToggle {
-      background: none;
-      border: 1px solid rgba(74,158,255,0.35);
-      border-radius: 4px;
-      color: #4a9eff;
-      font-size: 11px;
-      padding: 2px 8px;
-      cursor: pointer;
+    #updateBanner.visible { display: block; }
+
+    .update-banner-header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 14px 16px 12px;
+    }
+    .update-version-badge {
+      background: #4a9eff;
+      color: #fff;
+      font-size: 12px;
+      font-weight: 700;
+      padding: 3px 10px;
+      border-radius: 20px;
+      white-space: nowrap;
       flex-shrink: 0;
     }
-    #updateNotesToggle:hover { background: rgba(74,158,255,0.08); }
+    .update-headline {
+      flex: 1;
+      font-size: 14px;
+      font-weight: 600;
+      color: #e0e0e0;
+    }
+    .update-dismiss-btn {
+      background: none;
+      border: none;
+      color: #555;
+      font-size: 18px;
+      line-height: 1;
+      cursor: pointer;
+      padding: 0 4px;
+      flex-shrink: 0;
+    }
+    .update-dismiss-btn:hover { color: #aaa; }
+
+    .update-steps {
+      padding: 0 16px 14px;
+      display: flex;
+      gap: 10px;
+      align-items: flex-start;
+      flex-wrap: wrap;
+    }
+    .update-step {
+      display: flex;
+      align-items: flex-start;
+      gap: 8px;
+      flex: 1;
+      min-width: 160px;
+    }
+    .update-step-num {
+      width: 22px;
+      height: 22px;
+      border-radius: 50%;
+      background: rgba(74,158,255,0.15);
+      border: 1px solid rgba(74,158,255,0.35);
+      color: #4a9eff;
+      font-size: 11px;
+      font-weight: 700;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+      margin-top: 1px;
+    }
+    .update-step-text {
+      font-size: 13px;
+      color: #a0afc0;
+      line-height: 1.4;
+    }
+    .update-step-text strong { color: #e0e0e0; }
+
+    .update-download-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      background: #4a9eff;
+      color: #fff;
+      border: none;
+      border-radius: 6px;
+      padding: 7px 14px;
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      text-decoration: none;
+      white-space: nowrap;
+      margin-top: 2px;
+      transition: background 0.15s;
+    }
+    .update-download-btn:hover { background: #3a8eef; text-decoration: none; color: #fff; }
+
+    .update-notes-wrap {
+      border-top: 1px solid rgba(74,158,255,0.15);
+      padding: 0 16px;
+    }
+    #updateNotesToggle {
+      background: none;
+      border: none;
+      color: #4a9eff;
+      font-size: 12px;
+      padding: 8px 0;
+      cursor: pointer;
+      display: block;
+      width: 100%;
+      text-align: left;
+    }
+    #updateNotesToggle:hover { color: #7ab8ff; }
     #updateBannerNotes {
       display: none;
-      width: 100%;
-      margin-top: 8px;
-      padding-top: 8px;
-      border-top: 1px solid rgba(74,158,255,0.2);
-      font-size: 11px;
+      padding-bottom: 12px;
+      font-size: 12px;
       color: #8a9bb0;
       white-space: pre-wrap;
       line-height: 1.6;
@@ -585,9 +671,35 @@
 <div id="status">Enter your USPSA member number (recommended) and/or name, then click Fetch Scores.</div>
 
 <div id="updateBanner">
-  <span id="updateBannerText"></span>
-  <button id="updateNotesToggle">Release notes ▾</button>
-  <div id="updateBannerNotes"></div>
+  <div class="update-banner-header">
+    <span class="update-version-badge" id="updateVersionBadge">v—</span>
+    <span class="update-headline">Update available — takes about 30 seconds to install</span>
+    <button class="update-dismiss-btn" id="updateDismissBtn" title="Dismiss">×</button>
+  </div>
+  <div class="update-steps">
+    <div class="update-step">
+      <div class="update-step-num">1</div>
+      <div class="update-step-text">
+        <a class="update-download-btn" id="updateDownloadBtn" href="#" target="_blank">⬇ Download update</a>
+      </div>
+    </div>
+    <div class="update-step">
+      <div class="update-step-num">2</div>
+      <div class="update-step-text">Unzip the downloaded file — you'll get a folder called <strong>extension</strong></div>
+    </div>
+    <div class="update-step">
+      <div class="update-step-num">3</div>
+      <div class="update-step-text">Go to <strong>chrome://extensions</strong> → click <strong>Load unpacked</strong> → select the <strong>extension</strong> folder</div>
+    </div>
+    <div class="update-step">
+      <div class="update-step-num">4</div>
+      <div class="update-step-text">Close this tab and reopen PScharts — you're on the latest version</div>
+    </div>
+  </div>
+  <div class="update-notes-wrap" id="updateNotesWrap" style="display:none">
+    <button id="updateNotesToggle">What's new ▾</button>
+    <div id="updateBannerNotes"></div>
+  </div>
 </div>
 
 <div id="psLoginWarning" class="login-warning">

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -43,34 +43,6 @@ function isNewer(latest, current) {
   return false;
 }
 
-async function checkForUpdate() {
-  const { updateCheck } = await chrome.storage.local.get('updateCheck');
-  const now = Date.now();
-
-  if (updateCheck && (now - updateCheck.checkedAt) < CHECK_INTERVAL_MS) {
-    if (updateCheck.latestVersion && updateCheck.downloadUrl) {
-      showUpdateBanner(updateCheck.latestVersion, updateCheck.downloadUrl, updateCheck.releaseNotes || '');
-    }
-    return;
-  }
-
-  try {
-    const res = await fetch(RELEASES_API);
-    if (!res.ok) return;
-    const data = await res.json();
-    const latestVersion = (data.tag_name || '').replace(/^v/, '');
-    // Sanitize downloadUrl: only allow https://github.com URLs to prevent XSS via injected href
-    const rawUrl    = data.html_url || '';
-    const downloadUrl = /^https:\/\/github\.com\//.test(rawUrl)
-      ? rawUrl
-      : 'https://github.com/johnwaldo/PScharts/releases/latest';
-    const releaseNotes  = (data.body || '').trim();
-
-    await chrome.storage.local.set({ updateCheck: { latestVersion, downloadUrl, releaseNotes, checkedAt: now } });
-    showUpdateBanner(latestVersion, downloadUrl, releaseNotes);
-  } catch (_) {}
-}
-
 // Escape HTML special characters to prevent XSS when inserting untrusted text into innerHTML
 function escHtml(str) {
   return String(str ?? '')
@@ -81,32 +53,90 @@ function escHtml(str) {
     .replace(/'/g, '&#39;');
 }
 
-function showUpdateBanner(latestVersion, downloadUrl, releaseNotes) {
+async function checkForUpdate() {
+  // Don't show banner if user dismissed this version already
+  const { updateCheck, updateDismissed } = await chrome.storage.local.get(['updateCheck', 'updateDismissed']);
+  const now = Date.now();
+
+  // Use cached result if fresh enough
+  if (updateCheck && (now - updateCheck.checkedAt) < CHECK_INTERVAL_MS) {
+    if (updateCheck.latestVersion && updateCheck.zipUrl &&
+        updateDismissed !== updateCheck.latestVersion) {
+      showUpdateBanner(updateCheck.latestVersion, updateCheck.zipUrl, updateCheck.releasePageUrl, updateCheck.releaseNotes || '');
+    }
+    return;
+  }
+
+  try {
+    const res = await fetch(RELEASES_API);
+    if (!res.ok) return;
+    const data = await res.json();
+    const latestVersion = (data.tag_name || '').replace(/^v/, '');
+
+    // Sanitize release page URL — must be github.com
+    const rawPageUrl   = data.html_url || '';
+    const releasePageUrl = /^https:\/\/github\.com\//.test(rawPageUrl)
+      ? rawPageUrl
+      : 'https://github.com/johnwaldo/PScharts/releases/latest';
+
+    // Find the ZIP asset — prefer pscharts-*.zip, fall back to any .zip
+    const assets  = Array.isArray(data.assets) ? data.assets : [];
+    const zipAsset = assets.find(a => /pscharts.*\.zip$/i.test(a.name))
+                  || assets.find(a => /\.zip$/i.test(a.name));
+    // Sanitize asset download URL — must be github.com or objects.githubusercontent.com
+    const rawZip  = zipAsset?.browser_download_url || '';
+    const zipUrl  = /^https:\/\/(github\.com|objects\.githubusercontent\.com)\//.test(rawZip)
+      ? rawZip
+      : releasePageUrl; // fall back to release page if no ZIP attached
+
+    const releaseNotes = (data.body || '').trim();
+
+    await chrome.storage.local.set({
+      updateCheck: { latestVersion, zipUrl, releasePageUrl, releaseNotes, checkedAt: now },
+    });
+
+    if (updateDismissed !== latestVersion) {
+      showUpdateBanner(latestVersion, zipUrl, releasePageUrl, releaseNotes);
+    }
+  } catch (_) {}
+}
+
+function showUpdateBanner(latestVersion, zipUrl, releasePageUrl, releaseNotes) {
   const currentVersion = chrome.runtime.getManifest().version;
   if (!isNewer(latestVersion, currentVersion)) return;
 
-  const banner    = document.getElementById('updateBanner');
-  const textEl    = document.getElementById('updateBannerText');
-  const notesEl   = document.getElementById('updateBannerNotes');
-  const toggleBtn = document.getElementById('updateNotesToggle');
+  // Wire up version badge
+  document.getElementById('updateVersionBadge').textContent = `v${escHtml(latestVersion)}`;
 
-  // Use escHtml for latestVersion (from API); downloadUrl is already validated above
-  textEl.innerHTML = `Update available: v${escHtml(latestVersion)} &mdash; `
-    + `<a href="${escHtml(downloadUrl)}" target="_blank">Download</a>, then go to `
-    + `<a href="chrome://extensions" target="_blank">chrome://extensions</a> and click the reload button.`;
+  // Wire up download button — points to ZIP if available, release page otherwise
+  const dlBtn = document.getElementById('updateDownloadBtn');
+  dlBtn.href = escHtml(zipUrl);
 
-  if (releaseNotes) {
-    notesEl.textContent = releaseNotes;
-    toggleBtn.style.display = 'inline-block';
-    toggleBtn.addEventListener('click', () => {
-      const open = notesEl.classList.toggle('open');
-      toggleBtn.textContent = open ? 'Release notes ▴' : 'Release notes ▾';
-    });
-  } else {
-    toggleBtn.style.display = 'none';
+  // If the URL is the release page (no ZIP asset), update button label
+  if (zipUrl === releasePageUrl) {
+    dlBtn.textContent = '↗ View release';
   }
 
-  banner.classList.add('visible');
+  // Release notes toggle
+  const notesWrap = document.getElementById('updateNotesWrap');
+  const notesEl   = document.getElementById('updateBannerNotes');
+  const toggleBtn = document.getElementById('updateNotesToggle');
+  if (releaseNotes) {
+    notesWrap.style.display = '';
+    notesEl.textContent = releaseNotes;
+    toggleBtn.addEventListener('click', () => {
+      const open = notesEl.classList.toggle('open');
+      toggleBtn.textContent = open ? "What's new ▴" : "What's new ▾";
+    });
+  }
+
+  // Dismiss button — stores the version so banner stays gone until next release
+  document.getElementById('updateDismissBtn').addEventListener('click', () => {
+    chrome.storage.local.set({ updateDismissed: latestVersion });
+    document.getElementById('updateBanner').classList.remove('visible');
+  });
+
+  document.getElementById('updateBanner').classList.add('visible');
 }
 
 checkForUpdate();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,12 +1,12 @@
 {
   "manifest_version": 3,
   "name": "PScharts",
-  "version": "0.8",
-  "description": "PScharts 0.8 — Chart your USPSA match scores from PractiScore",
+  "version": "0.9",
+  "description": "PScharts 0.9 — Chart your USPSA match scores from PractiScore",
   "permissions": ["tabs", "scripting", "storage"],
-  "host_permissions": ["https://practiscore.com/*", "https://s3.amazonaws.com/*", "https://api.github.com/*", "https://uspsa.org/*"],
+  "host_permissions": ["https://practiscore.com/*", "https://s3.amazonaws.com/*", "https://api.github.com/*", "https://uspsa.org/*", "https://objects.githubusercontent.com/*"],
   "content_security_policy": {
-    "extension_pages": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src https://practiscore.com https://s3.amazonaws.com https://api.github.com https://uspsa.org"
+    "extension_pages": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src https://practiscore.com https://s3.amazonaws.com https://api.github.com https://uspsa.org https://objects.githubusercontent.com"
   },
   "icons": {
     "16":  "icons/icon16.png",


### PR DESCRIPTION
## Summary

Replaces the flat one-liner update banner with a structured, user-friendly install guide.

### What changed

**Banner redesign**
- Version badge showing the new version number
- 4-step numbered install guide: Download → Unzip → Load unpacked → Reopen
- Direct ZIP download button (fetches asset URL from GitHub release)
- Dismiss button — stores dismissed version in storage so it stays gone until the *next* release

**Update check improvements**
- `checkForUpdate()` now reads `assets[]` from the GitHub API response to get the direct ZIP download URL
- Falls back to the release page URL if no ZIP asset is attached
- Dismiss state is per-version — a new release clears the dismissal

**Manifest / permissions**
- `host_permissions` and CSP updated to include `objects.githubusercontent.com` (GitHub's release asset CDN)
- Version bump 0.8 → 0.9

### How to test
Load the extension at v0.8 (current), then create a v0.9 release with a ZIP attached — the banner should appear on next dashboard open with the download button pointing directly to the ZIP.