### PR TITLE
GH#31: Add dashboard date-range presets

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -19,3 +19,10 @@ Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter
 - Do not rely on hover for required actions or information.
 - Keep motion restrained in this analytical interface; resizing and filtering should feel immediate rather than animated.
 - Verify layout changes in both themes at approximately 375px, 1920px, and 2560px viewport widths.
+
+## Analytics date range
+
+- Keep all six presets immediately visible above the charts in this order: **Last 1 month**, **3 mo**, **6 mo**, **1 yr**, **3 yr**, and **all time**.
+- Activate **6 mo** on every dashboard load. Exactly one preset must expose a visible active state and `aria-pressed="true"`.
+- Use compact native buttons with a clear keyboard focus ring. The group wraps at narrow widths rather than becoming a dropdown or creating horizontal page overflow.
+- Date-range changes update the existing cached analytics immediately. They do not hide or delete older Match History records.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A Chrome extension that pulls your USPSA match results from PractiScore and disp
 - **Accuracy trend** — hit factor breakdown over time (A/C/D/M/NS/P)
 - **Match type detection** — identifies USPSA, IDPA, IPSC, Steel Challenge, 3-Gun, PCSL, ICORE matches; non-USPSA matches are shown in history but excluded from charts
 - **Filter matches** — checkboxes let you include or exclude individual matches from charts without deleting them
-- **Filter by year or custom date range** — year dropdown includes a "Custom Range…" option with from/to date pickers
+- **Readable date ranges** — charts default to six months with one-click presets for one month, three months, six months, one year, three years, and all time
 - **Export as image** — save any match or individual stage as a PNG card (floppy-disk button on each match row)
 - **Export as CSV** — download all chart-visible data as a flat CSV (one row per stage) including CM numbers, USPSA %, HF, hit counts, adjusted %, and the selected reference division, class, HF, normalized HF, and benchmark method
 - **Light/dark theme** — defaults to light mode; toggle in the header; preference syncs across devices via Chrome storage
@@ -119,7 +119,7 @@ Summaries appear automatically once enough data is loaded. Classifier trend requ
 
 ### Filtering by date
 
-Click the **All Time** pill above the chart to filter by year, or choose **Custom Range…** at the bottom of the dropdown to enter exact from/to dates. The filter applies to charts, stats, and CSV exports.
+Analytics open on the most recent **6 mo** so trends stay readable. Use the buttons above the charts to switch to **Last 1 month**, **3 mo**, **6 mo**, **1 yr**, **3 yr**, or **all time**. The active range applies to every chart, summary statistic, classifier-only view, and chart CSV export without re-fetching or deleting older Match History records.
 
 ### Exporting data
 

--- a/TODO.md
+++ b/TODO.md
@@ -5,8 +5,8 @@
 - [x] t003 build.sh: version tag passed as argument creates a misnamed ZIP (pscharts-v1.0-patch.zip instead of pscharts-v1.0.1.zip) — fix to derive patch version from manifest or accept full semver as argument
 - [ ] t004 Unknown match type detection — consider prompting user to manually classify unconfirmed-type matches rather than silently showing them as "unconfirmed type"
 - [x] t005 Image export — per-match and per-stage PNG export via Canvas (match card + stage card); upstream v1.0–v1.1 feature; floppy-disk button on each match row with dropdown for full match or individual stages pr:#12
