### PR TITLE
GH#23: fix: use strongest adjusted score benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable user-facing changes are documented here. Update this file before publishing a release so GitHub release notes call out features clearly instead of relying only on commit messages.
 
+## Unreleased
+
+### Fixed
+
+- Adjusted % now uses the strongest division-normalized stage result instead of allowing a weak GM or Master stage median to inflate scores above 100%.
+- CSV exports now include each stage's adjusted percentage and selected benchmark details for auditing.
+
 ## v1.6.2 — 2026-05-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -37,13 +37,9 @@ A Chrome extension that pulls your USPSA match results from PractiScore and disp
 
 **Division %** is your score relative to the top shooter in your division at that match. It tells you how you placed that day, but it only reflects who happened to show up in your division — if no GM competed in your division, even a mediocre performance can read as 90%+.
 
-**Adjusted %** is a field-strength correction for non-classifier stages, calculated in two steps:
+**Adjusted %** is a field-strength correction for non-classifier stages. For each stage, the extension takes the top hit factor from every represented division, translates each result to your division's equivalent using national HHF ratios from [hitfactor.info](https://hitfactor.info), and uses the strongest normalized result as the reference. Your own division participates without conversion, so the adjusted score remains between 0% and 100% while correcting for divisions with stronger competitors.
 
-1. **Own division first** — if a GM or Master competed in your division at that match, their median hit factor is used as the reference directly. No cross-division math needed; you're measured against the actual elite competition that was present.
-
-2. **Cross-division fallback** — if no GM or Master competed in your division, the extension finds the strongest competitor across all other divisions (GM median preferred, then Master, then top HF), translates their hit factor to your division's equivalent using national HHF ratios from [hitfactor.info](https://hitfactor.info), and uses that as the reference. This corrects for weak-field matches where winning your division by default would otherwise inflate the score.
-
-A 75% adjusted score means you performed at solid A-class level against the strongest competition at that match — whether they were in your division or another. Adjusted % is the better indicator of actual improvement over time because it accounts for who actually showed up, not just who showed up in your specific division. Classifier stages are excluded from adjusted % because official classifier percentages are already normalized against USPSA national division data.
+A 75% adjusted score means you performed at solid A-class level against the strongest actual stage result at that match after accounting for division equipment differences. Adjusted % is the better indicator of improvement over time because it accounts for the complete match field, not just your division draw. Classifier stages are excluded because official classifier percentages are already normalized against USPSA national division data.
 
 ---
 

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -1281,8 +1281,8 @@
     <canvas id="chartTime" height="380"></canvas>
     <div class="chart-note">
       <strong>Division %</strong> is your score relative to the top shooter in your division at that match — it tells you how you placed, but it only reflects who happened to show up in your division that day.
