### PR TITLE
chore: release v1.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes are documented here. Update this file before pub
 
 ## Unreleased
 
+## v1.6.5 — 2026-08-26
+
 ### Added
 
 - Six immediately visible graph range presets now cover the last month, three months, six months, one year, three years, and all time. Analytics default to six months while older cached matches remain available.

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hit Factor Charts",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "Track your USPSA match performance: division %, adjusted field-strength scores, classifier trends, and placement over time.",
   "permissions": ["tabs", "scripting", "storage"],
   "host_permissions": ["https://practiscore.com/*", "https://s3.amazonaws.com/*", "https://api.github.com/*", "https://uspsa.org/*", "https://objects.githubusercontent.com/*"],


### PR DESCRIPTION
## Summary

- promote the reviewed Unreleased notes to v1.6.5
- bump the Chrome extension manifest from 1.6.4 to 1.6.5
- trigger the repository release workflow after merge

## Verification

- `node --check extension/dashboard.js`
- `python3 -m json.tool extension/manifest.json`
- `./build.sh` produced `dist/hitfactorcharts-v1.6.5.zip`
- verified the release workflow regex extracts the complete v1.6.5 changelog section
- `git diff --check`
- repository pre-commit and pre-push quality gates

This release includes the reviewed work from PRs #33, #34, #36, and #37.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 1h 14m and 1,072,004 tokens on this with the user in an interactive session.