-- [x] t006 CSV export — flat per-stage CSV of all chart-visible match data including USPSA %, HF, hit counts, CM info; respects active division/year/date filters; "⤓ CSV" button in chart section header pr:#12
-- [x] t007 Custom date range filter — "Custom Range…" option in year dropdown with from/to date pickers; state: selectedDateRange {start, end}; applied in renderAll() and exportChartCSV(); upstream v1.0 feature pr:#12
+- [x] t006 CSV export — flat per-stage CSV of all chart-visible match data including USPSA %, HF, hit counts, CM info; respects active division and date-range presets; "⤓ CSV" button in chart section header pr:#12
+- [x] t007 Custom date range filter — shipped in v1.0 via pr:#12; superseded by the six immediately visible analytics presets in #31
 - [x] t008 Class-band Y-axis warp — buildWarpMap()/warpPct() for weighted Y-axis on score-over-time chart so each class band gets proportional visual height rather than linear % scale; upstream v0.8-beta feature pr:#12
 - [x] t009 clf_pct in stage table — when a stage is a known classifier and clf_pct is available, show official USPSA % as primary with match % as small secondary; one-line template change in renderMatchList(); upstream v0.9 feature pr:#12
 - [x] t010 normalizeStgName() + background.js regex fix — strip "Stage N:" prefix from cached stage names; tighten stage regex separator from required to optional (/[:\-–]?\s*/i); upstream v1.0/v1.1 fix pr:#12

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -223,37 +223,16 @@
     .div-dropdown-item:hover { background: #2a2d3a; }
     .div-dropdown-item.selected { color: #4a9eff; }
     #timeFilter {
-      display: none; gap: 6px; padding: 0 24px 14px; flex-wrap: wrap;
-      position: relative;
+      display: flex; gap: 6px; padding: 0 24px 14px; flex-wrap: wrap;
     }
     .time-btn {
-      padding: 4px 12px; border-radius: 6px; font-size: 12px;
+      padding: 6px 12px; border-radius: 6px; font-size: 12px;
       border: 1px solid #2a2d3a; background: #1a1d27; color: #888;
       cursor: pointer; user-select: none;
     }
     .time-btn:hover { border-color: #4a9eff; color: #ccc; }
     .time-btn.active { background: #1e3a5f; border-color: #4a9eff; color: #4a9eff; }
-
-    .date-range-form {
-      padding: 8px 14px 12px;
-      border-top: 1px solid #2a2d3a;
-      display: flex;
-      flex-direction: column;
-      gap: 5px;
-    }
-    .date-range-form label { font-size: 10px; color: #555; text-transform: uppercase; letter-spacing: 0.4px; }
-    .date-range-form input[type="date"] {
-      background: #131620; border: 1px solid #2a2d3a; border-radius: 4px;
-      color: #ccc; font-size: 12px; padding: 4px 8px; width: 100%;
-      color-scheme: dark;
-    }
-    .date-range-form input[type="date"]:focus { outline: none; border-color: #4a9eff; }
-    .date-range-form .dr-apply {
-      margin-top: 4px; padding: 5px 12px; align-self: flex-end;
-      border-radius: 4px; border: 1px solid #4a9eff;
-      background: none; color: #4a9eff; font-size: 12px; cursor: pointer;
-    }
-    .date-range-form .dr-apply:hover { background: #1e3a5f; }
+    .time-btn:focus-visible { outline: 2px solid #4a9eff; outline-offset: 2px; }
 
     #viewToggle { display: flex; flex-direction: row; gap: 8px; width: 100%; }
     .view-btn {
@@ -1108,13 +1087,6 @@
     [data-theme="light"] .chart-summary .s-val { color: #1a1d27; }
     [data-theme="light"] #exportCsvBtn { color: #8a9bb0; border-color: #d0d4dc; }
     [data-theme="light"] #exportCsvBtn:hover { color: #16a34a; border-color: #16a34a; }
-    [data-theme="light"] .date-range-form { border-top-color: #e0e2e8; }
-    [data-theme="light"] .date-range-form input[type="date"] {
-      background: #ffffff;
-      border-color: #c0c4cc;
-      color: #2c3040;
-      color-scheme: light;
-    }
     [data-theme="light"] .match-list-header { border-bottom-color: #e0e2e8; color: #5a6478; }
     [data-theme="light"] .match-row {
       background: #ffffff;
@@ -1310,7 +1282,14 @@
 </div>
 
 
-<div id="timeFilter"></div>
+<div id="timeFilter" role="group" aria-label="Analytics date range">
+  <button class="time-btn" type="button" data-date-preset="1m" aria-pressed="false">Last 1 month</button>
+  <button class="time-btn" type="button" data-date-preset="3m" aria-pressed="false">3 mo</button>
+  <button class="time-btn active" type="button" data-date-preset="6m" aria-pressed="true">6 mo</button>
+  <button class="time-btn" type="button" data-date-preset="1y" aria-pressed="false">1 yr</button>
+  <button class="time-btn" type="button" data-date-preset="3y" aria-pressed="false">3 yr</button>
+  <button class="time-btn" type="button" data-date-preset="all" aria-pressed="false">all time</button>
+</div>
 
 <div id="charts">
   <div class="chart-section">

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -218,8 +218,7 @@ let currentView      = 'ranked'; // 'ranked' | 'all'
 let deselectedMatches = new Set(); // match IDs manually excluded from charts
 let stageOverrides    = {};     // match_id -> stage key -> { included: false, note: string }
 let selectedDiv       = null;     // canonical division key (null = All)
-let selectedYear      = null;     // year filter for charts (null = All Time)
-let selectedDateRange = null;    // custom range { start: 'YYYY-MM-DD', end: 'YYYY-MM-DD' } or null
+let selectedDatePreset = '6m';   // analytics range; resets to six months on dashboard load
 let classificationData = null;  // data from uspsa.org/classification/[memberNumber]
 let classifiersOnly  = false;   // when true, charts show only classifier stage scores
 
@@ -863,87 +862,76 @@ fetchBtn.addEventListener('click', async () => {
   }
 });
 
-// ── Year filter pills ─────────────────────────────────────────────────────────
-// ── Year / date-range filter pill ────────────────────────────────────────────
-function renderYearFilter(years) {
-  const el = document.getElementById('timeFilter');
-  el.innerHTML = '';
-  if (years.length === 0) { el.style.display = 'none'; return; }
-  el.style.display = 'flex';
+// ── Analytics date-range presets ──────────────────────────────────────────────
+const DATE_RANGE_PRESETS = Object.freeze({
+  '1m':  { label: 'Last 1 month', months: 1,  fileTag: 'last 1 month' },
+  '3m':  { label: '3 mo',         months: 3,  fileTag: 'last 3 months' },
+  '6m':  { label: '6 mo',         months: 6,  fileTag: 'last 6 months' },
+  '1y':  { label: '1 yr',         months: 12, fileTag: 'last 1 year' },
+  '3y':  { label: '3 yr',         months: 36, fileTag: 'last 3 years' },
+  'all': { label: 'all time',     months: null, fileTag: 'all time' },
+});
 
-  const isCustom = !!selectedDateRange;
-  const label    = isCustom
-    ? `${selectedDateRange.start} – ${selectedDateRange.end}`
-    : selectedYear || 'All Time';
-
-  const pill = document.createElement('button');
-  pill.className = 'time-btn' + (selectedYear || isCustom ? ' active' : '');
-  pill.textContent = label;
-
-  pill.onclick = (e) => {
-    e.stopPropagation();
-    const existing = el.querySelector('.div-dropdown');
-    if (existing) { existing.remove(); return; }
-
-    const dropdown = document.createElement('div');
-    dropdown.className = 'div-dropdown';
-
-    // Standard year options
-    ['All Time', ...years].forEach(y => {
-      const item = document.createElement('div');
-      item.className = 'div-dropdown-item' +
-        ((y === 'All Time' && !selectedYear && !isCustom) || y === selectedYear ? ' selected' : '');
-      item.textContent = y;
-      item.onclick = (ev) => {
-        ev.stopPropagation();
-        selectedYear = y === 'All Time' ? null : y;
-        selectedDateRange = null;
-        dropdown.remove();
-        renderAll();
-      };
-      dropdown.appendChild(item);
-    });
-
-    // Custom range entry
-    const customItem = document.createElement('div');
-    customItem.className = 'div-dropdown-item' + (isCustom ? ' selected' : '');
-    customItem.textContent = 'Custom Range…';
-    customItem.onclick = (ev) => {
-      ev.stopPropagation();
-      if (dropdown.querySelector('.date-range-form')) return;
-      const form = document.createElement('div');
-      form.className = 'date-range-form';
-      form.innerHTML = `
-        <label>From</label>
-        <input type="date" class="dr-from" value="${selectedDateRange?.start || ''}">
-        <label>To</label>
-        <input type="date" class="dr-to"   value="${selectedDateRange?.end   || ''}">
-        <button class="dr-apply">Apply</button>
-      `;
-      form.addEventListener('click', ev2 => ev2.stopPropagation());
-      form.querySelector('.dr-apply').onclick = () => {
-        const start = form.querySelector('.dr-from').value;
-        const end   = form.querySelector('.dr-to').value;
-        if (start && end && start <= end) {
-          selectedDateRange = { start, end };
-          selectedYear = null;
-          dropdown.remove();
-          renderAll();
-        }
-      };
-      dropdown.appendChild(form);
-    };
-    dropdown.appendChild(customItem);
-
-    el.appendChild(dropdown);
-    setTimeout(() => document.addEventListener('click', function close() {
-      dropdown.remove();
-      document.removeEventListener('click', close);
-    }, { once: true }), 0);
-  };
-
-  el.appendChild(pill);
+function normalizeDateOnly(value) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})(?:$|T)/.exec(String(value || ''));
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(year, month - 1, day);
+  if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) return null;
+  return `${match[1]}-${match[2]}-${match[3]}`;
 }
+
+function localDateOnly(date = new Date()) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function subtractCalendarMonths(dateOnly, months) {
+  const [year, month, day] = dateOnly.split('-').map(Number);
+  const monthIndex = month - 1 - months;
+  const targetYear = year + Math.floor(monthIndex / 12);
+  const targetMonth = ((monthIndex % 12) + 12) % 12;
+  const lastDay = new Date(targetYear, targetMonth + 1, 0).getDate();
+  return localDateOnly(new Date(targetYear, targetMonth, Math.min(day, lastDay)));
+}
+
+function activeDateBounds(referenceDate = new Date()) {
+  const preset = DATE_RANGE_PRESETS[selectedDatePreset] || DATE_RANGE_PRESETS['6m'];
+  if (preset.months == null) return null;
+  const end = localDateOnly(referenceDate);
+  return { start: subtractCalendarMonths(end, preset.months), end };
+}
+
+function filterByActiveDateRange(records, referenceDate = new Date()) {
+  const bounds = activeDateBounds(referenceDate);
+  return records.filter(record => {
+    const date = normalizeDateOnly(record.date);
+    if (!date) return false;
+    return !bounds || (date >= bounds.start && date <= bounds.end);
+  });
+}
+
+function renderDateRangeFilter() {
+  document.querySelectorAll('[data-date-preset]').forEach(button => {
+    const active = button.dataset.datePreset === selectedDatePreset;
+    button.classList.toggle('active', active);
+    button.setAttribute('aria-pressed', String(active));
+  });
+}
+
+document.querySelectorAll('[data-date-preset]').forEach(button => {
+  button.addEventListener('click', () => {
+    if (!DATE_RANGE_PRESETS[button.dataset.datePreset]) return;
+    selectedDatePreset = button.dataset.datePreset;
+    renderDateRangeFilter();
+    renderAll();
+  });
+});
+renderDateRangeFilter();
 
 // ── Render charts + stats ─────────────────────────────────────────────────────
 function setPlacementVisible(visible) {
@@ -958,6 +946,7 @@ function setPlacementVisible(visible) {
 }
 
 function renderAll() {
+  renderDateRangeFilter();
   if (!allResults.length) return;
 
   // Level 2 filter: only chart USPSA/Hit Factor matches (excludes time-scored sports)
@@ -978,8 +967,6 @@ function renderAll() {
     const da = parseDate(a.date), db = parseDate(b.date);
     return (da && db) ? da - db : 0;
   });
-
-  const placeData = sorted.filter(r => r.place != null);
 
   summaryBar.classList.add('visible');
   chartsEl.classList.add('visible');
@@ -1010,19 +997,11 @@ function renderAll() {
     ['chartTimeSummary', 'chartAdjSummary', 'chartPlaceSummary', 'chartClfSummary']
       .forEach(id => { document.getElementById(id).style.display = 'none'; });
     renderClassBox(selectedDiv);
-    renderYearFilter([]);
     return;
   }
 
-  // Validate the time filter against the active division without changing division preference.
-  const years = [...new Set(sorted.map(r => r.date?.slice(0, 4)).filter(Boolean))].sort();
-  if (selectedYear && !years.includes(selectedYear)) selectedYear = null;
-
-  // Filter to selected year/range for stats + charts. Division is applied above.
-  const viewSorted = sorted.filter(r =>
-    (!selectedYear      || r.date?.startsWith(selectedYear)) &&
-    (!selectedDateRange || (r.date >= selectedDateRange.start && r.date <= selectedDateRange.end))
-  );
+  // Apply one shared range to stats, every chart, summaries, classifier mode, and CSV export.
+  const viewSorted = filterByActiveDateRange(sorted);
 
   if (viewSorted.length === 0) {
     const msg = selectedDiv
@@ -1048,7 +1027,6 @@ function renderAll() {
     ['chartTimeSummary', 'chartAdjSummary', 'chartPlaceSummary', 'chartClfSummary']
       .forEach(id => { document.getElementById(id).style.display = 'none'; });
     renderClassBox(selectedDiv);
-    renderYearFilter(years);
     return;
   }
 
@@ -1149,9 +1127,6 @@ function renderAll() {
   } else {
     divStatVal.textContent = '—';
   }
-
-  // Year filter pills
-  renderYearFilter(years);
 
   // Official classification stat box (D-GM class from USPSA.org)
   renderClassBox(selectedDiv || (divs.length === 1 ? normalizeDivision(divs[0]) : null));
@@ -2555,7 +2530,7 @@ function exportStageCard(match, stage) {
 
 // ── CSV Export ────────────────────────────────────────────────────────────────
 // Exports chart-visible match data as a flat CSV (one row per stage).
-// Respects the active division / year / custom date-range filter.
+// Respects the active division and date-range preset.
 // Includes USPSA clf_pct when available (official % vs national reference HF).
 function exportChartCSV() {
   const uspsaBase = allResults.filter(r => isChartable(r) && !deselectedMatches.has(r.match_id));
@@ -2566,10 +2541,7 @@ function exportChartCSV() {
     const da = parseDate(a.date), db = parseDate(b.date);
     return (da && db) ? da - db : 0;
   });
-  const viewSorted = sorted.filter(r =>
-    (!selectedYear      || r.date?.startsWith(selectedYear)) &&
-    (!selectedDateRange || (r.date >= selectedDateRange.start && r.date <= selectedDateRange.end))
-  );
+  const viewSorted = filterByActiveDateRange(sorted);
 
   // Flat format: one row per stage (match-level fields repeated).
   // In classifiersOnly mode, only classifier stages are included.
@@ -2629,9 +2601,7 @@ function exportChartCSV() {
   }
 
   const csv      = rows.map(r => r.map(v => `"${String(v).replace(/"/g, '""')}"`).join(',')).join('\n');
-  const dateTag  = selectedDateRange
-    ? `${selectedDateRange.start} to ${selectedDateRange.end}`
-    : selectedYear || 'all time';
+  const dateTag  = (DATE_RANGE_PRESETS[selectedDatePreset] || DATE_RANGE_PRESETS['6m']).fileTag;
   const divisionTag = selectedDiv ? ` ${divisionLabel(selectedDiv)}` : '';
   const filename = (classifiersOnly ? 'hfc_classifiers' : 'hfc_scores') + `${divisionTag} ${dateTag}.csv`;
   const blob     = new Blob([csv], { type: 'text/csv;charset=utf-8;' });


### PR DESCRIPTION
## Summary

Replace the year/custom dropdown with six accessible presets, default analytics to six calendar months, and share one local-date filter across dashboard analytics and CSV export.

## Files Changed

DESIGN.md, README.md, TODO.md, extension/dashboard.html, extension/dashboard.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — node --check extension/dashboard.js; ./build.sh; git diff --check; focused Node date-boundary assertions; pre-commit and pre-push hooks. Browser QA attempted but blocked because no Playwriter tab was approved.

Resolves #31


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 50m and 704,386 tokens on this with the user in an interactive session.