-      <strong>Adjusted %</strong> is a field-strength correction: it finds the strongest competitor across <em>all</em> divisions at that match (GM median hit factor preferred, then Master, then top HF), translates their score to your division's equivalent using national HHF ratios from hitfactor.info, and measures you against that benchmark.
-      Adjusted % is the more meaningful number — a 75% adjusted score means you competed at solid A-class level against the actual talent at that match, regardless of whether any GM or Master was shooting your division.
+      <strong>Adjusted %</strong> is a field-strength correction: it takes the top stage hit factor from every division at that match, translates each result to your division's equivalent using national HHF ratios from hitfactor.info, and measures you against the strongest normalized result.
+      Adjusted % is the more meaningful number — a 75% adjusted score means you performed at solid A-class level against the strongest actual stage result at that match, regardless of division.
     </div>
     <div class="chart-summary" id="chartTimeSummary" style="display:none"></div>
     <div class="chart-summary chart-summary--adj" id="chartAdjSummary" style="display:none"></div>

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -258,21 +258,11 @@ function psDivToHfi(psDiv) {
 // are already normalized against USPSA national division data, so applying this
 // match-field adjustment would double-normalize them.
 //
-// Two-pass strategy:
-//   Pass 1 — own division first. If the shooter's division has a GM or M median
-//             HF on this stage, use it directly (factor = 1.0, no normalization
-//             error). This is the most accurate reference: an actual classified
-//             competitor in the shooter's division who was standing at the same
-//             match. Cross-division normalization should never override a real
-//             own-division benchmark — the national HHF factors are averages and
-//             will systematically inflate or deflate the reference when the actual
-//             GM present is above or below the national mean.
-//
-//   Pass 2 — cross-division fallback. Only used when the shooter's division has
-//             no GM or M class benchmark (i.e. no elite competitor was present).
-//             Finds the highest reference across other divisions and normalizes it
-//             to the shooter's division using DIVISION_FACTORS (hitfactor.info
-//             March 2025 national HHFs). This corrects for weak-field matches.
+// Compare the strongest actual stage result from every represented division.
+// Each top HF is translated to the shooter's division using DIVISION_FACTORS;
+// the shooter's own division participates at factor 1.0. Using the strongest
+// normalized result prevents a weak GM/M stage from inflating the percentage and
+// guarantees a natural 0–100 range because the own-division winner is eligible.
 //
 // Returns { adjPct, adjClass, refDiv, refClass, refHF, normHF, method } or null.
 function computeAdjustedPct(stage, shooterDiv) {
@@ -285,72 +275,37 @@ function computeAdjustedPct(stage, shooterDiv) {
   const benchmarks = stage.xdiv_benchmarks;
   if (!benchmarks) return null;
 
-  // ── Pass 1: own-division GM or M ─────────────────────────────────────────
-  // Find the benchmark entry whose division key matches the shooter's division.
-  for (const [psDiv, bench] of Object.entries(benchmarks)) {
-    if (psDivToHfi(psDiv) !== myDivKey) continue;
-    // Prefer GM median; fall back to M median.
-    const ref    = bench.gmMedian || bench.mMedian;
-    const cls    = bench.gmMedian ? 'GM' : 'M';
-    const method = bench.gmMedian ? 'gm_median' : 'm_median';
-    if (!ref || ref <= 0) break; // own division found but no GM/M — go to pass 2
-    const adjPct = (stage.hf / ref) * 100;
-    return {
-      adjPct:   Math.min(adjPct, 120),
-      adjClass: classLetterForPct(adjPct),
-      refDiv:   psDiv,
-      refClass: cls,
-      refHF:    ref,
-      normHF:   ref,
-      method,
-    };
-  }
-
-  // ── Pass 2: cross-division fallback ───────────────────────────────────────
-  // No GM or M in shooter's division. Estimate from other divisions using
-  // national HHF ratio factors. Takes the highest normalized reference found.
   let bestNormalizedRef = 0;
   let bestRefDiv = null;
   let bestRefClass = null;
   let bestRefHF = null;
-  let bestMethod = null;
 
   for (const [psDiv, bench] of Object.entries(benchmarks)) {
     const srcDivKey = psDivToHfi(psDiv);
-    if (!srcDivKey || srcDivKey === myDivKey) continue; // own div already checked
-    const factor = DIVISION_FACTORS[myDivKey]?.[srcDivKey];
+    if (!srcDivKey || !bench.topHF || bench.topHF <= 0) continue;
+    const factor = srcDivKey === myDivKey ? 1 : DIVISION_FACTORS[myDivKey]?.[srcDivKey];
     if (!factor) continue;
 
-    const candidates = [
-      { hf: bench.gmMedian, cls: 'GM', method: 'gm_median' },
-      { hf: bench.mMedian,  cls: 'M',  method: 'm_median'  },
-      { hf: bench.topHF,    cls: bench.topClass || '?', method: 'top_hf' },
-    ];
-
-    for (const cand of candidates) {
-      if (!cand.hf || cand.hf <= 0) continue;
-      const normalized = cand.hf * factor;
-      if (normalized > bestNormalizedRef) {
-        bestNormalizedRef = normalized;
-        bestRefDiv        = psDiv;
-        bestRefClass      = cand.cls;
-        bestRefHF         = cand.hf;
-        bestMethod        = cand.method;
-      }
+    const normalized = bench.topHF * factor;
+    if (normalized > bestNormalizedRef) {
+      bestNormalizedRef = normalized;
+      bestRefDiv        = psDiv;
+      bestRefClass      = bench.topClass || '?';
+      bestRefHF         = bench.topHF;
     }
   }
 
   if (bestNormalizedRef <= 0) return null;
 
-  const adjPct = (stage.hf / bestNormalizedRef) * 100;
+  const adjPct = Math.min((stage.hf / bestNormalizedRef) * 100, 100);
   return {
-    adjPct:   Math.min(adjPct, 120),
+    adjPct,
     adjClass: classLetterForPct(adjPct),
     refDiv:   bestRefDiv,
     refClass: bestRefClass,
     refHF:    bestRefHF,
     normHF:   bestNormalizedRef,
-    method:   bestMethod,
+    method:   'top_hf',
   };
 }
 
@@ -1893,8 +1848,7 @@ function renderMatchList() {
             const color = b ? b.text.replace('0.55', '1') : '#8a9bb0';
             adjTd.innerHTML = `<span style="color:${color}">${adj.adjPct.toFixed(1)}% <small style="font-size:9px;opacity:0.75">${adj.adjClass}</small></span>`;
             // Build detailed tooltip explaining the adjustment
-            const methodLabel = adj.method === 'gm_median' ? 'GM median' : adj.method === 'm_median' ? 'Master median' : 'top shooter';
-            adjTd.title = `Field-adjusted: your HF (${s.hf?.toFixed(4)}) vs ${methodLabel} in ${adj.refDiv} (${adj.refHF?.toFixed(4)} HF)\n`
+            adjTd.title = `Field-adjusted: your HF (${s.hf?.toFixed(4)}) vs top shooter in ${adj.refDiv} (${adj.refHF?.toFixed(4)} HF, ${adj.refClass || '?'} class)\n`
               + `Normalized to ${match.division}: ${adj.normHF?.toFixed(4)} HF\n`
               + `${s.hf?.toFixed(4)} / ${adj.normHF?.toFixed(4)} = ${adj.adjPct.toFixed(1)}% (${adj.adjClass} class)`;
           } else if (clf) {
@@ -2568,6 +2522,8 @@ function exportChartCSV() {
     'Date', 'Match', 'Division', 'Class', 'Overall %', 'Div %', 'Place', 'Div Place',
     'Stage', 'Stage HF', 'Stage Match %', 'Stage Time', 'A', 'C', 'D', 'M', 'NS', 'P',
     'Stage Included', 'Stage Note', 'CM #', 'CM Name', 'USPSA %',
+    'Adjusted %', 'Adjusted Ref Division', 'Adjusted Ref Class', 'Adjusted Ref HF',
+    'Adjusted Normalized HF', 'Adjusted Method',
   ];
   const rows = [headers];
 
@@ -2593,6 +2549,7 @@ function exportChartCSV() {
       if (classifiersOnly && !clf) continue;
       const override = getStageOverride(r, s, stageIndex);
       const included = override.included !== false;
+      const adj = computeAdjustedPct(s, r.division);
       rows.push([
         ...matchCols,
         s.name  || '',
@@ -2606,6 +2563,12 @@ function exportChartCSV() {
         clf?.number || '',
         clf?.name   || '',
         s.clf_pct != null ? s.clf_pct.toFixed(2) : '',
+        adj?.adjPct != null ? adj.adjPct.toFixed(2) : '',
+        adj?.refDiv || '',
+        adj?.refClass || '',
+        adj?.refHF != null ? adj.refHF.toFixed(4) : '',
+        adj?.normHF != null ? adj.normHF.toFixed(4) : '',
+        adj?.method || '',
       ]);
     }
   }


### PR DESCRIPTION
## Summary

Implementation for issue #23.

## Files Changed

CHANGELOG.md, README.md, extension/dashboard.html, extension/dashboard.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — no additional evidence supplied

Resolves #23


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.289 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-sol spent 1h 26m and 393,223 tokens on this with the user in an interactive session.