### PR TITLE
chore: release v1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@ All notable user-facing changes are documented here. Update this file before pub
 
 ## Unreleased
 
+## v1.6.3 — 2026-08-24
+
 ### Fixed
 
 - Adjusted % now uses the strongest division-normalized stage result instead of allowing a weak GM or Master stage median to inflate scores above 100%.
+
+### Added
+
 - CSV exports now include each stage's adjusted percentage and selected benchmark details for auditing.
 
 ## v1.6.2 — 2026-05-26

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Chrome extension that pulls your USPSA match results from PractiScore and disp
 
 ![Hit Factor Charts — Analytics](/screenshots/bottom.png?raw=true "Hit Factor Charts — Full Analytics Suite")
 
-*Screenshots taken at v1.5.5. Current version is v1.6.2.*
+*Screenshots taken at v1.5.5. Current version is v1.6.3.*
 
 ---
 
@@ -16,7 +16,7 @@ A Chrome extension that pulls your USPSA match results from PractiScore and disp
 - **Placement chart** — finish position at each match, normalized to field size
 - **Per-stage breakdown** — expand any match row to see hits, HF, and percentage for every stage; classifier stages show official USPSA % (vs national reference HF) as the primary number; individual stages can be excluded from ratings with an optional note
 - **Division-aware** — automatically detects which division you shot in each match and shows division-specific results
-- **Field-strength adjusted %** — for non-classifier stages, finds the strongest competitor across all divisions at each match (GM median HF preferred, then Master, then top HF), translates their score to your division's scale using hitfactor.info HHF ratios, and measures you against that benchmark — a more reliable indicator of improvement than raw division % when your division draw varies
+- **Field-strength adjusted %** — for non-classifier stages, takes the top hit factor from every represented division, translates each result to your division's scale using hitfactor.info HHF ratios, and measures you against the strongest normalized benchmark — a more reliable indicator of improvement than raw division % when your division draw varies
 - **Chart summaries** — automatic plain-English insight below each chart: score trend (last 3 vs baseline), adjusted % context, placement percentile, and classifier trend using the national HHF reference
 - **Classifier tracking** — overlay of your classifier scores against your running average; identifies each CM by number and links to the USPSA stage description PDF
 - **Consistency card** — match-to-match score variance and accuracy loss metrics

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hit Factor Charts",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Track your USPSA match performance: division %, adjusted field-strength scores, classifier trends, and placement over time.",
   "permissions": ["tabs", "scripting", "storage"],
   "host_permissions": ["https://practiscore.com/*", "https://s3.amazonaws.com/*", "https://api.github.com/*", "https://uspsa.org/*", "https://objects.githubusercontent.com/*"],


### PR DESCRIPTION
## Summary

- bump the extension manifest and README to v1.6.3
- promote the adjusted-score correction and CSV benchmark fields into the v1.6.3 changelog section
- align the README feature description with the strongest normalized benchmark implementation

## Release notes

### Fixed

- Adjusted % now uses the strongest division-normalized stage result instead of allowing a weak GM or Master stage median to inflate scores above 100%.

### Added

- CSV exports now include each stage's adjusted percentage and selected benchmark details for auditing.

## Verification

- `git diff --check`
- manifest JSON/version validation with `jq`
- `node --check extension/dashboard.js`
- `node --check extension/background.js`
- built and integrity-tested `HitFactorCharts.zip`
- verified the release workflow extracts the v1.6.3 changelog section exactly

## Publication

Merging this PR triggers the existing release workflow, which creates tag `v1.6.3`, publishes the GitHub release, and attaches `HitFactorCharts.zip`.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.289 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-sol spent 1h 47m and 597,036 tokens on this with the user in an interactive session.