### PR TITLE
fix: restore themeToggle button, prevent allResults TDZ — Fetch Scores broken on fresh install

### DIFF
--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -39,6 +39,19 @@
       letter-spacing: 0.3px;
       flex-shrink: 0;
     }
+    #themeToggle {
+      background: none;
+      border: 1px solid #2a2d3a;
+      border-radius: 6px;
+      color: #666;
+      font-size: 16px;
+      padding: 4px 8px;
+      cursor: pointer;
+      line-height: 1;
+      margin-left: auto;
+      flex-shrink: 0;
+    }
+    #themeToggle:hover { color: #ccc; border-color: #4a9eff; }
 
     /* ── Controls ── */
     .controls {
@@ -851,6 +864,7 @@
 <header>
   <h1>USPSA Score Progression</h1>
   <span id="headerVersion"></span>
+  <button id="themeToggle" title="Toggle light/dark mode">&#9788;</button>
 </header>
 
 <div class="controls">

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -1,5 +1,8 @@
 // dashboard.js
 
+// ── Global state (declared first to avoid TDZ in event handlers below) ────────
+let allResults = [];
+
 // ── Size canvases to fill their containers ────────────────────────────────────
 function sizeCanvases() {
   document.querySelectorAll('canvas').forEach(c => {
@@ -197,7 +200,7 @@ async function restoreFromSync() {
 }
 
 // ── Module state ──────────────────────────────────────────────────────────────
-let allResults       = [];
+// allResults declared at top of file to prevent TDZ in early event handlers
 let currentView      = 'ranked'; // 'ranked' | 'all'
 let deselectedMatches = new Set(); // match IDs manually excluded from charts
 let selectedDiv       = null;     // division filter for stats + charts (null = All)


### PR DESCRIPTION
## Root cause

The t001 commit (4142794, PR #11) rewrote the dashboard header to add the version display and in the process dropped the `#themeToggle` button and its CSS that had been added in the v1.3 work (b11159a).

`dashboard.js` line 162 unconditionally calls `document.getElementById('themeToggle').addEventListener(...)`. With the element absent, this throws:

```
Uncaught TypeError: Cannot read properties of null (reading 'addEventListener')
```

This crash occurs before line 684 (`fetchBtn.addEventListener('click', ...)`), so the Fetch Scores button has no listener attached — clicks do nothing.

## Secondary bug

`let allResults = []` was declared at line 200. The `window.addEventListener('resize', () => { renderAll(); })` was registered at line 10. If a resize event fires after the script crashes at line 162 (before line 200 is reached), `allResults` is in the temporal dead zone and throws:

```
Uncaught ReferenceError: Cannot access 'allResults' before initialization
```

## Fixes

**`dashboard.html`** — restore `#themeToggle` button in the header and its CSS block.

**`dashboard.js`** — move `let allResults = []` to line 4 (top of file, before the resize listener registration) and remove the duplicate declaration at the old line 200.

## Verification

1. Load extension fresh (no saved credentials) — Fetch Scores button responds to click
2. Theme toggle (☀) visible in header, toggles light/dark
3. No console errors on page open
4. Resize window with data loaded — charts redraw without errors