### PR TITLE
fix: skip classifiers in adjusted percentages

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A Chrome extension that pulls your USPSA match results from PractiScore and disp
 - **Placement chart** — finish position at each match, normalized to field size
 - **Per-stage breakdown** — expand any match row to see hits, HF, and percentage for every stage; classifier stages show official USPSA % (vs national reference HF) as the primary number
 - **Division-aware** — automatically detects which division you shot in each match and shows division-specific results
-- **Field-strength adjusted %** — finds the strongest competitor across all divisions at each match (GM median HF preferred, then Master, then top HF), translates their score to your division's scale using hitfactor.info HHF ratios, and measures you against that benchmark — a more reliable indicator of improvement than raw division % when your division draw varies
+- **Field-strength adjusted %** — for non-classifier stages, finds the strongest competitor across all divisions at each match (GM median HF preferred, then Master, then top HF), translates their score to your division's scale using hitfactor.info HHF ratios, and measures you against that benchmark — a more reliable indicator of improvement than raw division % when your division draw varies
 - **Chart summaries** — automatic plain-English insight below each chart: score trend (last 3 vs baseline), adjusted % context, placement percentile, and classifier trend using the national HHF reference
 - **Classifier tracking** — overlay of your classifier scores against your running average; identifies each CM by number and links to the USPSA stage description PDF
 - **Consistency card** — match-to-match score variance and accuracy loss metrics
@@ -37,13 +37,13 @@ A Chrome extension that pulls your USPSA match results from PractiScore and disp
 
 **Division %** is your score relative to the top shooter in your division at that match. It tells you how you placed that day, but it only reflects who happened to show up in your division — if no GM competed in your division, even a mediocre performance can read as 90%+.
 
-**Adjusted %** is a field-strength correction calculated in two steps:
+**Adjusted %** is a field-strength correction for non-classifier stages, calculated in two steps:
 
 1. **Own division first** — if a GM or Master competed in your division at that match, their median hit factor is used as the reference directly. No cross-division math needed; you're measured against the actual elite competition that was present.
 
 2. **Cross-division fallback** — if no GM or Master competed in your division, the extension finds the strongest competitor across all other divisions (GM median preferred, then Master, then top HF), translates their hit factor to your division's equivalent using national HHF ratios from [hitfactor.info](https://hitfactor.info), and uses that as the reference. This corrects for weak-field matches where winning your division by default would otherwise inflate the score.
 
-A 75% adjusted score means you performed at solid A-class level against the strongest competition at that match — whether they were in your division or another. Adjusted % is the better indicator of actual improvement over time because it accounts for who actually showed up, not just who showed up in your specific division.
+A 75% adjusted score means you performed at solid A-class level against the strongest competition at that match — whether they were in your division or another. Adjusted % is the better indicator of actual improvement over time because it accounts for who actually showed up, not just who showed up in your specific division. Classifier stages are excluded from adjusted % because official classifier percentages are already normalized against USPSA national division data.
 
 ---
 

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -253,6 +253,9 @@ function psDivToHfi(psDiv) {
 }
 
 // Compute field-strength-adjusted stage percentage.
+// Classifier stages are intentionally skipped: official classifier percentages
+// are already normalized against USPSA national division data, so applying this
+// match-field adjustment would double-normalize them.
 //
 // Two-pass strategy:
 //   Pass 1 — own division first. If the shooter's division has a GM or M median
@@ -272,6 +275,7 @@ function psDivToHfi(psDiv) {
 //
 // Returns { adjPct, adjClass, refDiv, refClass, refHF, normHF, method } or null.
 function computeAdjustedPct(stage, shooterDiv) {
+  if (isClassifierStage(stage)) return null;
   if (!stage.hf || stage.hf <= 0) return null;
 
   const myDivKey = psDivToHfi(shooterDiv);
@@ -1027,8 +1031,9 @@ function renderAll() {
     if (adjAvgLbl) adjAvgLbl.textContent = adjBand ? `Adj Avg · ${adjBand.label} Class` : 'Adj Avg %';
     adjAvgBox.dataset.tip =
       `Field-strength adjusted average (${adjMatchPcts.length} match${adjMatchPcts.length > 1 ? 'es' : ''}).\n` +
-      `Uses the best HF from any division at each match,\n` +
+      `Uses non-classifier stages and the best HF from any division at each match,\n` +
       `normalized to your division using HHF ratios from hitfactor.info.\n` +
+      `Classifier stages are skipped because USPSA % is already nationally normalized.\n` +
       `This gives a more accurate read when no GM/Master is in your division.\n` +
       `Raw avg: ${avg.toFixed(1)}% → Adjusted: ${adjAvg.toFixed(1)}% (${adjBand?.label || '?'} class)`;
     adjAvgBox.style.display = '';
@@ -1787,6 +1792,9 @@ function renderMatchList() {
             adjTd.title = `Field-adjusted: your HF (${s.hf?.toFixed(4)}) vs ${methodLabel} in ${adj.refDiv} (${adj.refHF?.toFixed(4)} HF)\n`
               + `Normalized to ${match.division}: ${adj.normHF?.toFixed(4)} HF\n`
               + `${s.hf?.toFixed(4)} / ${adj.normHF?.toFixed(4)} = ${adj.adjPct.toFixed(1)}% (${adj.adjClass} class)`;
+          } else if (clf) {
+            adjTd.textContent = '—';
+            adjTd.title = 'Classifier stage — official classifier percentages are already normalized against national division data, so adjusted % is not applied.';
           } else {
             adjTd.textContent = '—';
             adjTd.title = 'No cross-division data available for this stage';


### PR DESCRIPTION
## Summary
- skips classifier stages inside `computeAdjustedPct()` so adjusted % only applies to non-classifier stages
- clarifies the adjusted average tooltip and stage Adj% tooltip for classifiers
- updates README wording to explain that classifier percentages are already nationally normalized

Resolves #20

## Verification
- `node --check extension/dashboard.js`
- `node --check extension/background.js`
- `bash -n build.sh`
- `bash -n run.sh`
- `./build.sh`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 1h 9m and 339,146 tokens on this with the user in an interactive session.
