### PR TITLE
chore: rename PScharts → Hit Factor Charts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           # Zip contents directly — no version in the folder name so users
           # can unzip over the same 'extension/' folder and just refresh.
           cd extension
-          zip -r ../PScharts.zip .
+          zip -r ../HitFactorCharts.zip .
 
       - name: Create GitHub Release
         if: steps.check_tag.outputs.exists == 'false'
@@ -53,6 +53,6 @@ jobs:
           fi
 
           gh release create "${{ steps.version.outputs.tag }}" \
-            "PScharts.zip" \
-            --title "PScharts v${{ steps.version.outputs.version }}" \
+            "HitFactorCharts.zip" \
+            --title "Hit Factor Charts v${{ steps.version.outputs.version }}" \
             --notes "${NOTES:-No notable changes.}"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# PScharts
+# Hit Factor Charts
 
 A Chrome extension that pulls your USPSA match results from PractiScore and displays them as interactive charts — score over time, placement, classifier tracking, and per-stage breakdowns — all inside your browser, with no server or API key required.
 
-![Alt text](/screenshots/PScharts.png?raw=true "PScharts Screenshot")
+![Hit Factor Charts](/screenshots/PScharts.png?raw=true "Hit Factor Charts")
 ---
 
 ## Features
@@ -57,14 +57,14 @@ Chrome does not allow side-loading extensions from a zip file directly, so you l
 
 **Option A — Download a release (recommended)**
 
