### PR TITLE
GH#29: make the extension dashboard fluid and full width

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,21 @@
+# Hit Factor Charts Design
+
+## Product UI
+
+Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter typography, blue accent, light/dark themes, compact controls, and chart-first hierarchy unless a feature explicitly changes them.
+
+## Responsive layout
+
+- The dashboard is fluid and uses 100% of the browser width. Do not restore a fixed page-level maximum width.
+- Sections provide their own horizontal gutters: 24–28px on desktop and 16px at widths up to 640px.
+- Charts fill their section width and redraw from their rendered width after a browser resize.
+- Summary cards and controls wrap rather than forcing page-level horizontal scrolling.
+- Wide layouts should use the available charting space; constrain individual text or control elements only when readability requires it.
+- Stage tables may scroll within their existing panel on narrow screens, but the page itself must not acquire unintended horizontal overflow.
+
+## Interaction and accessibility
+
+- Preserve visible keyboard focus and keyboard access for every control.
+- Do not rely on hover for required actions or information.
+- Keep motion restrained in this analytical interface; resizing and filtering should feel immediate rather than animated.
+- Verify layout changes in both themes at approximately 375px, 1920px, and 2560px viewport widths.

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -27,7 +27,12 @@
       -webkit-font-smoothing: antialiased;
     }
 
-    .page { max-width: 960px; margin: 0 auto; padding-bottom: 60px; }
+    .page {
+      width: 100%;
+      min-width: 0;
+      margin: 0;
+      padding-bottom: 60px;
+    }
 
     /* ── Header ── */
     header {
@@ -1003,6 +1008,21 @@
     .match-row:focus-within .refresh-btn,
     .match-row:focus-within .export-btn,
     .match-row:focus-within .delete-btn { opacity: 1; }
+
+    /* ── Responsive layout ── */
+    @media (max-width: 640px) {
+      header,
+      .controls { padding-left: 16px; padding-right: 16px; }
+      .controls input { flex-basis: 100%; max-width: none; }
+      #status { padding-left: 16px; padding-right: 16px; }
+      .summary-bar { padding-left: 16px; padding-right: 16px; }
+      #stats { gap: 10px; }
+      #timeFilter { padding-left: 16px; padding-right: 16px; }
+      .chart-section { padding: 20px 16px; }
+      .chart-section-header { align-items: flex-start; flex-wrap: wrap; gap: 8px; }
+      #matchHistory { margin-left: 16px; margin-right: 16px; }
+      .match-row { gap: 8px; padding: 10px 12px; }
+    }
 
     /* ── CSS variables: chart primitives (read by CHART_BG/GRID_COLOR etc. in JS) ── */
     :root {

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -6,11 +6,23 @@ let allResults = [];
 // ── Size canvases to fill their containers ────────────────────────────────────
 function sizeCanvases() {
   document.querySelectorAll('canvas').forEach(c => {
-    const w = c.parentElement?.offsetWidth || 860;
+    const renderedWidth = c.getBoundingClientRect().width;
+    const w = Math.floor(renderedWidth || c.parentElement?.clientWidth || 860);
     if (c.width !== w) c.width = w;
   });
 }
-window.addEventListener('resize', () => { sizeCanvases(); renderAll(); });
+
+let resizeFrame = null;
+function scheduleDashboardResize() {
+  if (resizeFrame !== null) return;
+  resizeFrame = requestAnimationFrame(() => {
+    resizeFrame = null;
+    sizeCanvases();
+    renderAll();
+  });
+}
+
+window.addEventListener('resize', scheduleDashboardResize);
 document.addEventListener('DOMContentLoaded', sizeCanvases);
 
 // ── Version display ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Remove the 960px page cap, add responsive narrow-screen gutters, keep chart canvases aligned to their rendered width, and document the dashboard layout contract in DESIGN.md.

## Files Changed

DESIGN.md, extension/dashboard.html, extension/dashboard.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — node --check extension/dashboard.js; ./build.sh; git diff --check; browser runtime harness attempted but unavailable because the installed Playwright package/browser runtime was not importable and headless Chrome stalled in the host display service

Resolves #29


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 37m and 446,253 tokens on this with the user in an interactive session.