### PR TITLE
fix: adjusted % uses own-division GM/M directly, cross-division only as fallback

### DIFF
--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -253,10 +253,24 @@ function psDivToHfi(psDiv) {
 }
 
 // Compute field-strength-adjusted stage percentage.
-// Uses cross-division benchmarks to find the best available reference HF,
-// normalizes it to the shooter's division, then computes shooter_hf / normalized_ref_hf.
 //
-// Returns { adjPct, adjClass, refDiv, refClass, refHF, method } or null if not computable.
+// Two-pass strategy:
+//   Pass 1 — own division first. If the shooter's division has a GM or M median
+//             HF on this stage, use it directly (factor = 1.0, no normalization
+//             error). This is the most accurate reference: an actual classified
+//             competitor in the shooter's division who was standing at the same
+//             match. Cross-division normalization should never override a real
+//             own-division benchmark — the national HHF factors are averages and
+//             will systematically inflate or deflate the reference when the actual
+//             GM present is above or below the national mean.
+//
+//   Pass 2 — cross-division fallback. Only used when the shooter's division has
+//             no GM or M class benchmark (i.e. no elite competitor was present).
+//             Finds the highest reference across other divisions and normalizes it
+//             to the shooter's division using DIVISION_FACTORS (hitfactor.info
+//             March 2025 national HHFs). This corrects for weak-field matches.
+//
+// Returns { adjPct, adjClass, refDiv, refClass, refHF, normHF, method } or null.
 function computeAdjustedPct(stage, shooterDiv) {
   if (!stage.hf || stage.hf <= 0) return null;
 
@@ -266,9 +280,30 @@ function computeAdjustedPct(stage, shooterDiv) {
   const benchmarks = stage.xdiv_benchmarks;
   if (!benchmarks) return null;
 
-  // Strategy: find the strongest reference point across all divisions.
-  // Priority: GM median > M median > A median > top HF, preferring higher classes.
-  // Then normalize that reference HF to the shooter's division using DIVISION_FACTORS.
+  // ── Pass 1: own-division GM or M ─────────────────────────────────────────
+  // Find the benchmark entry whose division key matches the shooter's division.
+  for (const [psDiv, bench] of Object.entries(benchmarks)) {
+    if (psDivToHfi(psDiv) !== myDivKey) continue;
+    // Prefer GM median; fall back to M median.
+    const ref    = bench.gmMedian || bench.mMedian;
+    const cls    = bench.gmMedian ? 'GM' : 'M';
+    const method = bench.gmMedian ? 'gm_median' : 'm_median';
+    if (!ref || ref <= 0) break; // own division found but no GM/M — go to pass 2
+    const adjPct = (stage.hf / ref) * 100;
+    return {
+      adjPct:   Math.min(adjPct, 120),
+      adjClass: classLetterForPct(adjPct),
+      refDiv:   psDiv,
+      refClass: cls,
+      refHF:    ref,
+      normHF:   ref,
+      method,
+    };
+  }
+
+  // ── Pass 2: cross-division fallback ───────────────────────────────────────
+  // No GM or M in shooter's division. Estimate from other divisions using
+  // national HHF ratio factors. Takes the highest normalized reference found.
   let bestNormalizedRef = 0;
   let bestRefDiv = null;
   let bestRefClass = null;
@@ -277,14 +312,13 @@ function computeAdjustedPct(stage, shooterDiv) {
 
   for (const [psDiv, bench] of Object.entries(benchmarks)) {
     const srcDivKey = psDivToHfi(psDiv);
-    if (!srcDivKey) continue;
+    if (!srcDivKey || srcDivKey === myDivKey) continue; // own div already checked
     const factor = DIVISION_FACTORS[myDivKey]?.[srcDivKey];
     if (!factor) continue;
 
-    // Try each reference level: GM > M > top (which includes A-class winners)
     const candidates = [
       { hf: bench.gmMedian, cls: 'GM', method: 'gm_median' },
-      { hf: bench.mMedian,  cls: 'M',  method: 'm_median' },
+      { hf: bench.mMedian,  cls: 'M',  method: 'm_median'  },
       { hf: bench.topHF,    cls: bench.topClass || '?', method: 'top_hf' },
     ];
 
@@ -293,10 +327,10 @@ function computeAdjustedPct(stage, shooterDiv) {
       const normalized = cand.hf * factor;
       if (normalized > bestNormalizedRef) {
         bestNormalizedRef = normalized;
-        bestRefDiv = psDiv;
-        bestRefClass = cand.cls;
-        bestRefHF = cand.hf;
-        bestMethod = cand.method;
+        bestRefDiv        = psDiv;
+        bestRefClass      = cand.cls;
+        bestRefHF         = cand.hf;
+        bestMethod        = cand.method;
       }
     }
   }
@@ -304,11 +338,9 @@ function computeAdjustedPct(stage, shooterDiv) {
   if (bestNormalizedRef <= 0) return null;
 
   const adjPct = (stage.hf / bestNormalizedRef) * 100;
-  const adjClass = classLetterForPct(adjPct);
-
   return {
-    adjPct:   Math.min(adjPct, 120), // cap at 120% to handle outliers
-    adjClass,
+    adjPct:   Math.min(adjPct, 120),
+    adjClass: classLetterForPct(adjPct),
     refDiv:   bestRefDiv,
     refClass: bestRefClass,
     refHF:    bestRefHF,


### PR DESCRIPTION
## Bug

The original single-pass algorithm iterated over all divisions and took the highest normalized reference regardless of source. For a CO shooter, it compared:

- CO GM median × 1.0 (own division, no normalization)
- Open GM median × 0.9021 (cross-division factor)
- PCC GM median × 0.9032
- etc.

When Open or PCC GMs at the match shot high enough that their normalized value exceeded the actual CO GM's HF, the algorithm silently used the cross-division reference instead — even when an elite CO GM was physically present at that match.

The `DIVISION_FACTORS` table is built from national average HHFs. A CO GM who is top-5 nationally shoots well above the national CO average. Normalizing an average Open GM to CO scale via a national factor can project a reference higher than what that elite CO GM actually shot, making adjusted % appear lower than the real performance.

Result: user shooting against a top-5 national CO GM was seeing adjusted % ~4% lower than their actual division % against that GM.

## Fix

Two-pass strategy:

**Pass 1 — own division first.** Check whether the shooter's division has a GM or M median HF on this stage. If yes, use it directly (factor = 1.0). This is always the most accurate reference — an actual classified competitor who was at the same match in the same division. Cross-division normalization introduces national-average error that grows when the actual competitor is above or below the national mean.

**Pass 2 — cross-division fallback.** Only runs when own division has no GM or M benchmark (no elite competitor present). Same logic as before: find the highest normalized reference across other divisions. This corrects the weak-field problem without interfering when real own-division competition exists.

## Effect on the numbers

- Matches WITH a CO GM: adjusted % now reflects direct comparison against that GM — should align closely with division %
- Matches WITHOUT a CO GM (weak field): adjusted % still applies cross-division correction, discounting the inflated division %
- Net: adjusted avg should increase toward the user's real performance level; the gap between adjusted and division % becomes meaningful rather than systematically wrong