### PR TITLE
GH#30: Add six-month Master Calendar

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -10,6 +10,7 @@ Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter
 - Sections provide their own horizontal gutters: 24–28px on desktop and 16px at widths up to 640px.
 - Charts fill their section width and redraw from their rendered width after a browser resize.
 - Summary cards and controls wrap rather than forcing page-level horizontal scrolling.
+- At narrow widths, Match History rows wrap metadata and keep refresh, export, and delete actions visibly keyboard-accessible.
 - Wide layouts should use the available charting space; constrain individual text or control elements only when readability requires it.
 - Stage tables may scroll within their existing panel on narrow screens, but the page itself must not acquire unintended horizontal overflow.
 
@@ -26,3 +27,11 @@ Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter
 - Activate **6 mo** on every dashboard load. Exactly one preset must expose a visible active state and `aria-pressed="true"`.
 - Use compact native buttons with a clear keyboard focus ring. The group wraps at narrow widths rather than becoming a dropdown or creating horizontal page overflow.
 - Date-range changes update the existing cached analytics immediately. They do not hide or delete older Match History records.
+
+## Master Calendar
+
+- Show exactly six chronological calendar-month blocks: the current month and the previous five months. Keep this window independent from the graph date preset.
+- Use three columns on wide screens, two on medium screens, and one at widths up to 640px. Day cells and match entries must remain inside their month block without page-level overflow.
+- Display the match name plus division and score when space allows. Preserve the full date, identity, division, and score in each entry's accessible name.
+- Calendar entries are native buttons that move keyboard focus to the corresponding Match History row. The destination receives a short, restrained highlight.
+- Empty months retain their complete calendar grid. If the whole window is empty, state that clearly without hiding the month blocks.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A Chrome extension that pulls your USPSA match results from PractiScore and disp
 - **Match type detection** — identifies USPSA, IDPA, IPSC, Steel Challenge, 3-Gun, PCSL, ICORE matches; non-USPSA matches are shown in history but excluded from charts
 - **Filter matches** — checkboxes let you include or exclude individual matches from charts without deleting them
 - **Readable date ranges** — charts default to six months with one-click presets for one month, three months, six months, one year, three years, and all time
+- **Master Calendar** — scan the current month and previous five months at a glance, then jump from any recent match directly to its Match History row
 - **Export as image** — save any match or individual stage as a PNG card (floppy-disk button on each match row)
 - **Export as CSV** — download all chart-visible data as a flat CSV (one row per stage) including CM numbers, USPSA %, HF, hit counts, adjusted %, and the selected reference division, class, HF, normalized HF, and benchmark method
 - **Light/dark theme** — defaults to light mode; toggle in the header; preference syncs across devices via Chrome storage
@@ -120,6 +121,10 @@ Summaries appear automatically once enough data is loaded. Classifier trend requ
 ### Filtering by date
 
 Analytics open on the most recent **6 mo** so trends stay readable. Use the buttons above the charts to switch to **Last 1 month**, **3 mo**, **6 mo**, **1 yr**, **3 yr**, or **all time**. The active range applies to every chart, summary statistic, classifier-only view, and chart CSV export without re-fetching or deleting older Match History records.
