### PR TITLE
GH#22: add persistent division selector (v1.6.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes are documented here. Update this file before pub
 
 ## Unreleased
 
+### Added
+
+- A persistent division selector before the USPSA member-number field now filters charts, statistics, classifier analysis, Match History, status counts, and CSV exports without re-fetching scores.
+
 ## v1.6.3 — 2026-08-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@ All notable user-facing changes are documented here. Update this file before pub
 
 ## Unreleased
 
+## v1.6.4 — 2026-08-26
+
 ### Added
 
 - A persistent division selector before the USPSA member-number field now filters charts, statistics, classifier analysis, Match History, status counts, and CSV exports without re-fetching scores.
+
+### Documentation
+
+- README now explains how the saved division filter applies across the dashboard without deleting cached scores from other divisions.
 
 ## v1.6.3 — 2026-08-24
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Chrome extension that pulls your USPSA match results from PractiScore and disp
 
 ![Hit Factor Charts — Analytics](/screenshots/bottom.png?raw=true "Hit Factor Charts — Full Analytics Suite")
 
-*Screenshots taken at v1.5.5. Current version is v1.6.3.*
+*Screenshots taken at v1.5.5. Current version is v1.6.4.*
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A Chrome extension that pulls your USPSA match results from PractiScore and disp
 - **Score over time** — match percentage plotted chronologically with USPSA classification bands (GM / M / A / B / C / D); Y-axis warped so higher classes get proportional visual space
 - **Placement chart** — finish position at each match, normalized to field size
 - **Per-stage breakdown** — expand any match row to see hits, HF, and percentage for every stage; classifier stages show official USPSA % (vs national reference HF) as the primary number; individual stages can be excluded from ratings with an optional note
-- **Division-aware** — automatically detects which division you shot in each match and shows division-specific results
+- **Division-aware filtering** — automatically detects which division you shot in each match; a persistent selector filters every chart, statistic, classification, history row, and CSV export to one division
 - **Field-strength adjusted %** — for non-classifier stages, takes the top hit factor from every represented division, translates each result to your division's scale using hitfactor.info HHF ratios, and measures you against the strongest normalized benchmark — a more reliable indicator of improvement than raw division % when your division draw varies
 - **Chart summaries** — automatic plain-English insight below each chart: score trend (last 3 vs baseline), adjusted % context, placement percentile, and classifier trend using the national HHF reference
 - **Classifier tracking** — overlay of your classifier scores against your running average; identifies each CM by number and links to the USPSA stage description PDF
@@ -101,6 +101,10 @@ The Hit Factor Charts icon will appear in your Chrome toolbar. Pin it for easy a
 4. **Click Fetch Scores** — the extension navigates to your PractiScore history, opens each match's results page, selects your division, and records your score. Progress is shown in the status bar.
 
 5. **Explore your data** — the summary bar shows matches found, average %, best %, field-strength adjusted average, and your USPSA classification. The **Scored Matches / All Matches** toggle below the cards switches between member-number lookup results and all name-matched results.
+
+### Filtering by division
+
+Use the **All Divisions** dropdown before the USPSA member-number field to focus the complete dashboard on Carry Optics, Limited Optics, Open, Production, or another USPSA division. The filter applies immediately to charts, statistics, classifier analysis, Match History, status counts, and CSV exports. It is saved locally and does not re-fetch or delete scores from other divisions.
 
 ### Reading the chart summaries
 

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -73,7 +73,8 @@
       flex-wrap: wrap;
       border-bottom: 1px solid #1e2130;
     }
