### PR TITLE
feat: light/dark theme, credential sync, update UX

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,10 @@ jobs:
       - name: Build extension zip
         if: steps.check_tag.outputs.exists == 'false'
         run: |
+          # Zip contents directly — no version in the folder name so users
+          # can unzip over the same 'extension/' folder and just refresh.
           cd extension
-          zip -r ../PScharts-v${{ steps.version.outputs.version }}.zip .
+          zip -r ../PScharts.zip .
 
       - name: Create GitHub Release
         if: steps.check_tag.outputs.exists == 'false'
@@ -51,6 +53,6 @@ jobs:
           fi
 
           gh release create "${{ steps.version.outputs.tag }}" \
-            "PScharts-v${{ steps.version.outputs.version }}.zip" \
+            "PScharts.zip" \
             --title "PScharts v${{ steps.version.outputs.version }}" \
             --notes "${NOTES:-No notable changes.}"

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -6,13 +6,98 @@
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
 
+    /* ── Theme variables ── */
+    :root {
+      --bg-page:       #0f1117;
+      --bg-surface:    #1a1d27;
+      --bg-surface2:   #131620;
+      --bg-hover:      #1e2235;
+      --border:        #2a2d3a;
+      --border-light:  #1e2130;
+      --text-primary:  #f0f0f0;
+      --text-body:     #d0d4dc;
+      --text-secondary:#a0afc0;
+      --text-muted:    #8a9bb0;
+      --text-faint:    #6b7a8d;
+      --accent:        #4a9eff;
+      --accent-hover:  #3a8eef;
+      --accent-dim:    #2a4a6a;
+      --grid:          #1e2130;
+      --axis:          #2a2d3a;
+      --chart-text:    #8a9bb0;
+      --chart-bg:      #0f1117;
+      --tooltip-bg:    #1a1d27;
+      --tooltip-border:#2a2d3a;
+      --input-bg:      #1a1d27;
+      --input-border:  #2a2d3a;
+      --placeholder:   #667;
+      --stage-bg:      #131620;
+      --stage-th-bg:   #0f1117;
+      --stage-td:      #b0b8c8;
+      --stage-name:    #e0e4ec;
+      --match-name:    #dde0e8;
+      --match-meta:    #8a9bb0;
+      --btn-muted:     #8a9bb0;
+      --section-title: #8a9bb0;
+      --stat-label:    #999;
+      --dropdown-bg:   #1a1d27;
+      --dropdown-item: #d0d4dc;
+      --onboard-desc:  #99a;
+      --debug-text:    #8a9bb0;
+      --badge-clf-bg:  #1a3a5c;
+      --badge-clf-text:#5ba3f5;
+      --badge-clf-bdr: #2a5a8c;
+    }
+
+    [data-theme="light"] {
+      --bg-page:       #f5f6f8;
+      --bg-surface:    #ffffff;
+      --bg-surface2:   #f0f1f4;
+      --bg-hover:      #e8eaef;
+      --border:        #d0d4dc;
+      --border-light:  #e0e2e8;
+      --text-primary:  #1a1d27;
+      --text-body:     #2c3040;
+      --text-secondary:#4a5060;
+      --text-muted:    #5a6478;
+      --text-faint:    #7a8494;
+      --accent:        #2563eb;
+      --accent-hover:  #1d4ed8;
+      --accent-dim:    #bfdbfe;
+      --grid:          #e0e2e8;
+      --axis:          #c0c4cc;
+      --chart-text:    #5a6478;
+      --chart-bg:      #ffffff;
+      --tooltip-bg:    #ffffff;
+      --tooltip-border:#d0d4dc;
+      --input-bg:      #ffffff;
+      --input-border:  #c0c4cc;
+      --placeholder:   #999;
+      --stage-bg:      #f8f9fb;
+      --stage-th-bg:   #eef0f4;
+      --stage-td:      #3a4050;
+      --stage-name:    #1a1d27;
+      --match-name:    #1a1d27;
+      --match-meta:    #5a6478;
+      --btn-muted:     #5a6478;
+      --section-title: #5a6478;
+      --stat-label:    #5a6478;
+      --dropdown-bg:   #ffffff;
+      --dropdown-item: #2c3040;
+      --onboard-desc:  #5a6478;
+      --debug-text:    #5a6478;
+      --badge-clf-bg:  #dbeafe;
+      --badge-clf-text:#1d4ed8;
+      --badge-clf-bdr: #93c5fd;
+    }
+
     html {
       overflow-y: scroll;
     }
     html, body {
       min-height: 100vh;
-      background: #0f1117;
-      color: #e0e0e0;
+      background: var(--bg-page);
+      color: var(--text-body);
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
       font-size: 15px;
       line-height: 1.5;
@@ -22,14 +107,14 @@
 
     /* ── Header ── */
     header {
-      background: #1a1d27;
+      background: var(--bg-surface);
       padding: 16px 24px;
       display: flex;
       align-items: center;
       gap: 10px;
-      border-bottom: 1px solid #2a2d3a;
+      border-bottom: 1px solid var(--border);
     }
-    header h1 { font-size: 22px; font-weight: 700; color: #fff; }
+    header h1 { font-size: 22px; font-weight: 700; color: var(--text-primary); }
     header span { font-size: 24px; }
 
     /* ── Controls ── */
@@ -39,7 +124,7 @@
       gap: 10px;
       align-items: center;
       flex-wrap: wrap;
-      border-bottom: 1px solid #1e2130;
+      border-bottom: 1px solid var(--border-light);
     }
     .controls input {
       flex: 1;
@@ -47,19 +132,19 @@
       max-width: 260px;
       padding: 10px 14px;
       border-radius: 6px;
-      border: 1px solid #2a2d3a;
-      background: #1a1d27;
-      color: #fff;
+      border: 1px solid var(--input-border);
+      background: var(--input-bg);
+      color: var(--text-primary);
       font-size: 14px;
       outline: none;
       transition: opacity 0.15s, border-color 0.15s;
     }
-    .controls input:focus  { border-color: #4a9eff; }
-    .controls input::placeholder { color: #555; }
+    .controls input:focus  { border-color: var(--accent); }
+    .controls input::placeholder { color: var(--placeholder); }
     .controls input:disabled {
       opacity: 0.45;
       cursor: default;
-      border-color: #1e2130;
+      border-color: var(--border-light);
     }
 
     .ctrl-btn {
@@ -72,36 +157,36 @@
       white-space: nowrap;
       min-height: 40px;
     }
-    #fetchBtn  { background: #4a9eff; color: #fff; border-color: #4a9eff; }
-    #fetchBtn:hover    { background: #3a8eef; }
-    #fetchBtn:disabled { background: #2a4a6a; border-color: #2a4a6a; cursor: default; }
+    #fetchBtn  { background: var(--accent); color: #fff; border-color: var(--accent); }
+    #fetchBtn:hover    { background: var(--accent-hover); }
+    #fetchBtn:disabled { background: var(--accent-dim); border-color: var(--accent-dim); cursor: default; }
 
-    #editBtn   { background: none; color: #8a9bb0; border-color: #2a2d3a; display: none; }
-    #editBtn:hover { color: #4a9eff; border-color: #4a9eff; }
+    #editBtn   { background: none; color: var(--btn-muted); border-color: var(--border); display: none; }
+    #editBtn:hover { color: var(--accent); border-color: var(--accent); }
 
-    #saveBtn   { background: #4a9eff; color: #fff; border-color: #4a9eff; display: none; }
-    #saveBtn:hover { background: #3a8eef; }
+    #saveBtn   { background: var(--accent); color: #fff; border-color: var(--accent); display: none; }
+    #saveBtn:hover { background: var(--accent-hover); }
 
-    #cancelBtn { background: none; color: #8a9bb0; border-color: #2a2d3a; display: none; }
-    #cancelBtn:hover { color: #e0e0e0; border-color: #555; }
+    #cancelBtn { background: none; color: var(--btn-muted); border-color: var(--border); display: none; }
+    #cancelBtn:hover { color: var(--text-primary); border-color: var(--text-faint); }
 
     /* ── Status ── */
     #status {
       padding: 10px 24px;
       font-size: 13px;
-      color: #a0afc0;
+      color: var(--text-secondary);
       min-height: 34px;
       display: flex;
       align-items: center;
       gap: 6px;
     }
-    #status.error   { color: #ff6b6b; }
-    #status.success { color: #4caf50; }
+    #status.error   { color: #ef4444; }
+    #status.success { color: #22c55e; }
 
     .spinner {
       width: 12px; height: 12px;
-      border: 2px solid #2a4a6a;
-      border-top-color: #4a9eff;
+      border: 2px solid var(--accent-dim);
+      border-top-color: var(--accent);
       border-radius: 50%;
       animation: spin 0.7s linear infinite;
       flex-shrink: 0;
@@ -121,18 +206,18 @@
     .stat-box {
       flex: 1;
       min-width: 90px;
-      background: #1a1d27;
-      border: 1px solid #2a2d3a;
+      background: var(--bg-surface);
+      border: 1px solid var(--border);
       border-radius: 10px;
       padding: 14px 16px;
       text-align: center;
       position: relative;
     }
-    .stat-box .val { font-size: 26px; font-weight: 700; color: #4a9eff; }
-    .stat-box .lbl { font-size: 12px; color: #777; margin-top: 5px; text-transform: uppercase; letter-spacing: 0.5px; }
+    .stat-box .val { font-size: 26px; font-weight: 700; color: var(--accent); }
+    .stat-box .lbl { font-size: 12px; color: var(--stat-label); margin-top: 5px; text-transform: uppercase; letter-spacing: 0.5px; }
     .stat-box.clickable { cursor: pointer; user-select: none; }
-    .stat-box.clickable:hover { border-color: #4a9eff; background: #1e2235; }
-    .stat-box.active-filter { border-color: #4a9eff; }
+    .stat-box.clickable:hover { border-color: var(--accent); background: var(--bg-hover); }
+    .stat-box.active-filter { border-color: var(--accent); }
     /* Stat box tooltip — shown on hover when data-tip is set */
     .stat-box[data-tip] { cursor: help; }
     .stat-box[data-tip]:hover::after {
@@ -141,12 +226,12 @@
       bottom: calc(100% + 6px);
       left: 50%;
       transform: translateX(-50%);
-      background: #1a1d27;
-      border: 1px solid #3a3d4a;
+      background: var(--tooltip-bg);
+      border: 1px solid var(--border);
       border-radius: 6px;
       padding: 7px 10px;
       font-size: 11px;
-      color: #ccc;
+      color: var(--text-secondary);
       white-space: pre-line;
       text-align: left;
       text-transform: none;
@@ -155,43 +240,43 @@
       min-width: 200px;
       max-width: 280px;
       z-index: 300;
-      box-shadow: 0 4px 16px rgba(0,0,0,0.5);
+      box-shadow: 0 4px 16px rgba(0,0,0,0.25);
       pointer-events: none;
     }
     .div-dropdown {
       position: absolute; top: calc(100% + 4px); left: 0;
-      min-width: 100%; background: #1a1d27;
-      border: 1px solid #3a3d4a; border-radius: 8px;
+      min-width: 100%; background: var(--dropdown-bg);
+      border: 1px solid var(--border); border-radius: 8px;
       overflow: hidden; z-index: 200;
     }
-    .div-dropdown-item { padding: 8px 16px; cursor: pointer; font-size: 13px; white-space: nowrap; color: #ccc; }
-    .div-dropdown-item:hover { background: #2a2d3a; }
-    .div-dropdown-item.selected { color: #4a9eff; }
+    .div-dropdown-item { padding: 8px 16px; cursor: pointer; font-size: 13px; white-space: nowrap; color: var(--dropdown-item); }
+    .div-dropdown-item:hover { background: var(--bg-hover); }
+    .div-dropdown-item.selected { color: var(--accent); }
     #timeFilter {
       display: none; gap: 6px; padding: 0 24px 14px; flex-wrap: wrap;
       position: relative;
     }
     .time-btn {
       padding: 4px 12px; border-radius: 6px; font-size: 12px;
-      border: 1px solid #2a2d3a; background: #1a1d27; color: #888;
+      border: 1px solid var(--border); background: var(--bg-surface); color: var(--text-muted);
       cursor: pointer; user-select: none;
     }
-    .time-btn:hover { border-color: #4a9eff; color: #ccc; }
-    .time-btn.active { background: #1e3a5f; border-color: #4a9eff; color: #4a9eff; }
+    .time-btn:hover { border-color: var(--accent); color: var(--text-body); }
+    .time-btn.active { background: var(--bg-hover); border-color: var(--accent); color: var(--accent); }
 
     #viewToggle { display: flex; flex-direction: column; gap: 6px; flex-shrink: 0; }
     .view-btn {
       padding: 8px 16px;
       border-radius: 6px;
-      border: 1px solid #2a2d3a;
-      background: #1a1d27;
-      color: #777;
+      border: 1px solid var(--border);
+      background: var(--bg-surface);
+      color: var(--text-muted);
       font-size: 13px;
       cursor: pointer;
       white-space: nowrap;
       min-height: 36px;
     }
-    .view-btn.active { background: #1e3a5f; border-color: #4a9eff; color: #4a9eff; }
+    .view-btn.active { background: var(--bg-hover); border-color: var(--accent); color: var(--accent); }
 
     /* ── Charts ── */
     #charts { display: none; padding: 8px 0; }
@@ -199,7 +284,7 @@
 
     .chart-section {
       padding: 16px 24px;
-      border-top: 1px solid #1e2130;
+      border-top: 1px solid var(--border-light);
     }
     .chart-section-header {
       display: flex;
@@ -210,7 +295,7 @@
     .chart-section h3 {
       font-size: 12px;
       font-weight: 600;
-      color: #666;
+      color: var(--section-title);
       text-transform: uppercase;
       letter-spacing: 0.8px;
       margin-bottom: 0;
@@ -226,7 +311,7 @@
     #classifiersToggleWrap .toggle-lbl {
       font-size: 12px;
       font-weight: 600;
-      color: #666;
+      color: var(--section-title);
       text-transform: uppercase;
       letter-spacing: 0.8px;
     }
@@ -241,7 +326,7 @@
     .toggle-track {
       position: absolute;
       inset: 0;
-      background: #2a2d3a;
+      background: var(--border);
       border-radius: 18px;
       transition: background 0.2s;
     }
@@ -250,14 +335,14 @@
       top: 3px; left: 3px;
       width: 12px; height: 12px;
       border-radius: 50%;
-      background: #555;
+      background: var(--text-faint);
       transition: transform 0.2s, background 0.2s;
     }
-    .toggle-switch input:checked ~ .toggle-track { background: #1e3a5f; }
-    .toggle-switch input:checked ~ .toggle-track .toggle-thumb { transform: translateX(14px); background: #4a9eff; }
-    #classifiersToggleWrap:hover .toggle-track { background: #3a3d4a; }
-    #classifiersToggleWrap:hover .toggle-lbl { color: #888; }
-    #classifiersToggleWrap.active .toggle-lbl { color: #4a9eff; }
+    .toggle-switch input:checked ~ .toggle-track { background: var(--bg-hover); }
+    .toggle-switch input:checked ~ .toggle-track .toggle-thumb { transform: translateX(14px); background: var(--accent); }
+    #classifiersToggleWrap:hover .toggle-track { background: var(--bg-hover); }
+    #classifiersToggleWrap:hover .toggle-lbl { color: var(--text-muted); }
+    #classifiersToggleWrap.active .toggle-lbl { color: var(--accent); }
 
     canvas { display: block; width: 100% !important; }
 
@@ -272,7 +357,7 @@
     #matchHistory h2 {
       font-size: 12px;
       font-weight: 600;
-      color: #666;
+      color: var(--section-title);
       text-transform: uppercase;
       letter-spacing: 0.8px;
       margin-bottom: 12px;
@@ -283,8 +368,8 @@
       align-items: center;
       gap: 12px;
       padding: 12px 16px;
-      background: #1a1d27;
-      border: 1px solid #2a2d3a;
+      background: var(--bg-surface);
+      border: 1px solid var(--border);
       border-radius: 8px;
       margin-bottom: 6px;
     }
@@ -294,29 +379,29 @@
       border-radius: 50%;
       flex-shrink: 0;
     }
-    .match-dot.scored { background: #4caf50; }
-    .match-dot.named  { background: #ff9800; }
-    .match-dot.none   { background: #333; border: 1px solid #444; }
+    .match-dot.scored { background: #22c55e; }
+    .match-dot.named  { background: #f59e0b; }
+    .match-dot.none   { background: var(--border); border: 1px solid var(--text-faint); }
 
     .match-info { flex: 1; min-width: 0; }
     .match-name {
       font-weight: 500;
-      color: #ccc;
+      color: var(--match-name);
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
     }
-    .match-meta { font-size: 12px; color: #666; margin-top: 3px; }
+    .match-meta { font-size: 12px; color: var(--match-meta); margin-top: 3px; }
 
-    .match-score { font-size: 14px; font-weight: 600; color: #4a9eff; white-space: nowrap; flex-shrink: 0; }
-    .match-score.none { color: #555; font-weight: 400; font-size: 13px; }
+    .match-score { font-size: 14px; font-weight: 600; color: var(--accent); white-space: nowrap; flex-shrink: 0; }
+    .match-score.none { color: var(--text-faint); font-weight: 400; font-size: 13px; }
 
     .refresh-btn, .expand-btn {
       padding: 6px 10px;
       border-radius: 4px;
-      border: 1px solid #2a2d3a;
+      border: 1px solid var(--border);
       background: none;
-      color: #666;
+      color: var(--text-faint);
       font-size: 15px;
       line-height: 1;
       cursor: pointer;
@@ -324,7 +409,7 @@
       min-height: 32px;
     }
     .expand-btn { font-size: 12px; }
-    .refresh-btn:hover, .expand-btn:hover { color: #4a9eff; border-color: #4a9eff; }
+    .refresh-btn:hover, .expand-btn:hover { color: var(--accent); border-color: var(--accent); }
     .refresh-btn:disabled { opacity: 0.3; cursor: default; }
     .refresh-btn.spinning { display: inline-block; animation: spin 0.8s linear infinite; }
 
@@ -335,8 +420,8 @@
 
     .stage-panel {
       display: none;
-      background: #131620;
-      border: 1px solid #2a2d3a;
+      background: var(--bg-surface2);
+      border: 1px solid var(--border);
       border-top: none;
       border-radius: 0 0 8px 8px;
       overflow-x: auto;
@@ -351,37 +436,37 @@
     }
     .stage-table th {
       padding: 7px 10px;
-      color: #555;
+      color: var(--text-faint);
       font-weight: 600;
       text-transform: uppercase;
       letter-spacing: 0.5px;
       text-align: right;
-      background: #0f1117;
-      border-bottom: 1px solid #1e2130;
+      background: var(--stage-th-bg);
+      border-bottom: 1px solid var(--border-light);
     }
     .stage-table th:first-child { text-align: left; }
     .stage-table td {
       padding: 6px 10px;
-      color: #8a9bb0;
+      color: var(--stage-td);
       text-align: right;
-      border-top: 1px solid #1a1d27;
+      border-top: 1px solid var(--bg-surface);
     }
-    .stage-table td:first-child { text-align: left; color: #ccc; max-width: 220px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-    .classifier-badge { display: inline-block; font-size: 0.65rem; font-weight: 700; letter-spacing: 0.03em; padding: 1px 5px; border-radius: 3px; background: #1a3a5c; color: #5ba3f5; border: 1px solid #2a5a8c; margin-right: 5px; vertical-align: middle; flex-shrink: 0; text-decoration: none; }
-    a.classifier-badge:hover { background: #1e4a7a; border-color: #4a9eff; color: #90c8ff; text-decoration: none; }
-    .stage-table tr:hover td { background: #1a1d27; }
-    .col-a  { color: #4caf50; }
-    .col-c  { color: #fdd835; }
-    .col-d  { color: #ff9800; }
-    .col-m  { color: #f44336; font-weight: 600; }
-    .col-ns { color: #f44336; font-weight: 600; }
-    .col-p  { color: #f44336; }
+    .stage-table td:first-child { text-align: left; color: var(--stage-name); max-width: 220px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .classifier-badge { display: inline-block; font-size: 0.65rem; font-weight: 700; letter-spacing: 0.03em; padding: 1px 5px; border-radius: 3px; background: var(--badge-clf-bg); color: var(--badge-clf-text); border: 1px solid var(--badge-clf-bdr); margin-right: 5px; vertical-align: middle; flex-shrink: 0; text-decoration: none; }
+    a.classifier-badge:hover { background: var(--bg-hover); border-color: var(--accent); color: var(--accent); text-decoration: none; }
+    .stage-table tr:hover td { background: var(--bg-surface); }
+    .col-a  { color: #22c55e; }
+    .col-c  { color: #eab308; }
+    .col-d  { color: #f59e0b; }
+    .col-m  { color: #ef4444; font-weight: 600; }
+    .col-ns { color: #ef4444; font-weight: 600; }
+    .col-p  { color: #ef4444; }
 
     /* ── Tooltip stage list ── */
     #tooltip .tt-stages {
       margin-top: 6px;
       padding-top: 6px;
-      border-top: 1px solid #2a2d3a;
+      border-top: 1px solid var(--border);
       max-height: 200px;
       overflow-y: auto;
     }
@@ -392,20 +477,20 @@
       padding: 3px 0;
       font-size: 12px;
     }
-    .tt-stage-name { color: #ccc; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-    .tt-stage-hf   { color: #4a9eff; flex-shrink: 0; }
-    .tt-stage-hits { color: #666; flex-shrink: 0; }
+    .tt-stage-name { color: var(--text-body); flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .tt-stage-hf   { color: var(--accent); flex-shrink: 0; }
+    .tt-stage-hits { color: var(--text-faint); flex-shrink: 0; }
 
     /* ── Misc ── */
     #debugLog {
       display: none;
       margin: 16px 24px 0;
       padding: 10px;
-      background: #111;
-      border: 1px solid #2a2d3a;
+      background: var(--bg-surface2);
+      border: 1px solid var(--border);
       border-radius: 6px;
       font-size: 11px;
-      color: #666;
+      color: var(--debug-text);
       max-height: 120px;
       overflow-y: auto;
       white-space: pre-wrap;
@@ -415,10 +500,10 @@
       display: none;
       margin: 0 24px 16px;
       padding: 14px;
-      background: #2a1a1a;
-      border: 1px solid #5a2a2a;
+      background: rgba(239,68,68,0.08);
+      border: 1px solid rgba(239,68,68,0.3);
       border-radius: 8px;
-      color: #ff9090;
+      color: #ef4444;
       font-size: 14px;
       line-height: 1.6;
     }
@@ -426,33 +511,33 @@
     #tooltip {
       position: fixed;
       display: none;
-      background: #1a1d27;
-      border: 1px solid #2a2d3a;
+      background: var(--tooltip-bg);
+      border: 1px solid var(--tooltip-border);
       border-radius: 8px;
       padding: 12px 16px;
       font-size: 13px;
-      color: #e0e0e0;
+      color: var(--text-body);
       pointer-events: none;
       z-index: 1000;
       max-width: 300px;
-      box-shadow: 0 4px 16px rgba(0,0,0,0.5);
+      box-shadow: 0 4px 16px rgba(0,0,0,0.25);
       line-height: 1.5;
     }
     #tooltip .tt-name  { font-weight: 600; margin-bottom: 2px; font-size: 14px; }
-    #tooltip .tt-date  { font-size: 12px; color: #777; }
-    #tooltip .tt-score { font-size: 18px; font-weight: 700; color: #4a9eff; margin: 4px 0 2px; }
-    #tooltip .tt-meta  { font-size: 12px; color: #999; }
+    #tooltip .tt-date  { font-size: 12px; color: var(--text-muted); }
+    #tooltip .tt-score { font-size: 18px; font-weight: 700; color: var(--accent); margin: 4px 0 2px; }
+    #tooltip .tt-meta  { font-size: 12px; color: var(--text-secondary); }
 
-    a { color: #4a9eff; text-decoration: none; }
+    a { color: var(--accent); text-decoration: none; }
     a:hover { text-decoration: underline; }
 
     /* ── Onboarding card ── */
     #onboardingCard {
       display: none;
       margin: 0 24px 16px;
-      background: #111827;
+      background: var(--bg-surface);
       border: 1px solid rgba(74,158,255,0.3);
-      border-left: 4px solid #4a9eff;
+      border-left: 4px solid var(--accent);
       border-radius: 8px;
       padding: 18px 20px 14px;
     }
@@ -465,7 +550,7 @@
     }
     .onboarding-subtitle {
       font-size: 13px;
-      color: #666;
+      color: var(--text-muted);
       margin-bottom: 16px;
     }
     .onboarding-steps {
@@ -504,7 +589,7 @@
     }
     .onboarding-step-desc {
       font-size: 13px;
-      color: #778;
+      color: var(--onboard-desc);
       line-height: 1.5;
     }
     .onboarding-link-btn {
@@ -526,22 +611,22 @@
     .onboarding-link-btn:hover { background: rgba(74,158,255,0.2); text-decoration: none; }
     .onboarding-divider {
       border: none;
-      border-top: 1px solid #1e2130;
+      border-top: 1px solid var(--border-light);
       margin: 14px 0 12px;
     }
     .onboarding-optional {
       font-size: 12px;
-      color: #555;
+      color: var(--text-muted);
     }
-    .onboarding-optional a { color: #4a9eff; }
+    .onboarding-optional a { color: var(--accent); }
 
     /* ── Update banner ── */
     #updateBanner {
       display: none;
       margin: 0 24px 12px;
-      background: #111827;
+      background: var(--bg-surface);
       border: 1px solid rgba(74,158,255,0.4);
-      border-left: 4px solid #4a9eff;
+      border-left: 4px solid var(--accent);
       border-radius: 8px;
       overflow: hidden;
     }
@@ -572,14 +657,14 @@
     .update-dismiss-btn {
       background: none;
       border: none;
-      color: #555;
+      color: var(--text-faint);
       font-size: 18px;
       line-height: 1;
       cursor: pointer;
       padding: 0 4px;
       flex-shrink: 0;
     }
-    .update-dismiss-btn:hover { color: #aaa; }
+    .update-dismiss-btn:hover { color: var(--text-secondary); }
 
     .update-steps {
       padding: 0 16px 14px;
@@ -674,7 +759,7 @@
       font-size: 13px;
       line-height: 1.5;
     }
-    .login-warning a { color: #f44336; }
+    .login-warning a { color: #ef4444; }
 
     /* ── Class badge (used in stat box + classifier labels) ── */
     .class-badge {
@@ -727,22 +812,36 @@
     .match-item.excluded .match-row {
       opacity: 0.45;
     }
-    .match-item.excluded .match-name { color: #888; }
+    .match-item.excluded .match-name { color: var(--text-muted); }
 
     /* ── Delete button ── */
     .delete-btn {
       padding: 6px 9px;
       border-radius: 4px;
-      border: 1px solid #2a2d3a;
+      border: 1px solid var(--border);
       background: none;
-      color: #666;
+      color: var(--text-faint);
       font-size: 13px;
       line-height: 1;
       cursor: pointer;
       flex-shrink: 0;
       min-height: 32px;
     }
-    .delete-btn:hover { color: #f44336; border-color: #f44336; }
+    .delete-btn:hover { color: #ef4444; border-color: #ef4444; }
+
+    /* ── Theme toggle ── */
+    #themeToggle {
+      background: none;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--text-muted);
+      font-size: 16px;
+      padding: 4px 8px;
+      cursor: pointer;
+      line-height: 1;
+      margin-left: auto;
+    }
+    #themeToggle:hover { color: var(--text-primary); border-color: var(--accent); }
   </style>
 </head>
 <body>
@@ -750,6 +849,7 @@
 
 <header>
   <h1>USPSA Score Progression</h1>
+  <button id="themeToggle" title="Toggle light/dark mode">&#9788;</button>
 </header>
 
 <div class="controls">
@@ -810,20 +910,20 @@
     <div class="update-step">
       <div class="update-step-num">1</div>
       <div class="update-step-text">
-        <a class="update-download-btn" id="updateDownloadBtn" href="#" target="_blank">⬇ Download update</a>
+        <a class="update-download-btn" id="updateDownloadBtn" href="#" target="_blank">Download update</a>
       </div>
     </div>
     <div class="update-step">
       <div class="update-step-num">2</div>
-      <div class="update-step-text">Unzip the downloaded file — you'll get a folder called <strong>extension</strong></div>
+      <div class="update-step-text">Unzip and <strong>overwrite</strong> your existing <strong>extension</strong> folder with the new files</div>
     </div>
     <div class="update-step">
       <div class="update-step-num">3</div>
-      <div class="update-step-text">Go to <strong>chrome://extensions</strong> → enable <strong>Developer mode</strong> (top-right toggle) → click <strong>Load unpacked</strong> → select the <strong>extension</strong> folder</div>
+      <div class="update-step-text">Go to <strong>chrome://extensions</strong> and click the <strong>refresh icon</strong> on PScharts</div>
     </div>
     <div class="update-step">
       <div class="update-step-num">4</div>
-      <div class="update-step-text">Close this tab and reopen PScharts — you're on the latest version</div>
+      <div class="update-step-text">Reopen PScharts — your data is preserved</div>
     </div>
   </div>
   <div class="update-notes-wrap" id="updateNotesWrap" style="display:none">
@@ -884,35 +984,35 @@
   <div class="chart-section" id="chartPlaceSection">
     <div class="chart-section-header">
       <h3>Placement Over Time</h3>
-      <span id="chartPlaceSubtitle" style="font-size:12px;color:#666;text-transform:uppercase;letter-spacing:0.5px"></span>
+      <span id="chartPlaceSubtitle" style="font-size:12px;color:var(--section-title);text-transform:uppercase;letter-spacing:0.5px"></span>
     </div>
     <canvas id="chartPlace" height="180"></canvas>
   </div>
   <div class="chart-section" id="chartNonClfSection" style="display:none">
     <div class="chart-section-header">
       <h3>Non-Classifier Stage Trend</h3>
-      <span style="font-size:12px;color:#666;text-transform:uppercase;letter-spacing:0.5px">Avg HF% across non-classifier stages per match</span>
+      <span style="font-size:12px;color:var(--section-title);text-transform:uppercase;letter-spacing:0.5px">Avg HF% across non-classifier stages per match</span>
     </div>
     <canvas id="chartNonClf" height="180"></canvas>
   </div>
   <div class="chart-section" id="chartClfOverlaySection" style="display:none">
     <div class="chart-section-header">
       <h3>Classifier vs Match Score</h3>
-      <span style="font-size:12px;color:#666;text-transform:uppercase;letter-spacing:0.5px">Are your classifier scores tracking your match performance?</span>
+      <span style="font-size:12px;color:var(--section-title);text-transform:uppercase;letter-spacing:0.5px">Are your classifier scores tracking your match performance?</span>
     </div>
     <canvas id="chartClfOverlay" height="200"></canvas>
   </div>
   <div class="chart-section" id="chartAccuracySection" style="display:none">
     <div class="chart-section-header">
       <h3>Accuracy Trend</h3>
-      <span style="font-size:12px;color:#666;text-transform:uppercase;letter-spacing:0.5px">Miss + No-shoot rate per match — lower is better</span>
+      <span style="font-size:12px;color:var(--section-title);text-transform:uppercase;letter-spacing:0.5px">Miss + No-shoot rate per match — lower is better</span>
     </div>
     <canvas id="chartAccuracy" height="180"></canvas>
   </div>
   <div class="chart-section" id="chartHitZoneSection" style="display:none">
     <div class="chart-section-header">
       <h3>Hit Zone Breakdown</h3>
-      <span style="font-size:12px;color:#666;text-transform:uppercase;letter-spacing:0.5px">A / C / D / M+NS distribution per match</span>
+      <span style="font-size:12px;color:var(--section-title);text-transform:uppercase;letter-spacing:0.5px">A / C / D / M+NS distribution per match</span>
     </div>
     <canvas id="chartHitZone" height="200"></canvas>
   </div>

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -141,6 +141,58 @@ function showUpdateBanner(latestVersion, zipUrl, releasePageUrl, releaseNotes) {
 
 checkForUpdate();
 
+// ── Theme toggle ──────────────────────────────────────────────────────────────
+function applyTheme(theme) {
+  document.documentElement.setAttribute('data-theme', theme);
+  const btn = document.getElementById('themeToggle');
+  if (btn) btn.textContent = theme === 'light' ? '\u263E' : '\u2606'; // moon / sun
+}
+
+// Restore saved theme (check sync first, then local)
+chrome.storage.sync.get(['theme'], syncData => {
+  const theme = syncData.theme || 'dark';
+  applyTheme(theme);
+  // Also save to local for fast restore
+  chrome.storage.local.set({ theme });
+});
+
+document.getElementById('themeToggle').addEventListener('click', () => {
+  const current = document.documentElement.getAttribute('data-theme') || 'dark';
+  const next = current === 'dark' ? 'light' : 'dark';
+  applyTheme(next);
+  chrome.storage.local.set({ theme: next });
+  chrome.storage.sync.set({ theme: next });
+  // Redraw charts with new theme colors
+  renderAll();
+});
+
+// ── Credential sync backup ────────────────────────────────────────────────────
+// On save, back up member number + name to chrome.storage.sync so they survive
+// extension reinstalls. On load, restore from sync if local is empty.
+async function syncCredentials(memberNumber, name) {
+  try {
+    await chrome.storage.sync.set({ memberNumber, name });
+  } catch (_) {} // sync may fail if quota exceeded or offline — non-critical
+}
+
+async function restoreFromSync() {
+  try {
+    const local = await chrome.storage.local.get(['memberNumber', 'name']);
+    if (local.memberNumber || local.name) return; // local has data, no need to restore
+    const sync = await chrome.storage.sync.get(['memberNumber', 'name']);
+    if (sync.memberNumber || sync.name) {
+      // Restore from sync to local
+      await chrome.storage.local.set({
+        memberNumber: sync.memberNumber || '',
+        name: sync.name || '',
+      });
+      if (sync.memberNumber) memberInput.value = sync.memberNumber;
+      if (sync.name) nameInput.value = sync.name;
+      lockInputs();
+    }
+  } catch (_) {}
+}
+
 // ── Module state ──────────────────────────────────────────────────────────────
 let allResults       = [];
 let currentView      = 'ranked'; // 'ranked' | 'all'
@@ -514,6 +566,7 @@ saveBtn.addEventListener('click', async () => {
 
   memberInput.value = newMember;
   chrome.storage.local.set({ memberNumber: newMember, name: newName });
+  syncCredentials(newMember, newName);
   lockInputs();
 });
 
@@ -533,7 +586,16 @@ function hideOnboarding() {
 }
 
 // ── Restore persisted state on load ──────────────────────────────────────────
-chrome.storage.local.get(['memberNumber', 'name', 'lastMatchList', 'matchCache', 'deselectedMatches', 'classificationData'], d => {
+chrome.storage.local.get(['memberNumber', 'name', 'lastMatchList', 'matchCache', 'deselectedMatches', 'classificationData'], async d => {
+  // Try restoring from sync if local has no credentials (e.g. after reinstall)
+  if (!d.memberNumber && !d.name) {
+    await restoreFromSync();
+    // Re-read local after potential sync restore
+    const refreshed = await chrome.storage.local.get(['memberNumber', 'name']);
+    if (refreshed.memberNumber) d.memberNumber = refreshed.memberNumber;
+    if (refreshed.name) d.name = refreshed.name;
+  }
+
   if (d.memberNumber) memberInput.value = d.memberNumber;
   if (d.name)         nameInput.value   = d.name;
   if (d.deselectedMatches) deselectedMatches = new Set(d.deselectedMatches);
@@ -541,6 +603,8 @@ chrome.storage.local.get(['memberNumber', 'name', 'lastMatchList', 'matchCache',
   // Lock inputs if we already have saved credentials
   if (d.memberNumber || d.name) {
     lockInputs();
+    // Ensure sync is up to date
+    syncCredentials(d.memberNumber || '', d.name || '');
   }
 
   // Show onboarding only on genuine first run — no credentials and no match history
@@ -1757,10 +1821,16 @@ function formatAge(ts) {
 // ═════════════════════════════════════════════════════════════════════════════
 
 const PAD        = { top: 24, right: 52, bottom: 44, left: 48 };
-const GRID_COLOR = '#1e2130';
-const AXIS_COLOR = '#2a2d3a';
-const TEXT_COLOR = '#666';
 const FONT       = '10px system-ui, sans-serif';
+
+// Read CSS custom properties for canvas drawing (canvas doesn't support var())
+function cssVar(name) {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}
+function GRID_COLOR() { return cssVar('--grid'); }
+function AXIS_COLOR() { return cssVar('--axis'); }
+function TEXT_COLOR() { return cssVar('--chart-text'); }
+function CHART_BG()   { return cssVar('--chart-bg'); }
 
 // USPSA classification bands (% thresholds)
 const CLASS_BANDS = [
@@ -1795,7 +1865,7 @@ function chartArea(canvas) {
 
 function clearCanvas(ctx, canvas) {
   ctx.clearRect(0, 0, canvas.width, canvas.height);
-  ctx.fillStyle = '#0f1117';
+  ctx.fillStyle = CHART_BG();
   ctx.fillRect(0, 0, canvas.width, canvas.height);
 }
 
@@ -1860,28 +1930,28 @@ function drawMultiSeriesChart(canvas, seriesArr, allDates, opts = {}) {
   }
 
   // Grid
-  ctx.strokeStyle = GRID_COLOR; ctx.lineWidth = 1;
+  ctx.strokeStyle = GRID_COLOR(); ctx.lineWidth = 1;
   for (let i = 0; i <= 5; i++) {
     const v = rawMin + yRange * i / 5, cy = toY(v);
     ctx.beginPath(); ctx.moveTo(area.x0, cy); ctx.lineTo(area.x0 + area.w, cy); ctx.stroke();
-    ctx.fillStyle = TEXT_COLOR; ctx.font = FONT; ctx.textAlign = 'right';
+    ctx.fillStyle = TEXT_COLOR(); ctx.font = FONT; ctx.textAlign = 'right';
     ctx.fillText(v.toFixed(0), area.x0 - 5, cy + 3);
   }
 
   // Axes
-  ctx.strokeStyle = AXIS_COLOR; ctx.lineWidth = 1;
+  ctx.strokeStyle = AXIS_COLOR(); ctx.lineWidth = 1;
   ctx.beginPath(); ctx.moveTo(area.x0, area.y0);
   ctx.lineTo(area.x0, area.y0 + area.h);
   ctx.lineTo(area.x0 + area.w, area.y0 + area.h); ctx.stroke();
 
   // Y label
   ctx.save(); ctx.translate(10, area.y0 + area.h / 2); ctx.rotate(-Math.PI / 2);
-  ctx.fillStyle = TEXT_COLOR; ctx.font = FONT; ctx.textAlign = 'center';
+  ctx.fillStyle = TEXT_COLOR(); ctx.font = FONT; ctx.textAlign = 'center';
   ctx.fillText(yLabel, 0, 0); ctx.restore();
 
   // X date labels
   const step = Math.ceil(allDates.length / 8);
-  ctx.fillStyle = TEXT_COLOR; ctx.font = FONT; ctx.textAlign = 'center';
+  ctx.fillStyle = TEXT_COLOR(); ctx.font = FONT; ctx.textAlign = 'center';
   allDates.forEach((d, i) => {
     if (i % step !== 0 && i !== allDates.length - 1) return;
     ctx.fillText(d.substring(5), dateToCanvasX(d), area.y0 + area.h + 14); // MM-DD
@@ -1894,7 +1964,7 @@ function drawMultiSeriesChart(canvas, seriesArr, allDates, opts = {}) {
     seriesArr.forEach(s => {
       ctx.fillStyle = s.color;
       ctx.fillRect(lx, ly - 7, 12, 8);
-      ctx.fillStyle = TEXT_COLOR; ctx.font = FONT; ctx.textAlign = 'left';
+      ctx.fillStyle = TEXT_COLOR(); ctx.font = FONT; ctx.textAlign = 'left';
       ctx.fillText(s.label, lx + 16, ly);
       lx += 16 + ctx.measureText(s.label).width + 16;
     });
@@ -2066,23 +2136,23 @@ function drawLineChart(canvas, points, opts = {}) {
   };
 
   // Grid
-  ctx.strokeStyle = GRID_COLOR; ctx.lineWidth = 1;
+  ctx.strokeStyle = GRID_COLOR(); ctx.lineWidth = 1;
   for (let i = 0; i <= 5; i++) {
     const v = rawMin + yRange * i / 5, cy = toY(v);
     ctx.beginPath(); ctx.moveTo(area.x0, cy); ctx.lineTo(area.x0 + area.w, cy); ctx.stroke();
-    ctx.fillStyle = TEXT_COLOR; ctx.font = FONT; ctx.textAlign = 'right';
+    ctx.fillStyle = TEXT_COLOR(); ctx.font = FONT; ctx.textAlign = 'right';
     ctx.fillText(v.toFixed(0), area.x0 - 5, cy + 3);
   }
 
   // Axes
-  ctx.strokeStyle = AXIS_COLOR; ctx.lineWidth = 1;
+  ctx.strokeStyle = AXIS_COLOR(); ctx.lineWidth = 1;
   ctx.beginPath(); ctx.moveTo(area.x0, area.y0);
   ctx.lineTo(area.x0, area.y0 + area.h);
   ctx.lineTo(area.x0 + area.w, area.y0 + area.h); ctx.stroke();
 
   // Y label
   ctx.save(); ctx.translate(10, area.y0 + area.h / 2); ctx.rotate(-Math.PI / 2);
-  ctx.fillStyle = TEXT_COLOR; ctx.font = FONT; ctx.textAlign = 'center';
+  ctx.fillStyle = TEXT_COLOR(); ctx.font = FONT; ctx.textAlign = 'center';
   ctx.fillText(yLabel, 0, 0); ctx.restore();
 
   // Trend
@@ -2113,7 +2183,7 @@ function drawLineChart(canvas, points, opts = {}) {
 
   // X labels (MM-DD)
   const step = Math.ceil(points.length / 8);
-  ctx.fillStyle = TEXT_COLOR; ctx.font = FONT; ctx.textAlign = 'center';
+  ctx.fillStyle = TEXT_COLOR(); ctx.font = FONT; ctx.textAlign = 'center';
   points.forEach((p, i) => {
     if (i % step !== 0 && i !== points.length - 1) return;
     const lbl = p.date ? p.date.substring(5) : `#${i+1}`;
@@ -2175,7 +2245,7 @@ function drawLineChart(canvas, points, opts = {}) {
 function drawMessage(canvas, msg) {
   const ctx = canvas.getContext('2d');
   clearCanvas(ctx, canvas);
-  ctx.fillStyle = '#444'; ctx.font = '13px system-ui, sans-serif'; ctx.textAlign = 'center';
+  ctx.fillStyle = TEXT_COLOR(); ctx.font = '13px system-ui, sans-serif'; ctx.textAlign = 'center';
   ctx.fillText(msg, canvas.width / 2, canvas.height / 2);
 }
 
@@ -2221,7 +2291,7 @@ function drawStackedBarChart(canvas, bars) {
 
     // X label
     if (n <= 12 || i % Math.ceil(n / 8) === 0 || i === n - 1) {
-      ctx.fillStyle = TEXT_COLOR;
+      ctx.fillStyle = TEXT_COLOR();
       ctx.font = FONT;
       ctx.textAlign = 'center';
       ctx.fillText(bar.date ? bar.date.substring(5) : `#${i + 1}`, cx, area.y0 + area.h + 14);
@@ -2229,16 +2299,16 @@ function drawStackedBarChart(canvas, bars) {
   });
 
   // Y axis — 0/25/50/75/100%
-  ctx.strokeStyle = GRID_COLOR; ctx.lineWidth = 1;
+  ctx.strokeStyle = GRID_COLOR(); ctx.lineWidth = 1;
   [0, 25, 50, 75, 100].forEach(v => {
     const cy = area.y0 + area.h - (v / 100) * area.h;
     ctx.beginPath(); ctx.moveTo(area.x0, cy); ctx.lineTo(area.x0 + area.w, cy); ctx.stroke();
-    ctx.fillStyle = TEXT_COLOR; ctx.font = FONT; ctx.textAlign = 'right';
+    ctx.fillStyle = TEXT_COLOR(); ctx.font = FONT; ctx.textAlign = 'right';
     ctx.fillText(v + '%', area.x0 - 5, cy + 3);
   });
 
   // Axes
-  ctx.strokeStyle = AXIS_COLOR; ctx.lineWidth = 1;
+  ctx.strokeStyle = AXIS_COLOR(); ctx.lineWidth = 1;
   ctx.beginPath();
   ctx.moveTo(area.x0, area.y0);
   ctx.lineTo(area.x0, area.y0 + area.h);
@@ -2251,7 +2321,7 @@ function drawStackedBarChart(canvas, bars) {
   SEGMENTS.forEach(seg => {
     ctx.fillStyle = COLORS[seg];
     ctx.fillRect(lx, ly - 7, 10, 8);
-    ctx.fillStyle = TEXT_COLOR; ctx.font = FONT; ctx.textAlign = 'left';
+    ctx.fillStyle = TEXT_COLOR(); ctx.font = FONT; ctx.textAlign = 'left';
     ctx.fillText(SEG_LABELS[seg], lx + 14, ly);
     lx += 14 + ctx.measureText(SEG_LABELS[seg]).width + 14;
   });

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "PScharts",
-  "version": "1.2",
-  "description": "PScharts 1.2 — Chart your USPSA match scores from PractiScore",
+  "version": "1.3",
+  "description": "PScharts 1.3 — Chart your USPSA match scores from PractiScore",
   "permissions": ["tabs", "scripting", "storage"],
   "host_permissions": ["https://practiscore.com/*", "https://s3.amazonaws.com/*", "https://api.github.com/*", "https://uspsa.org/*", "https://objects.githubusercontent.com/*"],
   "content_security_policy": {


### PR DESCRIPTION
## Summary

### Light/Dark Mode Toggle
- Sun/moon button in header toggles between dark and light themes
- Full CSS custom property system — every color in the UI is theme-aware
- **High-contrast text in both modes** — fixes the low-contrast gray-on-black readability issues (stage table data, match metadata, section titles, chart labels, tooltips, etc.)
- Theme preference saved to both local and sync storage

### Credential Sync Backup
- Member number and name are now backed up to `chrome.storage.sync` (tied to Google account)
- On fresh install/reinstall, credentials auto-restore from sync — no need to re-enter
- Match cache stays in local storage (too large for sync quota)

### Update UX Improvements
- Update banner now says **"overwrite your existing extension folder + click refresh"** instead of "Load unpacked"
- This preserves the extension ID, which preserves all cached data and credentials
- Release zip is now named `PScharts.zip` (no version in filename) so unzipping always overwrites the same folder

### Version
- Bumps to v1.3