### PR TITLE
feat: upstream sync — image export, CSV, date range, chart improvements (t005–t011)

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -527,7 +527,7 @@ async function fetchStageData(tabId, matchId, memberNumber, name, divKey, stageO
     if (!page?._found) { push(`     ${opt.text}: not found`); continue; }
 
     const d = page.competitorData;
-    const stageName = opt.text.replace(/^stage\s*\d+\s*[:\-–]\s*/i, '').trim() || opt.text;
+    const stageName = opt.text.replace(/^stage\s*\d+\s*[:\-–]?\s*/i, '').trim() || opt.text;
     const stageNum  = parseInt(opt.text.match(/\d+/)?.[0]) || stages.length + 1;
 
     // ── GM benchmark: collect HF values for all GM-class competitors in same division ──

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -352,7 +352,7 @@
     .match-score { font-size: 14px; font-weight: 600; color: #4a9eff; white-space: nowrap; flex-shrink: 0; }
     .match-score.none { color: #555; font-weight: 400; font-size: 13px; }
 
-    .refresh-btn, .expand-btn {
+    .refresh-btn {
       padding: 6px 10px;
       border-radius: 4px;
       border: 1px solid #2a2d3a;
@@ -364,10 +364,69 @@
       flex-shrink: 0;
       min-height: 32px;
     }
-    .expand-btn { font-size: 12px; }
-    .refresh-btn:hover, .expand-btn:hover { color: #4a9eff; border-color: #4a9eff; }
+    .refresh-btn:hover { color: #4a9eff; border-color: #4a9eff; }
     .refresh-btn:disabled { opacity: 0.3; cursor: default; }
     .refresh-btn.spinning { display: inline-block; animation: spin 0.8s linear infinite; }
+
+    .expand-btn {
+      background: none;
+      border: none;
+      color: #555;
+      font-size: 12px;
+      line-height: 1;
+      cursor: pointer;
+      flex-shrink: 0;
+      padding: 4px 2px;
+    }
+    .expand-btn:hover { color: #4a9eff; }
+    .expand-placeholder { width: 20px; flex-shrink: 0; display: inline-block; }
+
+    .export-btn {
+      padding: 4px 7px;
+      border-radius: 4px;
+      border: 1px solid #2a2d3a;
+      background: none;
+      color: #555;
+      line-height: 1;
+      cursor: pointer;
+      flex-shrink: 0;
+      display: inline-flex;
+      align-items: center;
+    }
+    .export-btn:hover { color: #4caf50; border-color: #4caf50; }
+
+    /* ── Export menu ── */
+    #exportMenu {
+      position: fixed;
+      display: none;
+      background: #1a1d27;
+      border: 1px solid #2a2d3a;
+      border-radius: 6px;
+      box-shadow: 0 6px 20px rgba(0,0,0,0.5);
+      z-index: 2000;
+      min-width: 210px;
+      overflow: hidden;
+    }
+    .export-menu-title {
+      padding: 6px 14px;
+      font-size: 10px;
+      color: #444;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      border-bottom: 1px solid #1e2130;
+    }
+    .export-menu-item {
+      padding: 8px 14px;
+      cursor: pointer;
+      font-size: 12px;
+      color: #ccc;
+      border-bottom: 1px solid #1a1d27;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .export-menu-item:last-child { border-bottom: none; }
+    .export-menu-item:hover { background: #1e2235; color: #4caf50; }
 
     /* ── Stage panel ── */
     .match-item { margin-bottom: 6px; }
@@ -969,6 +1028,7 @@
 <div id="debugLog"></div>
 
 </div>
+<div id="exportMenu"></div>
 <div id="tooltip"></div>
 <script src="dashboard.js"></script>
 </body>

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -888,7 +888,7 @@
         </span>
       </label>
     </div>
-    <canvas id="chartTime" height="220"></canvas>
+    <canvas id="chartTime" height="380"></canvas>
   </div>
   <div class="chart-section" id="chartPlaceSection">
     <div class="chart-section-header">

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -236,6 +236,18 @@
       justify-content: space-between;
       margin-bottom: 12px;
     }
+    #exportCsvBtn {
+      margin-left: auto;
+      margin-right: 12px;
+      padding: 4px 10px;
+      border-radius: 4px;
+      border: 1px solid #2a2d3a;
+      background: none;
+      color: #555;
+      font-size: 11px;
+      cursor: pointer;
+    }
+    #exportCsvBtn:hover { color: #4caf50; border-color: #4caf50; }
     .chart-section h3 {
       font-size: 12px;
       font-weight: 600;
@@ -901,6 +913,7 @@
   <div class="chart-section">
     <div class="chart-section-header">
       <h3 id="chartTimeTitle">Score Over Time</h3>
+      <button id="exportCsvBtn" title="Export chart data as CSV">⤓ CSV</button>
       <label id="classifiersToggleWrap">
         <span class="toggle-lbl">Classifiers Only</span>
         <span class="toggle-switch">

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -187,6 +187,27 @@
     .time-btn:hover { border-color: #4a9eff; color: #ccc; }
     .time-btn.active { background: #1e3a5f; border-color: #4a9eff; color: #4a9eff; }
 
+    .date-range-form {
+      padding: 8px 14px 12px;
+      border-top: 1px solid #2a2d3a;
+      display: flex;
+      flex-direction: column;
+      gap: 5px;
+    }
+    .date-range-form label { font-size: 10px; color: #555; text-transform: uppercase; letter-spacing: 0.4px; }
+    .date-range-form input[type="date"] {
+      background: #131620; border: 1px solid #2a2d3a; border-radius: 4px;
+      color: #ccc; font-size: 12px; padding: 4px 8px; width: 100%;
+      color-scheme: dark;
+    }
+    .date-range-form input[type="date"]:focus { outline: none; border-color: #4a9eff; }
+    .date-range-form .dr-apply {
+      margin-top: 4px; padding: 5px 12px; align-self: flex-end;
+      border-radius: 4px; border: 1px solid #4a9eff;
+      background: none; color: #4a9eff; font-size: 12px; cursor: pointer;
+    }
+    .date-range-form .dr-apply:hover { background: #1e3a5f; }
+
     #viewToggle { display: flex; flex-direction: column; gap: 6px; flex-shrink: 0; }
     .view-btn {
       padding: 8px 16px;

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -200,8 +200,9 @@ async function restoreFromSync() {
 let allResults       = [];
 let currentView      = 'ranked'; // 'ranked' | 'all'
 let deselectedMatches = new Set(); // match IDs manually excluded from charts
-let selectedDiv      = null;     // division filter for stats + charts (null = All)
-let selectedYear     = null;     // year filter for charts (null = All Time)
+let selectedDiv       = null;     // division filter for stats + charts (null = All)
+let selectedYear      = null;     // year filter for charts (null = All Time)
+let selectedDateRange = null;    // custom range { start: 'YYYY-MM-DD', end: 'YYYY-MM-DD' } or null
 let classificationData = null;  // data from uspsa.org/classification/[memberNumber]
 let classifiersOnly  = false;   // when true, charts show only classifier stage scores
 
@@ -771,39 +772,84 @@ fetchBtn.addEventListener('click', async () => {
 });
 
 // ── Year filter pills ─────────────────────────────────────────────────────────
+// ── Year / date-range filter pill ────────────────────────────────────────────
 function renderYearFilter(years) {
   const el = document.getElementById('timeFilter');
   el.innerHTML = '';
   if (years.length === 0) { el.style.display = 'none'; return; }
   el.style.display = 'flex';
 
+  const isCustom = !!selectedDateRange;
+  const label    = isCustom
+    ? `${selectedDateRange.start} – ${selectedDateRange.end}`
+    : selectedYear || 'All Time';
+
   const pill = document.createElement('button');
-  pill.className = 'time-btn' + (selectedYear ? ' active' : '');
-  pill.textContent = selectedYear || 'All Time';
+  pill.className = 'time-btn' + (selectedYear || isCustom ? ' active' : '');
+  pill.textContent = label;
+
   pill.onclick = (e) => {
     e.stopPropagation();
     const existing = el.querySelector('.div-dropdown');
     if (existing) { existing.remove(); return; }
+
     const dropdown = document.createElement('div');
     dropdown.className = 'div-dropdown';
+
+    // Standard year options
     ['All Time', ...years].forEach(y => {
       const item = document.createElement('div');
-      item.className = 'div-dropdown-item' + ((y === 'All Time' && !selectedYear) || y === selectedYear ? ' selected' : '');
+      item.className = 'div-dropdown-item' +
+        ((y === 'All Time' && !selectedYear && !isCustom) || y === selectedYear ? ' selected' : '');
       item.textContent = y;
       item.onclick = (ev) => {
         ev.stopPropagation();
         selectedYear = y === 'All Time' ? null : y;
+        selectedDateRange = null;
         dropdown.remove();
         renderAll();
       };
       dropdown.appendChild(item);
     });
+
+    // Custom range entry
+    const customItem = document.createElement('div');
+    customItem.className = 'div-dropdown-item' + (isCustom ? ' selected' : '');
+    customItem.textContent = 'Custom Range…';
+    customItem.onclick = (ev) => {
+      ev.stopPropagation();
+      if (dropdown.querySelector('.date-range-form')) return;
+      const form = document.createElement('div');
+      form.className = 'date-range-form';
+      form.innerHTML = `
+        <label>From</label>
+        <input type="date" class="dr-from" value="${selectedDateRange?.start || ''}">
+        <label>To</label>
+        <input type="date" class="dr-to"   value="${selectedDateRange?.end   || ''}">
+        <button class="dr-apply">Apply</button>
+      `;
+      form.addEventListener('click', ev2 => ev2.stopPropagation());
+      form.querySelector('.dr-apply').onclick = () => {
+        const start = form.querySelector('.dr-from').value;
+        const end   = form.querySelector('.dr-to').value;
+        if (start && end && start <= end) {
+          selectedDateRange = { start, end };
+          selectedYear = null;
+          dropdown.remove();
+          renderAll();
+        }
+      };
+      dropdown.appendChild(form);
+    };
+    dropdown.appendChild(customItem);
+
     el.appendChild(dropdown);
     setTimeout(() => document.addEventListener('click', function close() {
       dropdown.remove();
       document.removeEventListener('click', close);
     }, { once: true }), 0);
   };
+
   el.appendChild(pill);
 }
 
@@ -867,10 +913,11 @@ function renderAll() {
   const years = [...new Set(sorted.map(r => r.date?.slice(0, 4)).filter(Boolean))].sort();
   if (selectedYear && !years.includes(selectedYear)) selectedYear = null;
 
-  // Filter to selected division + year for stats + charts
+  // Filter to selected division + year/range for stats + charts
   const viewSorted = sorted.filter(r =>
-    (!selectedDiv || (r.division || 'Unknown') === selectedDiv) &&
-    (!selectedYear || r.date?.startsWith(selectedYear))
+    (!selectedDiv       || (r.division || 'Unknown') === selectedDiv) &&
+    (!selectedYear      || r.date?.startsWith(selectedYear)) &&
+    (!selectedDateRange || (r.date >= selectedDateRange.start && r.date <= selectedDateRange.end))
   );
 
   const avg  = viewSorted.reduce((s, r) => s + (r.overall_pct ?? 0), 0) / (viewSorted.length || 1);

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -1507,9 +1507,10 @@ function renderMatchList() {
       </div>
       <span class="match-type-badge ${typeBadgeClass}"></span>
       <div class="match-score ${scoreText ? '' : 'none'}">${scoreText || 'No score'}</div>
-      ${hasStages ? '<button class="expand-btn" title="Show stage breakdown">▼</button>' : ''}
-      <button class="refresh-btn" title="Re-fetch this match">↻</button>
-      <button class="delete-btn" title="Delete from history">✕</button>
+      ${hasStages ? '<button class="expand-btn" title="Show stage breakdown">&#9658;</button>' : '<span class="expand-placeholder"></span>'}
+      <button class="refresh-btn" title="Re-fetch this match">&#8635;</button>
+      <button class="export-btn" title="Save as image">${SAVE_ICON}</button>
+      <button class="delete-btn" title="Delete from history">&#x2715;</button>
     `;
     // Set untrusted text via textContent to prevent XSS
     row.querySelector('.match-name').textContent = match.match_name;
@@ -1673,12 +1674,12 @@ function renderMatchList() {
       const toggleExpand = () => {
         const isOpen = panel.classList.toggle('open');
         item.classList.toggle('open', isOpen);
-        row.querySelector('.expand-btn').textContent = isOpen ? '▲' : '▼';
+        row.querySelector('.expand-btn').textContent = isOpen ? '▼' : '▶';
       };
 
       row.style.cursor = 'pointer';
       row.addEventListener('click', e => {
-        if (e.target.closest('.refresh-btn, .delete-btn, .match-include-cb, .classifier-badge')) return;
+        if (e.target.closest('.refresh-btn, .delete-btn, .export-btn, .match-include-cb, .classifier-badge')) return;
         toggleExpand();
       });
       row.querySelector('.expand-btn').addEventListener('click', e => {
@@ -1712,6 +1713,17 @@ function renderMatchList() {
     row.querySelector('.refresh-btn').addEventListener('click', e => {
       e.stopPropagation();
       refreshSingleMatch(match, row.querySelector('.refresh-btn'));
+    });
+
+    // Export button → show per-match/stage image export menu
+    row.querySelector('.export-btn').addEventListener('click', e => {
+      e.stopPropagation();
+      if (_exportMenuMatch === match && _exportMenuEl.style.display !== 'none') {
+        _exportMenuEl.style.display = 'none';
+        _exportMenuMatch = null;
+      } else {
+        showExportMenu(match, e.currentTarget);
+      }
     });
 
     // Delete button
@@ -1865,6 +1877,337 @@ function updateStatusCounts(verb) {
   const unconfirmedNote  = unconfirmed.length > 0 ? ` · ${unconfirmed.length} unconfirmed type` : '';
   const skippedNote      = nonUspsa.length > 0    ? ` · ${nonUspsa.length} non-USPSA excluded` : '';
   setStatus(`${prefix} ${uspsa} USPSA match(es) — ${scored} with scores${checkedNote}.${unconfirmedNote}${skippedNote}`, 'success');
+}
+
+// ── Save icon SVG (floppy disk, feather-style) ────────────────────────────────
+const SAVE_ICON = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg>`;
+
+// ── Export menu ───────────────────────────────────────────────────────────────
+let _exportMenuMatch = null;
+const _exportMenuEl  = document.getElementById('exportMenu');
+
+function showExportMenu(match, anchorEl) {
+  _exportMenuMatch = match;
+  const stages = match.stages || [];
+  _exportMenuEl.innerHTML = `
+    <div class="export-menu-title">Save as Image</div>
+    <div class="export-menu-item" data-action="match">Full Match</div>
+    ${stages.map((s, i) => {
+      const nm = normalizeStgName(s.name);
+      return `<div class="export-menu-item" data-action="stage" data-idx="${i}">Stage ${i + 1}: ${nm.length > 32 ? nm.slice(0, 30) + '\u2026' : nm}</div>`;
+    }).join('')}
+  `;
+  _exportMenuEl.style.display = 'block';
+  const r = anchorEl.getBoundingClientRect();
+  const mh = _exportMenuEl.offsetHeight;
+  const top = r.bottom + mh + 4 > window.innerHeight ? r.top - mh - 4 : r.bottom + 4;
+  _exportMenuEl.style.top  = top + 'px';
+  _exportMenuEl.style.left = Math.min(r.left, window.innerWidth - 220) + 'px';
+}
+
+_exportMenuEl.addEventListener('click', e => {
+  const item = e.target.closest('.export-menu-item');
+  if (!item || !_exportMenuMatch) return;
+  _exportMenuEl.style.display = 'none';
+  if (item.dataset.action === 'match') {
+    exportMatchCard(_exportMenuMatch);
+  } else {
+    exportStageCard(_exportMenuMatch, _exportMenuMatch.stages[+item.dataset.idx]);
+  }
+  _exportMenuMatch = null;
+});
+
+document.addEventListener('click', e => {
+  if (_exportMenuEl.style.display !== 'none' && !_exportMenuEl.contains(e.target)
+      && !e.target.closest('.export-btn')) {
+    _exportMenuEl.style.display = 'none';
+    _exportMenuMatch = null;
+  }
+});
+
+// ── Export card helpers ───────────────────────────────────────────────────────
+function _rrPath(ctx, x, y, w, h, r) {
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + w - r, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+  ctx.lineTo(x + w, y + h - r);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+  ctx.lineTo(x + r, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
+}
+
+function _wrapText(ctx, text, maxWidth) {
+  const words = (text || '').split(' ');
+  const lines = [];
+  let line = '';
+  for (const word of words) {
+    const test = line ? line + ' ' + word : word;
+    if (line && ctx.measureText(test).width > maxWidth) { lines.push(line); line = word; }
+    else line = test;
+  }
+  if (line) lines.push(line);
+  return lines.length ? lines : [''];
+}
+
+function _trunc(ctx, text, maxWidth) {
+  if (ctx.measureText(text).width <= maxWidth) return text;
+  let t = text;
+  while (t.length > 0 && ctx.measureText(t + '\u2026').width > maxWidth) t = t.slice(0, -1);
+  return t + '\u2026';
+}
+
+function _cardColor(pct) {
+  if (pct == null) return '#8a9bb0';
+  if (pct >= 95) return '#ffd700';
+  if (pct >= 85) return '#e040fb';
+  if (pct >= 75) return '#4caf50';
+  if (pct >= 60) return '#4a9eff';
+  if (pct >= 40) return '#ff9800';
+  return '#8a9bb0';
+}
+
+function _cardLabel(pct) {
+  if (pct == null) return '';
+  if (pct >= 95) return 'GM';
+  if (pct >= 85) return 'M';
+  if (pct >= 75) return 'A';
+  if (pct >= 60) return 'B';
+  if (pct >= 40) return 'C';
+  return 'D';
+}
+
+function _dividerLine(ctx, x, y, w) {
+  ctx.save();
+  ctx.strokeStyle = '#2a2d3a';
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(x, y + 0.5);
+  ctx.lineTo(x + w, y + 0.5);
+  ctx.stroke();
+  ctx.restore();
+}
+
+function _downloadPng(canvas, name) {
+  canvas.toBlob(blob => {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = (name || 'card').replace(/[^a-z0-9._-]/gi, '_') + '.png';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }, 'image/png');
+}
+
+function exportMatchCard(match) {
+  const DPR = 2, F = 'system-ui,-apple-system,sans-serif';
+  const W = 320, PAD = 16;
+
+  const probe = document.createElement('canvas').getContext('2d');
+  probe.font = `bold 13px ${F}`;
+  const nameLines  = _wrapText(probe, match.match_name || '', W - PAD * 2);
+  const scorePct   = match.div_pct ?? match.overall_pct;
+  const hasScore   = scorePct != null;
+  const showOverall = match.overall_pct != null && match.div_pct != null
+                     && Math.abs(match.overall_pct - match.div_pct) > 0.1;
+  const hasStages  = match.stages?.length > 0;
+
+  let H = PAD;
+  H += nameLines.length * 16;
+  H += 4 + 14;
+  if (hasScore) {
+    H += 10 + 30;
+    if (showOverall) H += 14;
+    H += 8;
+  }
+  if (hasStages) { H += 1 + 8 + match.stages.length * 20 + 6; }
+  H += 1 + 8 + 14 + PAD;
+
+  const canvas = document.createElement('canvas');
+  canvas.width  = W * DPR;
+  canvas.height = H * DPR;
+  const ctx = canvas.getContext('2d');
+  ctx.scale(DPR, DPR);
+
+  const ox = 0, oy = 0;
+
+  ctx.fillStyle = '#1a1d27';
+  ctx.fillRect(0, 0, W, H);
+  ctx.strokeStyle = '#2a2d3a'; ctx.lineWidth = 1;
+  ctx.strokeRect(0.5, 0.5, W - 1, H - 1);
+
+  let y = oy + PAD;
+
+  ctx.font = `bold 13px ${F}`; ctx.fillStyle = '#fff';
+  nameLines.forEach(l => { ctx.fillText(l, ox + PAD, y + 12); y += 16; });
+  y += 4;
+
+  ctx.font = `11px ${F}`; ctx.fillStyle = '#888';
+  const meta = [match.date, [match.division, match.class_].filter(Boolean).join('/')].filter(Boolean).join(' \u00b7 ');
+  ctx.fillText(meta, ox + PAD, y + 10);
+  y += 14;
+
+  if (hasScore) {
+    y += 10;
+    const color = _cardColor(scorePct), label = _cardLabel(scorePct);
+    ctx.font = `bold 28px ${F}`; ctx.fillStyle = color;
+    const ps = scorePct.toFixed(1) + '%';
+    ctx.fillText(ps, ox + PAD, y + 24);
+    const pw = ctx.measureText(ps).width;
+    ctx.font = `bold 12px ${F}`; ctx.fillStyle = color;
+    ctx.fillText(label, ox + PAD + pw + 6, y + 20);
+    ctx.font = `9px ${F}`; ctx.fillStyle = '#555';
+    ctx.fillText(match.div_pct != null ? 'div %' : 'overall %', ox + PAD + pw + 6, y + 30);
+    y += 30;
+    if (showOverall) {
+      ctx.font = `11px ${F}`; ctx.fillStyle = '#888';
+      ctx.fillText(`overall: ${match.overall_pct.toFixed(1)}%`, ox + PAD, y + 10);
+      y += 14;
+    }
+    y += 8;
+  }
+
+  if (hasStages) {
+    _dividerLine(ctx, ox + PAD, y, W - PAD * 2); y += 8;
+    const pctX = ox + W - PAD;
+    const hfX  = pctX - 52;
+    const nameMaxW = hfX - 50 - (ox + PAD);
+    match.stages.forEach(s => {
+      const clf = isClassifierStage(s);
+      const pct = clf && s.clf_pct != null ? s.clf_pct : s.pct;
+      ctx.font = clf ? `bold 11px ${F}` : `11px ${F}`;
+      ctx.fillStyle = clf ? '#4a9eff' : '#ccc';
+      const nm = (clf ? `CM ${clf.number} \u00b7 ` : '') + normalizeStgName(s.name);
+      ctx.fillText(_trunc(ctx, nm, nameMaxW), ox + PAD, y + 10);
+      ctx.font = `11px ${F}`;
+      ctx.fillStyle = '#555';
+      const hfStr = s.hf != null ? s.hf.toFixed(4) : '\u2014';
+      ctx.fillText(hfStr, hfX - ctx.measureText(hfStr).width, y + 10);
+      ctx.fillStyle = _cardColor(pct);
+      const pStr = pct != null ? pct.toFixed(1) + '%' : '\u2014';
+      ctx.fillText(pStr, pctX - ctx.measureText(pStr).width, y + 10);
+      y += 20;
+    });
+    y += 6;
+  }
+
+  _dividerLine(ctx, ox + PAD, y, W - PAD * 2); y += 8;
+  ctx.font = `10px ${F}`; ctx.fillStyle = '#444';
+  ctx.fillText('PScharts', ox + W - PAD - ctx.measureText('PScharts').width, y + 10);
+
+  _downloadPng(canvas, [match.match_name || 'match', match.date].filter(Boolean).join(' '));
+}
+
+function exportStageCard(match, stage) {
+  const DPR = 2, F = 'system-ui,-apple-system,sans-serif';
+  const W = 280, PAD = 14;
+
+  const clf         = isClassifierStage(stage);
+  const officialPct = clf && stage.clf_pct != null ? stage.clf_pct : null;
+  const displayPct  = officialPct ?? stage.pct;
+  const showMatchPct = officialPct != null && stage.pct != null;
+  const hits = [
+    stage.a  > 0 && { t: `${stage.a}A`,   c: '#4caf50' },
+    stage.c  > 0 && { t: `${stage.c}C`,   c: '#fdd835' },
+    stage.d  > 0 && { t: `${stage.d}D`,   c: '#ff9800' },
+    stage.m  > 0 && { t: `${stage.m}M`,   c: '#f44336' },
+    stage.ns > 0 && { t: `${stage.ns}NS`, c: '#f44336' },
+    stage.p  > 0 && { t: `${stage.p}P`,   c: '#f44336' },
+  ].filter(Boolean);
+
+  let H = PAD;
+  if (clf) H += 14;
+  H += 16 + 8;
+  H += 1 + 10;
+  if (displayPct != null) {
+    H += 32;
+    if (showMatchPct) H += 14;
+  }
+  H += 10 + 1 + 8;
+  H += 14;
+  if (hits.length) H += 14;
+  H += 8 + 1 + 8 + 14 + PAD;
+
+  const canvas = document.createElement('canvas');
+  canvas.width  = W * DPR;
+  canvas.height = H * DPR;
+  const ctx = canvas.getContext('2d');
+  ctx.scale(DPR, DPR);
+
+  const ox = 0, oy = 0;
+
+  ctx.fillStyle = '#1a1d27';
+  ctx.fillRect(0, 0, W, H);
+  ctx.strokeStyle = '#2a2d3a'; ctx.lineWidth = 1;
+  ctx.strokeRect(0.5, 0.5, W - 1, H - 1);
+
+  let y = oy + PAD;
+
+  if (clf) {
+    ctx.font = `bold 11px ${F}`; ctx.fillStyle = '#4a9eff';
+    ctx.fillText(`CM ${clf.number}`, ox + PAD, y + 10);
+    y += 14;
+  }
+
+  ctx.font = `bold 13px ${F}`; ctx.fillStyle = '#fff';
+  ctx.fillText(_trunc(ctx, normalizeStgName(stage.name), W - PAD * 2), ox + PAD, y + 12);
+  y += 16; y += 8;
+
+  _dividerLine(ctx, ox + PAD, y, W - PAD * 2); y += 10;
+
+  if (displayPct != null) {
+    const color = _cardColor(displayPct), label = _cardLabel(displayPct);
+    ctx.font = `bold 28px ${F}`; ctx.fillStyle = color;
+    const ps = displayPct.toFixed(1) + '%';
+    ctx.fillText(ps, ox + PAD, y + 26);
+    const pw = ctx.measureText(ps).width;
+    ctx.font = `bold 13px ${F}`; ctx.fillStyle = color;
+    ctx.fillText(label, ox + PAD + pw + 6, y + 22);
+    y += 32;
+    if (showMatchPct) {
+      ctx.font = `11px ${F}`; ctx.fillStyle = '#666';
+      ctx.fillText(`match: ${stage.pct.toFixed(1)}%`, ox + PAD, y + 10);
+      y += 14;
+    }
+  }
+  y += 10;
+
+  _dividerLine(ctx, ox + PAD, y, W - PAD * 2); y += 8;
+
+  ctx.font = `11px ${F}`; ctx.fillStyle = '#888';
+  const stats = [
+    stage.hf   != null && `HF: ${stage.hf.toFixed(4)}`,
+    stage.time != null && `Time: ${stage.time.toFixed(2)}s`,
+  ].filter(Boolean).join('   ');
+  if (stats) ctx.fillText(stats, ox + PAD, y + 10);
+  y += 14;
+
+  if (hits.length) {
+    let hx = ox + PAD;
+    hits.forEach(h => {
+      ctx.font = `11px ${F}`; ctx.fillStyle = h.c;
+      ctx.fillText(h.t, hx, y + 10);
+      hx += ctx.measureText(h.t + '  ').width;
+    });
+    y += 14;
+  }
+  y += 8;
+
+  _dividerLine(ctx, ox + PAD, y, W - PAD * 2); y += 8;
+  ctx.font = `10px ${F}`;
+  ctx.fillStyle = '#555';
+  const fl = _trunc(ctx, [match.match_name, match.date].filter(Boolean).join(' \u00b7 '), W - PAD * 2 - 68);
+  ctx.fillText(fl, ox + PAD, y + 10);
+  ctx.fillStyle = '#444';
+  ctx.fillText('PScharts', ox + W - PAD - ctx.measureText('PScharts').width, y + 10);
+
+  const stageBase = clf ? `CM ${clf.number} ${normalizeStgName(stage.name)}` : normalizeStgName(stage.name) || 'stage';
+  _downloadPng(canvas, [stageBase, match.date].filter(Boolean).join(' '));
 }
 
 // ── CSV Export ────────────────────────────────────────────────────────────────

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -676,6 +676,10 @@ document.getElementById('classifiersOnlyChk').addEventListener('change', e => {
   renderAll();
 });
 
+document.getElementById('exportCsvBtn').addEventListener('click', () => {
+  exportChartCSV();
+});
+
 // ── Fetch button ──────────────────────────────────────────────────────────────
 fetchBtn.addEventListener('click', async () => {
   const memberNumber = memberInput.value.trim().toUpperCase();
@@ -1861,6 +1865,83 @@ function updateStatusCounts(verb) {
   const unconfirmedNote  = unconfirmed.length > 0 ? ` · ${unconfirmed.length} unconfirmed type` : '';
   const skippedNote      = nonUspsa.length > 0    ? ` · ${nonUspsa.length} non-USPSA excluded` : '';
   setStatus(`${prefix} ${uspsa} USPSA match(es) — ${scored} with scores${checkedNote}.${unconfirmedNote}${skippedNote}`, 'success');
+}
+
+// ── CSV Export ────────────────────────────────────────────────────────────────
+// Exports chart-visible match data as a flat CSV (one row per stage).
+// Respects the active division / year / custom date-range filter.
+// Includes USPSA clf_pct when available (official % vs national reference HF).
+function exportChartCSV() {
+  const uspsaBase = allResults.filter(r => isChartable(r) && !deselectedMatches.has(r.match_id));
+  const chartable = currentView === 'ranked'
+    ? uspsaBase.filter(r => r.found_by === 'member_number' && r.overall_pct != null)
+    : uspsaBase.filter(r => r.overall_pct != null || r.hf != null);
+  const sorted = [...chartable].sort((a, b) => {
+    const da = parseDate(a.date), db = parseDate(b.date);
+    return (da && db) ? da - db : 0;
+  });
+  const viewSorted = sorted.filter(r =>
+    (!selectedDiv       || (r.division || 'Unknown') === selectedDiv) &&
+    (!selectedYear      || r.date?.startsWith(selectedYear)) &&
+    (!selectedDateRange || (r.date >= selectedDateRange.start && r.date <= selectedDateRange.end))
+  );
+
+  // Flat format: one row per stage (match-level fields repeated).
+  // In classifiersOnly mode, only classifier stages are included.
+  const headers = [
+    'Date', 'Match', 'Division', 'Class', 'Overall %', 'Div %', 'Place', 'Div Place',
+    'Stage', 'Stage HF', 'Stage Match %', 'Stage Time', 'A', 'C', 'D', 'M', 'NS', 'P',
+    'CM #', 'CM Name', 'USPSA %',
+  ];
+  const rows = [headers];
+
+  for (const r of viewSorted) {
+    const matchCols = [
+      r.date        || '',
+      r.match_name  || '',
+      r.division    || '',
+      r.class_      || '',
+      r.overall_pct != null ? r.overall_pct.toFixed(2) : '',
+      r.div_pct     != null ? r.div_pct.toFixed(2)     : '',
+      r.place       != null ? r.place                   : '',
+      r.div_place   != null ? r.div_place               : '',
+    ];
+
+    if (!r.stages?.length) {
+      if (!classifiersOnly) rows.push([...matchCols, '', '', '', '', '', '', '', '', '', '', '', '']);
+      continue;
+    }
+
+    for (const s of r.stages) {
+      const clf = isClassifierStage(s);
+      if (classifiersOnly && !clf) continue;
+      rows.push([
+        ...matchCols,
+        s.name  || '',
+        s.hf    != null ? s.hf.toFixed(4)   : '',
+        s.pct   != null ? s.pct.toFixed(2)  : '',
+        s.time  != null ? s.time.toFixed(2) : '',
+        s.a  ?? '', s.c  ?? '', s.d  ?? '',
+        s.m  ?? '', s.ns ?? '', s.p  ?? '',
+        clf?.number || '',
+        clf?.name   || '',
+        s.clf_pct != null ? s.clf_pct.toFixed(2) : '',
+      ]);
+    }
+  }
+
+  const csv      = rows.map(r => r.map(v => `"${String(v).replace(/"/g, '""')}"`).join(',')).join('\n');
+  const dateTag  = selectedDateRange
+    ? `${selectedDateRange.start} to ${selectedDateRange.end}`
+    : selectedYear || 'all time';
+  const filename = (classifiersOnly ? 'pscharts_classifiers' : 'pscharts_scores') + ` ${dateTag}.csv`;
+  const blob     = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url      = URL.createObjectURL(blob);
+  const a        = document.createElement('a');
+  a.href = url; a.download = filename;
+  document.body.appendChild(a); a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
 }
 
 function parseDate(str) {

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -444,6 +444,13 @@ const USPSA_CLASSIFIERS = new Map([
   ['25-09', 'Descent Into Madness'],
 ]);
 
+// Strips leading "Stage N" / "Stage N:" / "Stage N -" prefix from cached stage names.
+// PractiScore sometimes includes the prefix in the option text; background.js now strips
+// it on fresh fetches but cached data may still carry it.
+function normalizeStgName(name) {
+  return (name || '').replace(/^stage\s*\d+\s*[:\-–]?\s*/i, '').trim() || name || '';
+}
+
 // Returns { number, name } if the stage is a known classifier, or null if not.
 // Checks stored match_def fields first (authoritative), then falls back to name pattern matching.
 function isClassifierStage(stage) {
@@ -1524,7 +1531,7 @@ function renderMatchList() {
           badge.textContent = `CM ${clf.number}`;
           nameTd.appendChild(badge);
         }
-        nameTd.appendChild(document.createTextNode(s.name));
+        nameTd.appendChild(document.createTextNode(normalizeStgName(s.name)));
         tr.appendChild(nameTd);
 
         // Numeric cells
@@ -1538,9 +1545,13 @@ function renderMatchList() {
           td.textContent = val;
           tr.appendChild(td);
         });
-        // % cell — fmtPct returns safe HTML with color spans
+        // % cell — show official USPSA clf_pct as primary when available, match % as secondary
         const pctTd = tr.children[3];
-        pctTd.innerHTML = fmtPct(s.pct);
+        if (clf && s.clf_pct != null) {
+          pctTd.innerHTML = `${fmtPct(s.clf_pct)}<br><small style="opacity:0.6" title="Match %">match: ${s.pct != null ? s.pct.toFixed(1) + '%' : '—'}</small>`;
+        } else {
+          pctTd.innerHTML = fmtPct(s.pct);
+        }
 
         // Adjusted % cell — field-strength-normalized percentage
         if (hasXdiv) {
@@ -1837,16 +1848,54 @@ function CHART_BG()   { return cssVar('--chart-bg'); }
 
 // USPSA classification bands (% thresholds)
 const CLASS_BANDS = [
-  { label: 'GM', min: 95,  max: 110, fill: 'rgba(255,215,0,0.07)',    text: 'rgba(255,215,0,0.55)' },
-  { label: 'M',  min: 85,  max: 95,  fill: 'rgba(192,192,192,0.07)', text: 'rgba(192,192,192,0.55)' },
-  { label: 'A',  min: 75,  max: 85,  fill: 'rgba(74,158,255,0.07)',  text: 'rgba(74,158,255,0.55)' },
-  { label: 'B',  min: 60,  max: 75,  fill: 'rgba(76,175,80,0.07)',   text: 'rgba(76,175,80,0.55)' },
-  { label: 'C',  min: 40,  max: 60,  fill: 'rgba(255,152,0,0.07)',   text: 'rgba(255,152,0,0.55)' },
-  { label: 'D',  min: 0,   max: 40,  fill: 'rgba(120,120,120,0.07)', text: 'rgba(120,120,120,0.55)' },
+  { label: 'GM', min: 95,  max: 110, weight: 6, fill: 'rgba(255,215,0,0.07)',    text: 'rgba(255,215,0,0.55)' },
+  { label: 'M',  min: 85,  max: 95,  weight: 5, fill: 'rgba(192,192,192,0.07)', text: 'rgba(192,192,192,0.55)' },
+  { label: 'A',  min: 75,  max: 85,  weight: 4, fill: 'rgba(74,158,255,0.07)',  text: 'rgba(74,158,255,0.55)' },
+  { label: 'B',  min: 60,  max: 75,  weight: 3, fill: 'rgba(76,175,80,0.07)',   text: 'rgba(76,175,80,0.55)' },
+  { label: 'C',  min: 40,  max: 60,  weight: 2, fill: 'rgba(255,152,0,0.07)',   text: 'rgba(255,152,0,0.55)' },
+  { label: 'D',  min: 0,   max: 40,  weight: 1, fill: 'rgba(120,120,120,0.07)', text: 'rgba(120,120,120,0.55)' },
 ];
 
 function bandForPct(pct) {
   return CLASS_BANDS.find(b => pct >= b.min && pct < b.max) || null;
+}
+
+// ── Class-band Y-axis warp ────────────────────────────────────────────────────
+// Builds a piecewise-linear warp map so each class band occupies proportional
+// visual height on the chart (weighted by CLASS_BANDS weight), rather than the
+// raw linear % scale which compresses A/M/GM shooters into the top sliver.
+// Returns an array of { real, visual } breakpoints, or null if only one band
+// is visible (in which case the chart falls back to a linear scale).
+function buildWarpMap(lo, hi) {
+  const segs = [];
+  for (let i = CLASS_BANDS.length - 1; i >= 0; i--) {
+    const b = CLASS_BANDS[i];
+    const segLo = Math.max(b.min, lo);
+    const segHi = Math.min(b.max, hi);
+    if (segLo >= segHi) continue;
+    segs.push({ lo: segLo, hi: segHi, weight: b.weight || (b.max - b.min) });
+  }
+  if (segs.length < 2) return null;
+  const totalWeight = segs.reduce((s, g) => s + g.weight, 0);
+  const pts = [{ real: segs[0].lo, visual: 0 }];
+  let vPos = 0;
+  for (const seg of segs) {
+    vPos += seg.weight / totalWeight;
+    pts.push({ real: seg.hi, visual: vPos });
+  }
+  return pts;
+}
+
+// Map a real % value to a [0,1] visual position using a warp map.
+function warpPct(v, pts) {
+  for (let i = 1; i < pts.length; i++) {
+    const p = pts[i - 1], c = pts[i];
+    if (v <= c.real + 0.001) {
+      const t = (v - p.real) / (c.real - p.real);
+      return p.visual + t * (c.visual - p.visual);
+    }
+  }
+  return 1;
 }
 
 function fmtPct(pct) {
@@ -1888,12 +1937,16 @@ function drawMultiSeriesChart(canvas, seriesArr, allDates, opts = {}) {
   const rawMax = yMax != null ? yMax : Math.max(...allY);
   const yRange = rawMax - rawMin || 1;
 
+  // Build warp map for class-band-weighted Y-axis when showClassBands is active.
+  // Falls back to null (linear scale) when fewer than two bands are visible.
+  const warpMap = showClassBands ? buildWarpMap(rawMin, rawMax) : null;
+
   const dateToCanvasX = date => {
     const idx = allDates.indexOf(date);
     return area.x0 + (idx / Math.max(allDates.length - 1, 1)) * area.w;
   };
   const toY = v => {
-    const norm = (v - rawMin) / yRange;
+    const norm = warpMap ? warpPct(v, warpMap) : (v - rawMin) / yRange;
     return invertY ? area.y0 + norm * area.h : area.y0 + (1 - norm) * area.h;
   };
 


### PR DESCRIPTION
## Summary

Pulls in all meaningful upstream (queueingqt/PScharts) additions since the v0.8 fork point, adapted to preserve our fork's unique features (theme toggle, analytics suite, HHF normalization, onboarding).

## Changes

### t005 — Per-match/stage PNG export
- Floppy-disk icon button on every match row opens a dropdown: "Full Match" or any individual stage
- `exportMatchCard()` and `exportStageCard()` render to an off-screen Canvas at 2× DPR and download as PNG
- Canvas helpers: `_rrPath`, `_wrapText`, `_trunc`, `_cardColor`, `_cardLabel`, `_dividerLine`, `_downloadPng`
- Export menu (`#exportMenu`) positioned relative to the trigger button with viewport-edge clamping
- CSS: `.export-btn`, `#exportMenu`, `.export-menu-title`, `.export-menu-item`

### t006 — CSV export
- `exportChartCSV()`: flat per-stage CSV with match-level fields repeated; includes CM number/name and official USPSA clf_pct
- "⤓ CSV" button in the Score Over Time chart section header
- Respects active division/year/custom date-range filter; filename includes the active filter tag

### t007 — Custom date range filter
- `selectedDateRange = { start, end }` state variable
- "Custom Range…" option at the bottom of the year dropdown with inline date picker (from/to inputs)
- Filter applied in `renderAll()` and `exportChartCSV()`
- CSS: `.date-range-form` with dark-themed date inputs

### t008 — Class-band Y-axis warp
- `buildWarpMap(lo, hi)` + `warpPct(v, pts)` give higher USPSA classes proportionally more chart height
- Weights: GM=6, M=5, A=4, B=3, C=2, D=1 (inverted — harder classes get more visual room)
- Hooked into `drawMultiSeriesChart()` via warpMap computed once per render

### t009 — Official clf_pct in stage table
- When a stage is a known classifier and `clf_pct` is populated, the % column shows the official USPSA % as primary with the match % as small secondary
- Single rendering change in `renderMatchList()`

### t010 — normalizeStgName() + background.js regex fix
- `normalizeStgName(name)` strips "Stage N:" prefix from cached stage names
- Applied to stage table name cell and PNG export card
- background.js regex: separator now optional (`[:\-–]?\s*/i`)

### t011 — Chart height 220→380
- Main score chart canvas taller for better readability

## Verification
Load extension from `extension/`, fetch matches, confirm:
1. Floppy-disk export button on each match row → PNG downloads correctly
2. "⤓ CSV" button downloads correctly structured CSV
3. Year dropdown "Custom Range…" applies date filter
4. Score chart Y-axis gives more space to A/M/GM bands
5. Stage table shows clf_pct for classifiers with match % secondary
6. Cached "Stage N:" prefixes stripped in stage table
7. Main score chart is visually taller