+
+### Using the Master Calendar
+
+The **Master Calendar** always shows six chronological month blocks: the current month and the previous five months. It follows the current division, view, and match selections but stays independent from the graph date preset. Select any calendar entry to jump to that match in Match History; older records remain cached and available there.
 
 ### Exporting data
 

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -234,6 +234,104 @@
     .time-btn.active { background: #1e3a5f; border-color: #4a9eff; color: #4a9eff; }
     .time-btn:focus-visible { outline: 2px solid #4a9eff; outline-offset: 2px; }
 
+    /* ── Master Calendar ── */
+    #masterCalendar {
+      display: none;
+      padding: 24px 28px;
+      border-top: 1px solid #252838;
+    }
+    #masterCalendar.visible { display: block; }
+    .calendar-header {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 16px;
+      margin-bottom: 16px;
+    }
+    .calendar-header h2 {
+      font-size: 13px;
+      font-weight: 600;
+      color: #888;
+      text-transform: uppercase;
+      letter-spacing: 0.8px;
+    }
+    #calendarStatus { color: #666; font-size: 12px; text-align: right; }
+    #calendarMonths {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 16px;
+    }
+    .calendar-month {
+      min-width: 0;
+      overflow: hidden;
+      border: 1px solid #252838;
+      border-radius: 8px;
+      background: #131620;
+    }
+    .calendar-month h3 {
+      padding: 10px 12px;
+      border-bottom: 1px solid #252838;
+      color: #aeb8c8;
+      font-size: 13px;
+      font-weight: 600;
+    }
+    .calendar-weekdays,
+    .calendar-days { display: grid; grid-template-columns: repeat(7, minmax(0, 1fr)); }
+    .calendar-weekdays span {
+      padding: 6px 2px;
+      color: #555;
+      font-size: 9px;
+      font-weight: 600;
+      text-align: center;
+      text-transform: uppercase;
+    }
+    .calendar-day {
+      min-width: 0;
+      min-height: 82px;
+      padding: 5px;
+      border-top: 1px solid #202330;
+      border-right: 1px solid #202330;
+      background: #10131b;
+    }
+    .calendar-day:nth-child(7n) { border-right: 0; }
+    .calendar-day.empty { background: #0f1117; }
+    .calendar-day.today { background: #131d2d; }
+    .calendar-day-number {
+      display: block;
+      margin-bottom: 4px;
+      color: #667085;
+      font-size: 10px;
+      line-height: 1;
+    }
+    .calendar-day.today .calendar-day-number { color: #4a9eff; font-weight: 700; }
+    .calendar-entry {
+      display: block;
+      width: 100%;
+      margin-top: 4px;
+      padding: 5px 6px;
+      overflow: hidden;
+      border: 0;
+      border-left: 2px solid #4a9eff;
+      border-radius: 3px;
+      background: #1a2435;
+      color: #d6dfed;
+      cursor: pointer;
+      font: inherit;
+      text-align: left;
+    }
+    .calendar-entry:hover { background: #21324a; }
+    .calendar-entry:focus-visible { outline: 2px solid #4a9eff; outline-offset: -1px; }
+    .calendar-entry-name,
+    .calendar-entry-meta {
+      display: block;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .calendar-entry-name { font-size: 10px; font-weight: 600; }
+    .calendar-entry-meta { margin-top: 2px; color: #91a0b5; font-size: 9px; }
+    .match-row.calendar-target { border-color: #4a9eff; box-shadow: 0 0 0 2px rgba(74,158,255,0.18); }
+
     #viewToggle { display: flex; flex-direction: row; gap: 8px; width: 100%; }
     .view-btn {
       padding: 7px 18px;
@@ -989,6 +1087,10 @@
     .match-row:focus-within .delete-btn { opacity: 1; }
 
     /* ── Responsive layout ── */
+    @media (min-width: 641px) and (max-width: 1200px) {
+      #calendarMonths { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    }
+
     @media (max-width: 640px) {
       header,
       .controls { padding-left: 16px; padding-right: 16px; }
@@ -997,10 +1099,23 @@
       .summary-bar { padding-left: 16px; padding-right: 16px; }
       #stats { gap: 10px; }
       #timeFilter { padding-left: 16px; padding-right: 16px; }
+      #masterCalendar { padding: 20px 16px; }
+      .calendar-header { align-items: flex-start; flex-direction: column; gap: 4px; }
+      #calendarStatus { text-align: left; }
+      #calendarMonths { grid-template-columns: minmax(0, 1fr); gap: 12px; }
+      .calendar-day { min-height: 64px; padding: 3px; }
+      .calendar-entry { padding: 4px; }
+      .calendar-entry-meta { display: none; }
       .chart-section { padding: 20px 16px; }
       .chart-section-header { align-items: flex-start; flex-wrap: wrap; gap: 8px; }
       #matchHistory { margin-left: 16px; margin-right: 16px; }
-      .match-row { gap: 8px; padding: 10px 12px; }
+      .match-row { flex-wrap: wrap; gap: 6px; padding: 10px 12px; }
+      .match-info { flex: 1 1 calc(100% - 55px); }
+      .match-type-badge { display: none; }
+      .match-score { margin-left: 29px; font-size: 12px; }
+      .refresh-btn,
+      .export-btn,
+      .delete-btn { opacity: 1; }
     }
 
     /* ── CSS variables: chart primitives (read by CHART_BG/GRID_COLOR etc. in JS) ── */
@@ -1074,6 +1189,18 @@
       color: #4a5060;
     }
     [data-theme="light"] .time-btn.active { background: #dbeafe; border-color: #2563eb; color: #2563eb; }
+    [data-theme="light"] #masterCalendar { border-top-color: #e0e2e8; }
+    [data-theme="light"] #calendarStatus { color: #5a6478; }
+    [data-theme="light"] .calendar-month { background: #ffffff; border-color: #d8dce6; }
+    [data-theme="light"] .calendar-month h3 { color: #2c3040; border-bottom-color: #d8dce6; }
+    [data-theme="light"] .calendar-weekdays span { color: #7b8495; }
+    [data-theme="light"] .calendar-day { background: #ffffff; border-color: #e6e8ed; }
+    [data-theme="light"] .calendar-day.empty { background: #f6f7f9; }
+    [data-theme="light"] .calendar-day.today { background: #eff6ff; }
+    [data-theme="light"] .calendar-day-number { color: #7b8495; }
+    [data-theme="light"] .calendar-entry { background: #e9f2ff; color: #1f3658; }
+    [data-theme="light"] .calendar-entry:hover { background: #dbeafe; }
+    [data-theme="light"] .calendar-entry-meta { color: #52647d; }
     [data-theme="light"] .view-btn { background: #f0f1f4; border-color: #c0c4cc; color: #4a5060; }
     [data-theme="light"] .view-btn:hover { color: #1a1d27; border-color: #8a9bb0; }
     [data-theme="light"] .view-btn.active { background: #2563eb; border-color: #2563eb; color: #fff; }
@@ -1281,6 +1408,13 @@
   </div>
 </div>
 
+<section id="masterCalendar" aria-labelledby="masterCalendarTitle">
+  <div class="calendar-header">
+    <h2 id="masterCalendarTitle">Master Calendar</h2>
+    <p id="calendarStatus" role="status"></p>
+  </div>
+  <div id="calendarMonths"></div>
+</section>
 
 <div id="timeFilter" role="group" aria-label="Analytics date range">
   <button class="time-btn" type="button" data-date-preset="1m" aria-pressed="false">Last 1 month</button>

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -43,6 +43,9 @@ const chartsEl     = document.getElementById('charts');
 const debugLogEl   = document.getElementById('debugLog');
 const matchHistory = document.getElementById('matchHistory');
 const matchRowsEl  = document.getElementById('matchRows');
+const masterCalendar = document.getElementById('masterCalendar');
+const calendarMonthsEl = document.getElementById('calendarMonths');
+const calendarStatusEl = document.getElementById('calendarStatus');
 const tooltipEl    = document.getElementById('tooltip');
 
 // ── Update check ─────────────────────────────────────────────────────────────
@@ -915,6 +918,147 @@ function filterByActiveDateRange(records, referenceDate = new Date()) {
   });
 }
 
+function calendarMonthStarts(referenceDate = new Date()) {
+  const currentMonth = new Date(referenceDate.getFullYear(), referenceDate.getMonth(), 1);
+  return Array.from({ length: 6 }, (_, index) =>
+    new Date(currentMonth.getFullYear(), currentMonth.getMonth() - (5 - index), 1)
+  );
+}
+
+function calendarWindow(records, referenceDate = new Date()) {
+  const months = calendarMonthStarts(referenceDate);
+  const start = localDateOnly(months[0]);
+  const end = localDateOnly(referenceDate);
+  const matchesByDate = new Map();
+  let invalidDateCount = 0;
+
+  for (const match of records) {
+    const date = normalizeDateOnly(match.date);
+    if (!date) {
+      invalidDateCount++;
+      continue;
+    }
+    if (date < start || date > end) continue;
+    if (!matchesByDate.has(date)) matchesByDate.set(date, []);
+    matchesByDate.get(date).push(match);
+  }
+
+  return { months, start, end, matchesByDate, invalidDateCount };
+}
+
+function focusMatchHistory(matchId) {
+  const row = [...document.querySelectorAll('.match-row')]
+    .find(candidate => candidate.dataset.matchId === String(matchId));
+  if (!row) return;
+  row.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  row.focus({ preventScroll: true });
+  row.classList.add('calendar-target');
+  window.setTimeout(() => row.classList.remove('calendar-target'), 1800);
+}
+
+function renderMasterCalendar(records, referenceDate = new Date()) {
+  masterCalendar.classList.add('visible');
+  calendarMonthsEl.innerHTML = '';
+
+  const { months, end, matchesByDate, invalidDateCount } = calendarWindow(records, referenceDate);
+
+  const monthFormatter = new Intl.DateTimeFormat(undefined, { month: 'long', year: 'numeric' });
+  const dateFormatter = new Intl.DateTimeFormat(undefined, { month: 'long', day: 'numeric', year: 'numeric' });
+  const weekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+  let visibleCount = 0;
+
+  for (const monthStart of months) {
+    const year = monthStart.getFullYear();
+    const month = monthStart.getMonth();
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+    const block = document.createElement('section');
+    block.className = 'calendar-month';
+    block.setAttribute('aria-label', monthFormatter.format(monthStart));
+
+    const heading = document.createElement('h3');
+    heading.textContent = monthFormatter.format(monthStart);
+    block.appendChild(heading);
+
+    const weekdayRow = document.createElement('div');
+    weekdayRow.className = 'calendar-weekdays';
+    weekdayRow.setAttribute('aria-hidden', 'true');
+    for (const weekday of weekdays) {
+      const label = document.createElement('span');
+      label.textContent = weekday;
+      weekdayRow.appendChild(label);
+    }
+    block.appendChild(weekdayRow);
+
+    const days = document.createElement('div');
+    days.className = 'calendar-days';
+    for (let blank = 0; blank < monthStart.getDay(); blank++) {
+      const spacer = document.createElement('div');
+      spacer.className = 'calendar-day empty';
+      spacer.setAttribute('aria-hidden', 'true');
+      days.appendChild(spacer);
+    }
+
+    for (let day = 1; day <= daysInMonth; day++) {
+      const dateObject = new Date(year, month, day);
+      const date = localDateOnly(dateObject);
+      const cell = document.createElement('div');
+      cell.className = 'calendar-day' + (date === end ? ' today' : '');
+
+      const dayNumber = document.createElement('span');
+      dayNumber.className = 'calendar-day-number';
+      dayNumber.textContent = String(day);
+      cell.appendChild(dayNumber);
+
+      for (const match of matchesByDate.get(date) || []) {
+        visibleCount++;
+        const name = match.match_name || 'Untitled match';
+        const division = divisionLabel(match.division);
+        const score = effectiveOverallPct(match);
+        const scoreText = score != null ? `${score.toFixed(1)}%` : 'No score';
+
+        const entry = document.createElement('button');
+        entry.type = 'button';
+        entry.className = 'calendar-entry';
+        entry.setAttribute('aria-label', `View ${name} in Match History — ${dateFormatter.format(dateObject)}, ${division}, ${scoreText}`);
+        entry.addEventListener('click', () => focusMatchHistory(match.match_id));
+
+        const nameEl = document.createElement('span');
+        nameEl.className = 'calendar-entry-name';
+        nameEl.textContent = name;
+        entry.appendChild(nameEl);
+
+        const metaEl = document.createElement('span');
+        metaEl.className = 'calendar-entry-meta';
+        metaEl.textContent = `${division} · ${scoreText}`;
+        entry.appendChild(metaEl);
+        cell.appendChild(entry);
+      }
+
+      days.appendChild(cell);
+    }
+
+    const renderedCellCount = monthStart.getDay() + daysInMonth;
+    for (let blank = renderedCellCount; blank % 7 !== 0; blank++) {
+      const spacer = document.createElement('div');
+      spacer.className = 'calendar-day empty';
+      spacer.setAttribute('aria-hidden', 'true');
+      days.appendChild(spacer);
+    }
+
+    block.appendChild(days);
+    calendarMonthsEl.appendChild(block);
+  }
+
+  const rangeLabel = `${monthFormatter.format(months[0])}–${monthFormatter.format(months[5])}`;
+  const matchLabel = visibleCount
+    ? `${visibleCount} match${visibleCount === 1 ? '' : 'es'} · ${rangeLabel}`
+    : `No chartable matches · ${rangeLabel}`;
+  const invalidLabel = invalidDateCount
+    ? ` · ${invalidDateCount} record${invalidDateCount === 1 ? '' : 's'} without a valid date omitted`
+    : '';
+  calendarStatusEl.textContent = matchLabel + invalidLabel;
+}
+
 function renderDateRangeFilter() {
   document.querySelectorAll('[data-date-preset]').forEach(button => {
     const active = button.dataset.datePreset === selectedDatePreset;
@@ -947,7 +1091,10 @@ function setPlacementVisible(visible) {
 
 function renderAll() {
   renderDateRangeFilter();
-  if (!allResults.length) return;
+  if (!allResults.length) {
+    masterCalendar.classList.remove('visible');
+    return;
+  }
 
   // Level 2 filter: only chart USPSA/Hit Factor matches (excludes time-scored sports)
   // Also exclude matches the user has manually deselected
@@ -967,6 +1114,7 @@ function renderAll() {
     const da = parseDate(a.date), db = parseDate(b.date);
     return (da && db) ? da - db : 0;
   });
+  renderMasterCalendar(sorted);
 
   summaryBar.classList.add('visible');
   chartsEl.classList.add('visible');
@@ -1724,6 +1872,7 @@ function renderMatchList() {
     const row = document.createElement('div');
     row.className = 'match-row';
     row.dataset.matchId = match.match_id;
+    row.tabIndex = -1;
     // Build row using DOM methods for untrusted text (match_name, matchType) to prevent XSS (F1)
     row.innerHTML = `
       <input type="checkbox" class="match-include-cb" title="Include in charts"


### PR DESCRIPTION
## Summary

Add a responsive six-month Master Calendar with accessible Match History links, independent graph presets, complete empty-month grids, and non-destructive cached data behavior.

## Files Changed

DESIGN.md, README.md, extension/dashboard.html, extension/dashboard.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — node --check extension/dashboard.js; ./build.sh; git diff --check; focused Node calendar boundary assertions; Playwright extension QA at 1920/1024/375 widths in light and dark themes, including accessible labels, Match History focus, graph-range independence, zero horizontal overflow, and zero console errors; pre-commit and pre-push hooks.

Resolves #30


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 1h 5m and 944,447 tokens on this with the user in an interactive session.