-1. Go to the [Releases page](https://github.com/johnwaldo/PScharts/releases)
-2. Download the latest `PScharts.zip`
+1. Go to the [Releases page](https://github.com/johnwaldo/hitfactorcharts/releases)
+2. Download the latest `HitFactorCharts.zip`
 3. Unzip the archive anywhere on your computer
 
 **Option B — Clone the repo**
 
 ```bash
-git clone https://github.com/johnwaldo/PScharts.git
+git clone https://github.com/johnwaldo/hitfactorcharts.git
 ```
 
 ### 2 — Open Chrome Extensions
@@ -83,7 +83,7 @@ In the top-right corner of the Extensions page, toggle on **Developer mode**.
 2. Navigate to the unzipped folder — if you used Option A (release ZIP), select the top-level unzipped folder; if you used Option B (cloned repo), select the `extension/` subfolder (the one containing `manifest.json`)
 3. Click **Select Folder**
 
-The PScharts icon will appear in your Chrome toolbar. Pin it for easy access via the puzzle-piece menu.
+The Hit Factor Charts icon will appear in your Chrome toolbar. Pin it for easy access via the puzzle-piece menu.
 
 ---
 
@@ -91,7 +91,7 @@ The PScharts icon will appear in your Chrome toolbar. Pin it for easy access via
 
 1. **Log in to PractiScore** — visit [practiscore.com](https://practiscore.com) and sign in normally. The extension uses your existing browser session.
 
-2. **Open PScharts** — click the PScharts icon in the toolbar. The dashboard opens in a new tab.
+2. **Open Hit Factor Charts** — click the Hit Factor Charts icon in the toolbar. The dashboard opens in a new tab.
 
 3. **Enter your member number and/or name** — type your USPSA member number (e.g. `A12345`) and/or your name as it appears on result sheets (e.g. `Smith, Jane`). At least one is required; providing both improves match accuracy.
 
@@ -166,7 +166,7 @@ A helper script is included to package the extension for distribution:
 ./build.sh
 ```
 
-This creates `dist/pscharts.zip` containing only the extension files, ready to share or submit to the Chrome Web Store.
+This creates `dist/HitFactorCharts.zip` containing only the extension files, ready to share or submit to the Chrome Web Store.
 
 ---
 
@@ -184,5 +184,5 @@ extension/          ← Load this folder in Chrome
     icon16.png
     icon48.png
     icon128.png
-build.sh            ← Packages extension/ into dist/pscharts.zip
+build.sh            ← Packages extension/ into dist/HitFactorCharts.zip
 ```

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Packages the PScharts Chrome extension into a distributable ZIP.
-# Output: dist/pscharts-vX.Y.Z.zip
+# Packages the Hit Factor Charts Chrome extension into a distributable ZIP.
+# Output: dist/hitfactorcharts-vX.Y.Z.zip
 #
 # Usage:
 #   ./build.sh              — uses version from manifest.json  (e.g. v1.2)
@@ -25,7 +25,7 @@ else
 	LABEL="v${MANIFEST_VERSION}"
 fi
 
-ZIP="$OUT/pscharts-${LABEL}.zip"
+ZIP="$OUT/hitfactorcharts-${LABEL}.zip"
 
 if [ ! -f "$SRC/manifest.json" ]; then
 	echo "Error: extension/manifest.json not found. Run this script from the repo root." >&2

--- a/extension/background.js
+++ b/extension/background.js
@@ -24,7 +24,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     return true;
   }
   if (msg.action === 'fetchClassification') {
-    fetchUSPSAClassification(msg.memberNumber, m => console.log('[PScharts]', m))
+    fetchUSPSAClassification(msg.memberNumber, m => console.log('[HFC]', m))
       .then(async data => {
         if (data && !data._not_logged_in) {
           const stored = { ...data, member_number: msg.memberNumber, updated_at: Date.now() };
@@ -451,8 +451,8 @@ async function fetchMatchDef(matchId, push) {
     if (!Array.isArray(raw) || !raw.length) { push('     match_def: no stages array'); return null; }
 
     // Log the first stage's full key set so we can identify the real field names
-    console.log('[PScharts] match_def stage[0] keys:', Object.keys(raw[0]));
-    console.log('[PScharts] match_def stage[0]:', JSON.stringify(raw[0]));
+    console.log('[HFC] match_def stage[0] keys:', Object.keys(raw[0]));
+    console.log('[HFC] match_def stage[0]:', JSON.stringify(raw[0]));
 
     const map = new Map();
     raw.forEach((s, idx) => {
@@ -761,9 +761,9 @@ async function fetchUSPSAClassification(memberNumber, push) {
     }
 
     // Log compact debug info — tables and division select only
-    console.log('[PScharts] USPSA page debug:', JSON.stringify(state._debug, null, 2));
+    console.log('[HFC] USPSA page debug:', JSON.stringify(state._debug, null, 2));
     // Log the actual parsed classifier records so we can verify dates/pcts/codes
-    console.log('[PScharts] USPSA classifiers parsed:', JSON.stringify(state.classifiers, null, 2));
+    console.log('[HFC] USPSA classifiers parsed:', JSON.stringify(state.classifiers, null, 2));
 
     const clf = state?.classifiers?.length ?? 0;
     push(`  Found ${clf} classifier record(s) for ${memberNumber}`);
@@ -777,7 +777,7 @@ async function fetchUSPSAClassification(memberNumber, push) {
       if (!triggered) { push(`  Calculator not found — skipping division loop`); break; }
       await sleep(1200);
       const result = await runInTab(tabId, readCalculatorResult);
-      console.log(`[PScharts] Calculator result for ${opt.text}:`, JSON.stringify(result));
+      console.log(`[HFC] Calculator result for ${opt.text}:`, JSON.stringify(result));
       if (result?.text) push(`  ${opt.text}: ${result.text.slice(0, 80)}`);
     }
 
@@ -794,7 +794,7 @@ async function fetchUSPSAClassification(memberNumber, push) {
 // ── Fetch all match scores ────────────────────────────────────────────────────
 async function fetchScores(memberNumber, name) {
   const log = [];
-  const push = m => { log.push(m); console.log('[PScharts]', m); };
+  const push = m => { log.push(m); console.log('[HFC]', m); };
   let tabId = null;
 
   try {
@@ -813,7 +813,7 @@ async function fetchScores(memberNumber, name) {
 
     const rawMatchList = await runInTab(tabId, extractMatchList);
     push(`Found ${rawMatchList.length} match(es).`);
-    console.log('[PScharts] matchList:', JSON.stringify(rawMatchList, null, 2));
+    console.log('[HFC] matchList:', JSON.stringify(rawMatchList, null, 2));
 
     if (rawMatchList.length === 0) {
       push('No matches found — are you logged into PractiScore?');
@@ -905,7 +905,7 @@ async function fetchScores(memberNumber, name) {
 // ── Refresh a single match ────────────────────────────────────────────────────
 async function refreshMatch(match, memberNumber, name) {
   const log = [];
-  const push = m => { log.push(m); console.log('[PScharts]', m); };
+  const push = m => { log.push(m); console.log('[HFC]', m); };
   let tabId = null;
 
   try {

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -2,7 +2,7 @@
 <html lang="en" data-theme="light">
 <head>
   <meta charset="UTF-8" />
-  <title>PScharts</title>
+  <title>Hit Factor Charts</title>
   <style>
     @font-face {
       font-family: 'Inter';
@@ -1074,8 +1074,8 @@
 <div class="page">
 
 <header>
-  <h1>USPSA Score Progression</h1>
-  <a id="headerVersion" href="https://github.com/johnwaldo/PScharts" target="_blank" rel="noopener noreferrer"></a>
+  <h1>Hit Factor Charts</h1>
+  <a id="headerVersion" href="https://github.com/johnwaldo/hitfactorcharts" target="_blank" rel="noopener noreferrer"></a>
   <button id="themeToggle" title="Toggle light/dark mode">&#9788;</button>
 </header>
 
@@ -1150,7 +1150,7 @@
     </div>
     <div class="update-step">
       <div class="update-step-num">4</div>
-      <div class="update-step-text">Close this tab and reopen PScharts — you're on the latest version</div>
+      <div class="update-step-text">Close this tab and reopen Hit Factor Charts — you're on the latest version</div>
     </div>
   </div>
   <div class="update-notes-wrap" id="updateNotesWrap" style="display:none">

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -33,7 +33,7 @@ const matchRowsEl  = document.getElementById('matchRows');
 const tooltipEl    = document.getElementById('tooltip');
 
 // ── Update check ─────────────────────────────────────────────────────────────
-const RELEASES_API      = 'https://api.github.com/repos/johnwaldo/PScharts/releases/latest';
+const RELEASES_API      = 'https://api.github.com/repos/johnwaldo/hitfactorcharts/releases/latest';
 const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000; // re-check at most every 4 hours
 
 function parseVersion(v) {
@@ -83,11 +83,11 @@ async function checkForUpdate() {
     const rawPageUrl   = data.html_url || '';
     const releasePageUrl = /^https:\/\/github\.com\//.test(rawPageUrl)
       ? rawPageUrl
-      : 'https://github.com/johnwaldo/PScharts/releases/latest';
+      : 'https://github.com/johnwaldo/hitfactorcharts/releases/latest';
 
     // Find the ZIP asset — prefer pscharts-*.zip, fall back to any .zip
     const assets  = Array.isArray(data.assets) ? data.assets : [];
-    const zipAsset = assets.find(a => /pscharts.*\.zip$/i.test(a.name))
+    const zipAsset = assets.find(a => /hitfactorcharts.*\.zip$/i.test(a.name) || /\.zip$/i.test(a.name))
                   || assets.find(a => /\.zip$/i.test(a.name));
     // Sanitize asset download URL — must be github.com or objects.githubusercontent.com
     const rawZip  = zipAsset?.browser_download_url || '';
@@ -2267,7 +2267,7 @@ function exportMatchCard(match) {
 
   _dividerLine(ctx, ox + PAD, y, W - PAD * 2); y += 8;
   ctx.font = `10px ${F}`; ctx.fillStyle = '#444';
-  ctx.fillText('PScharts', ox + W - PAD - ctx.measureText('PScharts').width, y + 10);
+  ctx.fillText('Hit Factor Charts', ox + W - PAD - ctx.measureText('Hit Factor Charts').width, y + 10);
 
   _downloadPng(canvas, [match.match_name || 'match', match.date].filter(Boolean).join(' '));
 }
@@ -2373,7 +2373,7 @@ function exportStageCard(match, stage) {
   const fl = _trunc(ctx, [match.match_name, match.date].filter(Boolean).join(' \u00b7 '), W - PAD * 2 - 68);
   ctx.fillText(fl, ox + PAD, y + 10);
   ctx.fillStyle = '#444';
-  ctx.fillText('PScharts', ox + W - PAD - ctx.measureText('PScharts').width, y + 10);
+  ctx.fillText('Hit Factor Charts', ox + W - PAD - ctx.measureText('Hit Factor Charts').width, y + 10);
 
   const stageBase = clf ? `CM ${clf.number} ${normalizeStgName(stage.name)}` : normalizeStgName(stage.name) || 'stage';
   _downloadPng(canvas, [stageBase, match.date].filter(Boolean).join(' '));
@@ -2446,7 +2446,7 @@ function exportChartCSV() {
   const dateTag  = selectedDateRange
     ? `${selectedDateRange.start} to ${selectedDateRange.end}`
     : selectedYear || 'all time';
-  const filename = (classifiersOnly ? 'pscharts_classifiers' : 'pscharts_scores') + ` ${dateTag}.csv`;
+  const filename = (classifiersOnly ? 'hfc_classifiers' : 'hfc_scores') + ` ${dateTag}.csv`;
   const blob     = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
   const url      = URL.createObjectURL(blob);
   const a        = document.createElement('a');

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
-  "name": "PScharts",
+  "name": "Hit Factor Charts",
   "version": "1.6",
-  "description": "PScharts 1.6 — Chart your USPSA match scores from PractiScore",
+  "description": "Track your USPSA match performance: division %, adjusted field-strength scores, classifier trends, and placement over time.",
   "permissions": ["tabs", "scripting", "storage"],
   "host_permissions": ["https://practiscore.com/*", "https://s3.amazonaws.com/*", "https://api.github.com/*", "https://uspsa.org/*", "https://objects.githubusercontent.com/*"],
   "content_security_policy": {
@@ -14,7 +14,7 @@
     "128": "icons/icon128.png"
   },
   "action": {
-    "default_title": "PScharts — open dashboard",
+    "default_title": "Hit Factor Charts — open dashboard",
     "default_icon": {
       "16":  "icons/icon16.png",
       "48":  "icons/icon48.png",


### PR DESCRIPTION
Renames the extension everywhere — manifest, dashboard, exports, README, build scripts, release workflow, and GitHub repo. No functionality changes.