-    .controls input {
+    .controls input,
+    .controls select {
       flex: 1;
       min-width: 160px;
       max-width: 260px;
@@ -86,7 +87,12 @@
       outline: none;
       transition: opacity 0.15s, border-color 0.15s;
     }
-    .controls input:focus  { border-color: #4a9eff; }
+    .controls select {
+      flex: 0 1 180px;
+      cursor: pointer;
+    }
+    .controls input:focus,
+    .controls select:focus { border-color: #4a9eff; }
     .controls input::placeholder { color: #5a6070; }
     .controls input:disabled {
       opacity: 0.45;
@@ -385,6 +391,13 @@
       text-transform: uppercase;
       letter-spacing: 0.8px;
       margin-bottom: 16px;
+    }
+    .match-empty {
+      padding: 18px;
+      border: 1px dashed #2a2d3a;
+      border-radius: 8px;
+      color: #777;
+      text-align: center;
     }
 
     .match-row {
@@ -1022,7 +1035,8 @@
     [data-theme="light"] #themeToggle { color: #4a5060; border-color: #c0c4cc; }
     [data-theme="light"] #themeToggle:hover { color: #1a1d27; border-color: #2563eb; }
     [data-theme="light"] .controls { border-bottom-color: #e0e2e8; }
-    [data-theme="light"] .controls input {
+    [data-theme="light"] .controls input,
+    [data-theme="light"] .controls select {
       background: #ffffff;
       border-color: #c0c4cc;
       color: #2c3040;
@@ -1086,6 +1100,7 @@
       background: #ffffff;
       border-color: #d0d4dc;
     }
+    [data-theme="light"] .match-empty { border-color: #c0c4cc; color: #5a6478; }
     [data-theme="light"] .match-row:hover { background: #f0f1f4; }
     [data-theme="light"] .match-name { color: #1a1d27; }
     [data-theme="light"] .match-meta { color: #5a6478; }
@@ -1150,6 +1165,18 @@
 </header>
 
 <div class="controls">
+  <select id="divisionFilter" aria-label="Filter progress by division" title="Filter progress by division">
+    <option value="">All Divisions</option>
+    <option value="co">Carry Optics</option>
+    <option value="lo">Limited Optics</option>
+    <option value="opn">Open</option>
+    <option value="prod">Production</option>
+    <option value="ltd">Limited</option>
+    <option value="l10">Limited 10</option>
+    <option value="pcc">PCC</option>
+    <option value="rev">Revolver</option>
+    <option value="ss">Single Stack</option>
+  </select>
   <input id="memberInput" type="text" placeholder="USPSA member # (e.g. A12345, optional)" />
   <input id="nameInput"   type="text" placeholder="Name (e.g. Smith, Jane)" />
   <button id="editBtn"   class="ctrl-btn">Edit</button>

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -988,8 +988,11 @@ function renderAll() {
     document.getElementById('statDiv').textContent     = selectedDiv ? divisionLabel(selectedDiv) : '—';
     document.getElementById('statConsistencyBox').style.display = 'none';
     document.getElementById('statAdjAvgBox').style.display = 'none';
-    document.getElementById('chartTimeTitle').textContent = 'Score Over Time';
-    setPlacementVisible(true);
+    document.getElementById('chartTimeTitle').textContent = classifiersOnly
+      ? 'Classifier Scores Over Time'
+      : 'Score Over Time';
+    document.getElementById('chartPlaceSubtitle').textContent = '';
+    setPlacementVisible(!classifiersOnly);
     ['chartNonClfSection', 'chartClfOverlaySection', 'chartAccuracySection', 'chartHitZoneSection']
       .forEach(id => { document.getElementById(id).style.display = 'none'; });
     ['chartTimeSummary', 'chartAdjSummary', 'chartPlaceSummary', 'chartClfSummary']
@@ -1018,9 +1021,19 @@ function renderAll() {
     document.getElementById('statMatches').textContent = '0';
     document.getElementById('statAvg').textContent = '—';
     document.getElementById('statBest').textContent = '—';
+    document.getElementById('statDiv').textContent = selectedDiv
+      ? divisionLabel(selectedDiv)
+      : (divs.length === 1 ? divisionLabel(divs[0]) : 'All');
     document.getElementById('statConsistencyBox').style.display = 'none';
     document.getElementById('statAdjAvgBox').style.display = 'none';
+    document.getElementById('chartTimeTitle').textContent = classifiersOnly
+      ? 'Classifier Scores Over Time'
+      : 'Score Over Time';
+    document.getElementById('chartPlaceSubtitle').textContent = '';
+    setPlacementVisible(!classifiersOnly);
     ['chartNonClfSection', 'chartClfOverlaySection', 'chartAccuracySection', 'chartHitZoneSection']
+      .forEach(id => { document.getElementById(id).style.display = 'none'; });
+    ['chartTimeSummary', 'chartAdjSummary', 'chartPlaceSummary', 'chartClfSummary']
       .forEach(id => { document.getElementById(id).style.display = 'none'; });
     renderClassBox(selectedDiv);
     renderYearFilter(years);
@@ -1168,6 +1181,9 @@ function renderAll() {
     // Classifier-only mode never displays the normal analysis charts.
     ['chartNonClfSection','chartClfOverlaySection','chartAccuracySection','chartHitZoneSection']
       .forEach(id => { const el = document.getElementById(id); if (el) el.style.display = 'none'; });
+    ['chartTimeSummary', 'chartAdjSummary', 'chartPlaceSummary', 'chartClfSummary']
+      .forEach(id => { document.getElementById(id).style.display = 'none'; });
+    document.getElementById('chartPlaceSubtitle').textContent = '';
 
     if (clfPoints.length === 0) {
       document.getElementById('statMatches').textContent = '0';

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -19,6 +19,7 @@ document.getElementById('headerVersion').textContent = 'v' + chrome.runtime.getM
 // ── DOM refs ──────────────────────────────────────────────────────────────────
 const memberInput  = document.getElementById('memberInput');
 const nameInput    = document.getElementById('nameInput');
+const divisionFilter = document.getElementById('divisionFilter');
 const fetchBtn     = document.getElementById('fetchBtn');
 const editBtn      = document.getElementById('editBtn');
 const saveBtn      = document.getElementById('saveBtn');
@@ -204,7 +205,7 @@ async function restoreFromSync() {
 let currentView      = 'ranked'; // 'ranked' | 'all'
 let deselectedMatches = new Set(); // match IDs manually excluded from charts
 let stageOverrides    = {};     // match_id -> stage key -> { included: false, note: string }
-let selectedDiv       = null;     // division filter for stats + charts (null = All)
+let selectedDiv       = null;     // canonical division key (null = All)
 let selectedYear      = null;     // year filter for charts (null = All Time)
 let selectedDateRange = null;    // custom range { start: 'YYYY-MM-DD', end: 'YYYY-MM-DD' } or null
 let classificationData = null;  // data from uspsa.org/classification/[memberNumber]
@@ -244,6 +245,12 @@ const PS_DIV_TO_HFI = {
   // Full names (from combined view)
   CARRYOPTICS: 'co', LIMITED: 'ltd', LIMITEDOPTICS: 'lo', OPEN: 'opn',
   PRODUCTION: 'prod', REVOLVER: 'rev', SINGLESTACK: 'ss',
+  LIMITED10: 'l10', PISTOLCALIBERCARBINE: 'pcc',
+};
+
+const DIVISION_LABELS = {
+  co: 'Carry Optics', lo: 'Limited Optics', opn: 'Open', prod: 'Production',
+  ltd: 'Limited', l10: 'Limited 10', pcc: 'PCC', rev: 'Revolver', ss: 'Single Stack',
 };
 
 // Convert a PractiScore division string to hitfactor.info key
@@ -251,6 +258,20 @@ function psDivToHfi(psDiv) {
   if (!psDiv) return null;
   const key = psDiv.trim().toUpperCase().replace(/[\s\-]+/g, '');
   return PS_DIV_TO_HFI[key] || key.toLowerCase();
+}
+
+function normalizeDivision(psDiv) {
+  const key = psDivToHfi(psDiv);
+  return key && DIVISION_LABELS[key] ? key : null;
+}
+
+function divisionLabel(psDiv) {
+  const key = normalizeDivision(psDiv);
+  return key ? DIVISION_LABELS[key] : (psDiv || 'Unknown');
+}
+
+function matchesSelectedDivision(match) {
+  return !selectedDiv || normalizeDivision(match?.division) === selectedDiv;
 }
 
 // Compute field-strength-adjusted stage percentage.
@@ -647,7 +668,7 @@ function hideOnboarding() {
 }
 
 // ── Restore persisted state on load ──────────────────────────────────────────
-chrome.storage.local.get(['memberNumber', 'name', 'lastMatchList', 'matchCache', 'deselectedMatches', 'stageOverrides', 'classificationData'], async d => {
+chrome.storage.local.get(['memberNumber', 'name', 'lastMatchList', 'matchCache', 'deselectedMatches', 'stageOverrides', 'classificationData', 'selectedDivision'], async d => {
   // Try restoring from sync if local has no credentials (e.g. after reinstall)
   if (!d.memberNumber && !d.name) {
     await restoreFromSync();
@@ -661,6 +682,8 @@ chrome.storage.local.get(['memberNumber', 'name', 'lastMatchList', 'matchCache',
   if (d.name)         nameInput.value   = d.name;
   if (d.deselectedMatches) deselectedMatches = new Set(d.deselectedMatches);
   if (d.stageOverrides && typeof d.stageOverrides === 'object') stageOverrides = d.stageOverrides;
+  selectedDiv = normalizeDivision(d.selectedDivision);
+  divisionFilter.value = selectedDiv || '';
 
   // Lock inputs if we already have saved credentials
   if (d.memberNumber || d.name) {
@@ -687,14 +710,7 @@ chrome.storage.local.get(['memberNumber', 'name', 'lastMatchList', 'matchCache',
       if (!d.memberNumber) switchView('all');
       renderAll();
       renderMatchList();
-      const confirmedRestored  = restored.filter(r => isConfirmedUSPSA(r.match_type || 'Unknown'));
-      const unconfirmedRestored = restored.filter(r => isLikelyUSPSA(r.match_type || 'Unknown') && !isConfirmedUSPSA(r.match_type || 'Unknown'));
-      const nonUspsaRestored   = restored.filter(r => !isLikelyUSPSA(r.match_type || 'Unknown'));
-      const scored    = confirmedRestored.filter(r => r.overall_pct != null).length;
-      const uspsa     = confirmedRestored.length;
-      const unconfirmedNote = unconfirmedRestored.length > 0 ? ` · ${unconfirmedRestored.length} unconfirmed type` : '';
-      const skippedNote     = nonUspsaRestored.length > 0    ? ` · ${nonUspsaRestored.length} non-USPSA excluded` : '';
-      setStatus(`Showing cached data — ${scored}/${uspsa} USPSA matches scored.${unconfirmedNote}${skippedNote} Click Fetch Scores to check for new matches.`, 'success');
+      updateStatusCounts('Showing cached data:');
     }
   }
 });
@@ -729,6 +745,14 @@ document.getElementById('classifiersOnlyChk').addEventListener('change', e => {
 
 document.getElementById('exportCsvBtn').addEventListener('click', () => {
   exportChartCSV();
+});
+
+divisionFilter.addEventListener('change', () => {
+  selectedDiv = normalizeDivision(divisionFilter.value);
+  chrome.storage.local.set({ selectedDivision: selectedDiv });
+  renderAll();
+  renderMatchList();
+  updateStatusCounts();
 });
 
 // ── Fetch button ──────────────────────────────────────────────────────────────
@@ -937,7 +961,8 @@ function renderAll() {
     ? uspsaBase.filter(r => r.found_by === 'member_number' && effectiveOverallPct(r) != null)
     : uspsaBase.filter(r => effectiveOverallPct(r) != null || r.hf != null);
 
-  const sorted = [...chartable].sort((a, b) => {
+  const divs = [...new Set(chartable.map(r => r.division).filter(Boolean))];
+  const sorted = chartable.filter(matchesSelectedDivision).sort((a, b) => {
     const da = parseDate(a.date), db = parseDate(b.date);
     return (da && db) ? da - db : 0;
   });
@@ -950,28 +975,36 @@ function renderAll() {
   document.getElementById('classifiersToggleWrap').style.display = currentView === 'ranked' ? 'flex' : 'none';
 
   if (sorted.length === 0) {
-    const msg = currentView === 'ranked'
+    const msg = selectedDiv
+      ? `No ${divisionLabel(selectedDiv)} matches found in the current view.`
+      : currentView === 'ranked'
       ? 'No member-number confirmed scores.\nSwitch to "All Matches" to see name-matched results.'
       : 'No data.';
     drawMessage(document.getElementById('chartTime'),  msg);
     drawMessage(document.getElementById('chartPlace'), msg);
-    document.getElementById('statMatches').textContent = '—';
+    document.getElementById('statMatches').textContent = '0';
     document.getElementById('statAvg').textContent     = '—';
     document.getElementById('statBest').textContent    = '—';
-    document.getElementById('statDiv').textContent     = '—';
+    document.getElementById('statDiv').textContent     = selectedDiv ? divisionLabel(selectedDiv) : '—';
+    document.getElementById('statConsistencyBox').style.display = 'none';
+    document.getElementById('statAdjAvgBox').style.display = 'none';
+    document.getElementById('chartTimeTitle').textContent = 'Score Over Time';
+    setPlacementVisible(true);
+    ['chartNonClfSection', 'chartClfOverlaySection', 'chartAccuracySection', 'chartHitZoneSection']
+      .forEach(id => { document.getElementById(id).style.display = 'none'; });
+    ['chartTimeSummary', 'chartAdjSummary', 'chartPlaceSummary', 'chartClfSummary']
+      .forEach(id => { document.getElementById(id).style.display = 'none'; });
+    renderClassBox(selectedDiv);
+    renderYearFilter([]);
     return;
   }
 
-  const divs = [...new Set(sorted.map(r => r.division).filter(Boolean))];
-
-  // Validate selectedDiv / selectedYear against current data
-  if (selectedDiv && !divs.includes(selectedDiv)) selectedDiv = null;
+  // Validate the time filter against the active division without changing division preference.
   const years = [...new Set(sorted.map(r => r.date?.slice(0, 4)).filter(Boolean))].sort();
   if (selectedYear && !years.includes(selectedYear)) selectedYear = null;
 
-  // Filter to selected division + year/range for stats + charts
+  // Filter to selected year/range for stats + charts. Division is applied above.
   const viewSorted = sorted.filter(r =>
-    (!selectedDiv       || (r.division || 'Unknown') === selectedDiv) &&
     (!selectedYear      || r.date?.startsWith(selectedYear)) &&
     (!selectedDateRange || (r.date >= selectedDateRange.start && r.date <= selectedDateRange.end))
   );
@@ -990,7 +1023,7 @@ function renderAll() {
   document.getElementById('statBest').style.color    = bestBand?.text.replace('0.55','1') || '#4a9eff';
 
   // Stat box tooltips — explain what each metric measures
-  const divLabel = selectedDiv ? ` in ${selectedDiv}` : '';
+  const divLabel = selectedDiv ? ` in ${divisionLabel(selectedDiv)}` : '';
   const filteredStageTotal = viewSorted.reduce((sum, r) => sum + excludedStageCount(r), 0);
   const filteredStageTip = filteredStageTotal
     ? `\n${filteredStageTotal} excluded stage${filteredStageTotal > 1 ? 's are' : ' is'} omitted; filtered match scores use the average included stage %.`
@@ -1059,49 +1092,18 @@ function renderAll() {
     adjAvgBox.style.display = 'none';
   }
 
-  // Division stat box — opens a dropdown
+  // Division stat box mirrors the primary filter and is intentionally display-only.
   const divStatBox = document.getElementById('statDiv').closest('.stat-box');
   const divStatVal = document.getElementById('statDiv');
-  // Tooltip on the label — explains the card and the click-to-filter behaviour
   const divLblEl = divStatBox.querySelector('.lbl');
-  if (divLblEl) {
-    const divTipLines = divs.length > 1
-      ? `The division(s) detected in your match history.\nClick to filter all charts and stats to a single division.`
-      : `The division you shot in your match history.\nAll charts and stats reflect this division.`;
-    divLblEl.title = divTipLines;
-  }
+  divStatBox.classList.remove('clickable', 'active-filter');
+  divStatBox.onclick = null;
+  if (divLblEl) divLblEl.title = 'Use the division selector above to filter all progress data.';
   if (divs.length > 0) {
-    divStatBox.classList.add('clickable');
-    divStatBox.classList.toggle('active-filter', !!selectedDiv);
-    divStatVal.textContent = selectedDiv || (divs.length === 1 ? divs[0] : 'All');
-    divStatBox.onclick = (e) => {
-      e.stopPropagation();
-      const existing = divStatBox.querySelector('.div-dropdown');
-      if (existing) { existing.remove(); return; }
-      const dropdown = document.createElement('div');
-      dropdown.className = 'div-dropdown';
-      const options = divs.length > 1 ? ['All', ...divs] : divs;
-      options.forEach(d => {
-        const item = document.createElement('div');
-        item.className = 'div-dropdown-item' + ((d === 'All' && !selectedDiv) || d === selectedDiv ? ' selected' : '');
-        item.textContent = d;
-        item.onclick = (ev) => {
-          ev.stopPropagation();
-          selectedDiv = d === 'All' ? null : d;
-          dropdown.remove();
-          renderAll();
-        };
-        dropdown.appendChild(item);
-      });
-      divStatBox.appendChild(dropdown);
-      setTimeout(() => document.addEventListener('click', function close() {
-        dropdown.remove();
-        document.removeEventListener('click', close);
-      }, { once: true }), 0);
-    };
+    divStatVal.textContent = selectedDiv
+      ? divisionLabel(selectedDiv)
+      : (divs.length === 1 ? divisionLabel(divs[0]) : 'All');
   } else {
-    divStatBox.classList.remove('clickable', 'active-filter');
-    divStatBox.onclick = null;
     divStatVal.textContent = '—';
   }
 
@@ -1109,7 +1111,7 @@ function renderAll() {
   renderYearFilter(years);
 
   // Official classification stat box (D-GM class from USPSA.org)
-  renderClassBox(selectedDiv || (divs.length === 1 ? divs[0] : null));
+  renderClassBox(selectedDiv || (divs.length === 1 ? normalizeDivision(divs[0]) : null));
 
   const avgLbl = document.querySelector('#statMatches')?.closest('#stats')
     ?.querySelectorAll('.stat-box')[1]?.querySelector('.lbl');
@@ -1636,10 +1638,18 @@ function renderMatchList() {
   matchHistory.classList.add('visible');
   matchRowsEl.innerHTML = '';
 
-  const sorted = [...allResults].sort((a, b) => {
+  const sorted = allResults.filter(matchesSelectedDivision).sort((a, b) => {
     const da = parseDate(a.date), db = parseDate(b.date);
     return (da && db) ? db - da : 0;
   });
+
+  if (!sorted.length) {
+    const empty = document.createElement('div');
+    empty.className = 'match-empty';
+    empty.textContent = `No ${divisionLabel(selectedDiv)} matches found.`;
+    matchRowsEl.appendChild(empty);
+    return;
+  }
 
   sorted.forEach(match => {
     const hasStages  = !!(match.stages && match.stages.length > 0);
@@ -2028,16 +2038,17 @@ function renderClassBox(viewSortedDivision) {
   if (!classificationData?.divisions) { box.style.display = 'none'; return; }
 
   const divs = classificationData.divisions;
-  // Use the selected division key, or try to match by substring, or first available
+  // Match official division names to the canonical key used by the primary filter.
   let info = null;
+  let matchedKey = null;
   if (viewSortedDivision) {
-    const key = Object.keys(divs).find(k =>
-      k.toLowerCase().includes(viewSortedDivision.toLowerCase().slice(0, 4)) ||
-      viewSortedDivision.toLowerCase().includes(k.toLowerCase().slice(0, 4))
-    );
-    if (key) info = divs[key];
+    matchedKey = Object.keys(divs).find(k => normalizeDivision(k) === normalizeDivision(viewSortedDivision));
+    if (matchedKey) info = divs[matchedKey];
   }
-  if (!info) info = Object.values(divs)[0];
+  if (!info && !viewSortedDivision) {
+    matchedKey = Object.keys(divs)[0];
+    info = matchedKey ? divs[matchedKey] : null;
+  }
   if (!info?.class_) { box.style.display = 'none'; return; }
 
   const c = info.class_.toUpperCase();
@@ -2055,10 +2066,7 @@ function renderClassBox(viewSortedDivision) {
   `;
 
   // Tooltip — explain what the class and % mean
-  const divName = Object.keys(classificationData.divisions).find(k =>
-    k.toLowerCase().includes((viewSortedDivision || '').toLowerCase().slice(0, 4)) ||
-    (viewSortedDivision || '').toLowerCase().includes(k.toLowerCase().slice(0, 4))
-  ) || viewSortedDivision || 'your division';
+  const divName = matchedKey || divisionLabel(viewSortedDivision) || 'your division';
   const tipPctLine = info.pct != null
     ? `${info.pct.toFixed(1)}% — your current classifier average.\n`
     : '';
@@ -2105,9 +2113,7 @@ async function deleteMatch(match) {
     matchHistory.classList.remove('visible');
     setStatus('No matches. Click Fetch Scores to load.', '');
   } else {
-    const uspsaLeft = allResults.filter(r => isLikelyUSPSA(r.match_type || 'Unknown'));
-    const scored = uspsaLeft.filter(r => r.overall_pct != null).length;
-    setStatus(`${uspsaLeft.length} USPSA match(es) — ${scored} with scores.`, 'success');
+    updateStatusCounts();
   }
 }
 
@@ -2133,6 +2139,7 @@ async function refreshSingleMatch(match, btn) {
 
     renderAll();
     renderMatchList();
+    updateStatusCounts();
 
   } catch (err) {
     console.error('Refresh failed:', err);
@@ -2151,18 +2158,20 @@ function setStatus(msg, type = '', loading = false) {
 // verb = 'Loaded' on first fetch, omitted (defaults to 'Showing') on checkbox changes.
 function updateStatusCounts(verb) {
   if (!allResults.length) return;
-  const confirmedUSPSA  = allResults.filter(r => isConfirmedUSPSA(r.match_type || 'Unknown'));
-  const unconfirmed     = allResults.filter(r => isLikelyUSPSA(r.match_type || 'Unknown') && !isConfirmedUSPSA(r.match_type || 'Unknown'));
-  const nonUspsa        = allResults.filter(r => !isLikelyUSPSA(r.match_type || 'Unknown'));
+  const visibleResults  = allResults.filter(matchesSelectedDivision);
+  const confirmedUSPSA  = visibleResults.filter(r => isConfirmedUSPSA(r.match_type || 'Unknown'));
+  const unconfirmed     = visibleResults.filter(r => isLikelyUSPSA(r.match_type || 'Unknown') && !isConfirmedUSPSA(r.match_type || 'Unknown'));
+  const nonUspsa        = visibleResults.filter(r => !isLikelyUSPSA(r.match_type || 'Unknown'));
   const uspsa           = confirmedUSPSA.length;
   const scored          = confirmedUSPSA.filter(r => r.overall_pct != null).length;
   const checked         = confirmedUSPSA.filter(r => !deselectedMatches.has(r.match_id)).length;
 
   const prefix           = verb || 'Showing';
+  const divisionNote     = selectedDiv ? ` ${divisionLabel(selectedDiv)}` : '';
   const checkedNote      = checked < uspsa ? ` · ${checked} checked` : '';
   const unconfirmedNote  = unconfirmed.length > 0 ? ` · ${unconfirmed.length} unconfirmed type` : '';
   const skippedNote      = nonUspsa.length > 0    ? ` · ${nonUspsa.length} non-USPSA excluded` : '';
-  setStatus(`${prefix} ${uspsa} USPSA match(es) — ${scored} with scores${checkedNote}.${unconfirmedNote}${skippedNote}`, 'success');
+  setStatus(`${prefix}${divisionNote} ${uspsa} USPSA match(es) — ${scored} with scores${checkedNote}.${unconfirmedNote}${skippedNote}`, 'success');
 }
 
 // ── Save icon SVG (floppy disk, feather-style) ────────────────────────────────
@@ -2506,12 +2515,11 @@ function exportChartCSV() {
   const chartable = currentView === 'ranked'
     ? uspsaBase.filter(r => r.found_by === 'member_number' && effectiveOverallPct(r) != null)
     : uspsaBase.filter(r => effectiveOverallPct(r) != null || r.hf != null);
-  const sorted = [...chartable].sort((a, b) => {
+  const sorted = chartable.filter(matchesSelectedDivision).sort((a, b) => {
     const da = parseDate(a.date), db = parseDate(b.date);
     return (da && db) ? da - db : 0;
   });
   const viewSorted = sorted.filter(r =>
-    (!selectedDiv       || (r.division || 'Unknown') === selectedDiv) &&
     (!selectedYear      || r.date?.startsWith(selectedYear)) &&
     (!selectedDateRange || (r.date >= selectedDateRange.start && r.date <= selectedDateRange.end))
   );
@@ -2577,7 +2585,8 @@ function exportChartCSV() {
   const dateTag  = selectedDateRange
     ? `${selectedDateRange.start} to ${selectedDateRange.end}`
     : selectedYear || 'all time';
-  const filename = (classifiersOnly ? 'hfc_classifiers' : 'hfc_scores') + ` ${dateTag}.csv`;
+  const divisionTag = selectedDiv ? ` ${divisionLabel(selectedDiv)}` : '';
+  const filename = (classifiersOnly ? 'hfc_classifiers' : 'hfc_scores') + `${divisionTag} ${dateTag}.csv`;
   const blob     = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
   const url      = URL.createObjectURL(blob);
   const a        = document.createElement('a');

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -961,7 +961,7 @@ function renderAll() {
     ? uspsaBase.filter(r => r.found_by === 'member_number' && effectiveOverallPct(r) != null)
     : uspsaBase.filter(r => effectiveOverallPct(r) != null || r.hf != null);
 
-  const divs = [...new Set(chartable.map(r => r.division).filter(Boolean))];
+  const divs = [...new Set(chartable.map(r => normalizeDivision(r.division)).filter(Boolean))];
   const sorted = chartable.filter(matchesSelectedDivision).sort((a, b) => {
     const da = parseDate(a.date), db = parseDate(b.date);
     return (da && db) ? da - db : 0;
@@ -1008,6 +1008,24 @@ function renderAll() {
     (!selectedYear      || r.date?.startsWith(selectedYear)) &&
     (!selectedDateRange || (r.date >= selectedDateRange.start && r.date <= selectedDateRange.end))
   );
+
+  if (viewSorted.length === 0) {
+    const msg = selectedDiv
+      ? `No ${divisionLabel(selectedDiv)} matches found in the selected date range.`
+      : 'No matches found in the selected date range.';
+    drawMessage(document.getElementById('chartTime'), msg);
+    drawMessage(document.getElementById('chartPlace'), msg);
+    document.getElementById('statMatches').textContent = '0';
+    document.getElementById('statAvg').textContent = '—';
+    document.getElementById('statBest').textContent = '—';
+    document.getElementById('statConsistencyBox').style.display = 'none';
+    document.getElementById('statAdjAvgBox').style.display = 'none';
+    ['chartNonClfSection', 'chartClfOverlaySection', 'chartAccuracySection', 'chartHitZoneSection']
+      .forEach(id => { document.getElementById(id).style.display = 'none'; });
+    renderClassBox(selectedDiv);
+    renderYearFilter(years);
+    return;
+  }
 
   const overallPcts = viewSorted.map(r => effectiveOverallPct(r)).filter(v => v != null);
   const avg  = overallPcts.length ? _avg(overallPcts) : 0;
@@ -1137,7 +1155,7 @@ function renderAll() {
           hf: s.hf,
           label: clf.number ? `CM ${clf.number}${clf.name ? ' · ' + clf.name : ''}` : 'Classifier',
           match_name: r.match_name,
-          division: r.division || 'Unknown',
+          division: divisionLabel(r.division),
           code: clf.number,
           a: s.a, c: s.c, d: s.d, m: s.m, ns: s.ns, p: s.p,
         });
@@ -1146,6 +1164,10 @@ function renderAll() {
 
     // Sort chronologically
     clfPoints.sort((a, b) => (a.date || '').localeCompare(b.date || ''));
+
+    // Classifier-only mode never displays the normal analysis charts.
+    ['chartNonClfSection','chartClfOverlaySection','chartAccuracySection','chartHitZoneSection']
+      .forEach(id => { const el = document.getElementById(id); if (el) el.style.display = 'none'; });
 
     if (clfPoints.length === 0) {
       document.getElementById('statMatches').textContent = '0';
@@ -1204,9 +1226,6 @@ function renderAll() {
       showClassBands: true,
     });
     setPlacementVisible(false);
-    // Hide analysis charts in classifiers-only mode
-    ['chartNonClfSection','chartClfOverlaySection','chartAccuracySection','chartHitZoneSection']
-      .forEach(id => { const el = document.getElementById(id); if (el) el.style.display = 'none'; });
     return;
   }
 
@@ -1220,7 +1239,7 @@ function renderAll() {
   // Group viewSorted results by division
   const byDiv = {};
   viewSorted.forEach(r => {
-    const key = r.division || 'Unknown';
+    const key = divisionLabel(r.division);
     if (!byDiv[key]) byDiv[key] = [];
     byDiv[key].push(r);
   });

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hit Factor Charts",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Track your USPSA match performance: division %, adjusted field-strength scores, classifier trends, and placement over time.",
   "permissions": ["tabs", "scripting", "storage"],
   "host_permissions": ["https://practiscore.com/*", "https://s3.amazonaws.com/*", "https://api.github.com/*", "https://uspsa.org/*", "https://objects.githubusercontent.com/*"],


### PR DESCRIPTION
## Summary

- add a persistent division selector before the USPSA member-number field
- apply normalized division filtering to charts, statistics, classification, Match History, status counts, and CSV exports
- preserve the selected division locally without fetching or deleting cached scores
- publish the change as v1.6.4 with changelog-driven release notes

## Verification

- `node --check extension/dashboard.js`
- `node --check extension/background.js`
- `git diff --check origin/main...HEAD`
- `./build.sh`
- release-note extraction verified for manifest version `1.6.4`
- independent final diff review found no release-blocking defects

Resolves #22

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 31m and 150,920 tokens on this with the user in an interactive session.