### PR TITLE
GH#28: Define stable trend thresholds and safe chart labels

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -21,6 +21,13 @@ Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter
 - Keep motion restrained in this analytical interface; resizing and filtering should feel immediate rather than animated.
 - Verify layout changes in both themes at approximately 375px, 1920px, and 2560px viewport widths.
 
+## Chart language and axes
+
+- Trend summaries must state their comparison and use percentage-point units. When labelled **Stable**, show the metric-specific threshold in visible supporting text.
+- Date ticks use measured text width and a minimum 10px gap. Keep the final date only when it does not collide with the preceding retained label.
+- Suppress duplicate date labels while preserving distinct same-day data points and tooltips.
+- Axis labels must remain inside the canvas and readable in both themes at narrow, desktop, and wide widths.
+
 ## Analytics date range
 
 - Keep all six presets immediately visible above the charts in this order: **Last 1 month**, **3 mo**, **6 mo**, **1 yr**, **3 yr**, and **all time**.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -25,7 +25,7 @@ Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter
 
 - Trend summaries must state their comparison and use percentage-point units. When labelled **Stable**, show the metric-specific threshold in visible supporting text.
 - Date ticks use measured text width and a minimum 10px gap. Keep the final date only when it does not collide with the preceding retained label.
-- Suppress duplicate date labels while preserving distinct same-day data points and tooltips.
+- Suppress labels for duplicate source dates while preserving distinct same-day data points and tooltips. If different years share the same month and day, include the year so useful dates remain distinguishable.
 - Axis labels must remain inside the canvas and readable in both themes at narrow, desktop, and wide widths.
 
 ## Analytics date range

--- a/README.md
+++ b/README.md
@@ -111,10 +111,10 @@ Use the **All Divisions** dropdown before the USPSA member-number field to focus
 
 Below the Score Over Time and Placement charts, plain-English summaries show:
 
-- **Score trend** — your last 3 matches averaged vs your prior baseline, with direction
+- **Score trend** — your last 3 matches averaged vs your prior baseline; **Stable** means the change is within ±1.0 percentage point
 - **Adjusted % context** — whether your adjusted average runs above or below your raw division average, and what that means about field strength
-- **Placement** — your average finishing percentile in your division, with trend
-- **Classifier trend** — your recent classifier average vs prior, using the national HHF reference (the only stage-level metric that is directly comparable across different matches and courses)
+- **Placement** — your average finishing percentile in your division, with recent-vs-prior changes measured in percentage points; **Stable** means within ±1.0 point
+- **Classifier trend** — your recent classifier average vs prior; **Stable** means within ±1.5 points, using the national HHF reference (the only stage-level metric that is directly comparable across different matches and courses)
 
 Summaries appear automatically once enough data is loaded. Classifier trend requires at least 6 classifier stages.
 

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -442,7 +442,7 @@
     .chart-summary .s-up   { color: #4caf50; font-weight: 600; }
     .chart-summary .s-down { color: #ff6b6b; font-weight: 600; }
     .chart-summary .s-flat { color: #888;    font-weight: 500; }
-    .chart-summary .s-note { font-size: 11px; opacity: 0.6; }
+    .chart-summary .s-note { font-size: 12px; color: #aab3c2; }
 
     /* ── Chart explanatory note ── */
     .chart-note {
@@ -1212,6 +1212,7 @@
     [data-theme="light"] .chart-summary { color: #5a6478; border-top-color: #d8dce6; }
     [data-theme="light"] .chart-summary--adj { border-top-color: #e0e2e8; }
     [data-theme="light"] .chart-summary .s-val { color: #1a1d27; }
+    [data-theme="light"] .chart-summary .s-note { color: #4f596b; }
     [data-theme="light"] #exportCsvBtn { color: #8a9bb0; border-color: #d0d4dc; }
     [data-theme="light"] #exportCsvBtn:hover { color: #16a34a; border-color: #16a34a; }
     [data-theme="light"] .match-list-header { border-bottom-color: #e0e2e8; color: #5a6478; }

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -1674,11 +1674,13 @@ function _avg(arr) {
   return arr.length ? arr.reduce((s, v) => s + v, 0) / arr.length : 0;
 }
 
-// Trend label HTML for a delta value, with a ±threshold for "stable".
+// Trend label HTML for a percentage-point delta, with an inclusive ±threshold for "stable".
 function _trendLabel(delta, threshold = 1.0) {
   if (delta >  threshold) return `<span class="s-up">↑ improving</span>`;
   if (delta < -threshold) return `<span class="s-down">↓ declining</span>`;
-  return `<span class="s-flat">→ stable</span>`;
+  const unit = threshold === 1 ? 'percentage point' : 'percentage points';
+  return `<span class="s-flat">→ stable</span> ` +
+    `<span class="s-note">(within ±${threshold.toFixed(1)} ${unit} of baseline)</span>`;
 }
 
 function generateSummaries(viewSorted) {
@@ -1701,7 +1703,7 @@ function generateSummaries(viewSorted) {
       scoreEl.innerHTML =
         `Last 3 matches: <span class="s-val">${recentAvg.toFixed(1)}%</span> ` +
         `vs prior baseline <span class="s-val">${priorAvg.toFixed(1)}%</span> ` +
-        `— ${sign}${delta.toFixed(1)}% ${_trendLabel(delta)}`;
+        `— ${sign}${delta.toFixed(1)} pp ${_trendLabel(delta)}`;
       scoreEl.style.display = '';
     } else {
       scoreEl.style.display = 'none';
@@ -1751,10 +1753,13 @@ function generateSummaries(viewSorted) {
       let trendStr    = '';
       if (placeData.length >= 4) {
         // Lower percentile ratio = higher in the field = better
-        const recentPct = _avg(pcts.slice(-3));
-        const priorPct  = _avg(pcts.slice(0, -3));
-        const delta     = recentPct - priorPct; // negative = moved up = improving
-        trendStr        = ' ' + _trendLabel(-delta); // flip sign: lower ratio is better
+        const recentPct = _avg(pcts.slice(-3)) * 100;
+        const priorPct  = _avg(pcts.slice(0, -3)) * 100;
+        const delta     = priorPct - recentPct; // positive = moved up = improving
+        const sign      = delta >= 0 ? '+' : '';
+        trendStr        = ` Recent: top <span class="s-val">${recentPct.toFixed(1)}%</span> ` +
+          `vs prior top <span class="s-val">${priorPct.toFixed(1)}%</span> ` +
+          `— ${sign}${delta.toFixed(1)} pp ${_trendLabel(delta)}.`;
       }
       placeEl.innerHTML =
         `Finishing in the top <span class="s-val">${topPct}%</span> of your division on average.${trendStr}`;
@@ -1785,7 +1790,7 @@ function generateSummaries(viewSorted) {
       clfEl.innerHTML =
         `Last ${N} classifiers: <span class="s-val">${recentAvg.toFixed(1)}%</span> ` +
         `vs prior <span class="s-val">${priorAvg.toFixed(1)}%</span> ` +
-        `— ${sign}${delta.toFixed(1)}% ${_trendLabel(delta, 1.5)} ` +
+        `— ${sign}${delta.toFixed(1)} pp ${_trendLabel(delta, 1.5)} ` +
         `<span class="s-note">(national HHF reference — directly comparable across matches)</span>`;
       clfEl.style.display = '';
     } else if (clfStages.length >= 2) {
@@ -2783,6 +2788,44 @@ function formatAge(ts) {
 const PAD        = { top: 24, right: 52, bottom: 44, left: 48 };
 const FONT       = '11px Inter, system-ui, sans-serif';
 
+function selectAxisTickIndices(labels, positions, measureText, minGap = 10) {
+  if (!labels.length || labels.length !== positions.length) return [];
+
+  const widths = labels.map(label => measureText(label));
+  const selected = [0];
+  const selectedLabels = new Set([labels[0]]);
+  let lastRight = positions[0] + widths[0] / 2;
+
+  for (let index = 1; index < labels.length - 1; index++) {
+    if (selectedLabels.has(labels[index])) continue;
+    const left = positions[index] - widths[index] / 2;
+    if (left < lastRight + minGap) continue;
+    selected.push(index);
+    selectedLabels.add(labels[index]);
+    lastRight = positions[index] + widths[index] / 2;
+  }
+
+  if (labels.length === 1) return selected;
+
+  const finalIndex = labels.length - 1;
+  const finalLeft = positions[finalIndex] - widths[finalIndex] / 2;
+  while (selected.length > 1) {
+    const priorIndex = selected[selected.length - 1];
+    const priorRight = positions[priorIndex] + widths[priorIndex] / 2;
+    if (finalLeft >= priorRight + minGap) break;
+    selected.pop();
+    selectedLabels.delete(labels[priorIndex]);
+  }
+
+  const firstRight = positions[selected[0]] + widths[selected[0]] / 2;
+  if (!selectedLabels.has(labels[finalIndex]) &&
+      finalLeft >= firstRight + minGap) {
+    selected.push(finalIndex);
+  }
+
+  return selected;
+}
+
 // Read CSS custom properties for canvas drawing (canvas doesn't support var())
 function cssVar(name) {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
@@ -2952,11 +2995,12 @@ function drawMultiSeriesChart(canvas, seriesArr, allDates, opts = {}) {
   ctx.fillText(yLabel, 0, 0); ctx.restore();
 
   // X date labels
-  const step = Math.ceil(allDates.length / 8);
   ctx.fillStyle = TEXT_COLOR(); ctx.font = FONT; ctx.textAlign = 'center';
-  allDates.forEach((d, i) => {
-    if (i % step !== 0 && i !== allDates.length - 1) return;
-    ctx.fillText(d.substring(5), dateToCanvasX(d), area.y0 + area.h + 14); // MM-DD
+  const dateLabels = allDates.map(date => date.substring(5));
+  const datePositions = allDates.map(dateToCanvasX);
+  selectAxisTickIndices(dateLabels, datePositions, label => ctx.measureText(label).width)
+    .forEach(index => {
+      ctx.fillText(dateLabels[index], datePositions[index], area.y0 + area.h + 14);
   });
 
   // Legend (if multiple series)
@@ -3184,12 +3228,12 @@ function drawLineChart(canvas, points, opts = {}) {
   });
 
   // X labels (MM-DD)
-  const step = Math.ceil(points.length / 8);
   ctx.fillStyle = TEXT_COLOR(); ctx.font = FONT; ctx.textAlign = 'center';
-  points.forEach((p, i) => {
-    if (i % step !== 0 && i !== points.length - 1) return;
-    const lbl = p.date ? p.date.substring(5) : `#${i+1}`;
-    ctx.fillText(lbl, toX(i), area.y0 + area.h + 14);
+  const pointLabels = points.map((point, index) => point.date ? point.date.substring(5) : `#${index + 1}`);
+  const pointPositions = points.map((_, index) => toX(index));
+  selectAxisTickIndices(pointLabels, pointPositions, label => ctx.measureText(label).width)
+    .forEach(index => {
+      ctx.fillText(pointLabels[index], pointPositions[index], area.y0 + area.h + 14);
   });
 
   // Interactive tooltip
@@ -3291,13 +3335,15 @@ function drawStackedBarChart(canvas, bars) {
 
     hitMap.push({ cx, cy: area.y0 + area.h / 2, bar });
 
-    // X label
-    if (n <= 12 || i % Math.ceil(n / 8) === 0 || i === n - 1) {
-      ctx.fillStyle = TEXT_COLOR();
-      ctx.font = FONT;
-      ctx.textAlign = 'center';
-      ctx.fillText(bar.date ? bar.date.substring(5) : `#${i + 1}`, cx, area.y0 + area.h + 14);
-    }
+  });
+
+  // X labels
+  ctx.fillStyle = TEXT_COLOR(); ctx.font = FONT; ctx.textAlign = 'center';
+  const barLabels = bars.map((bar, index) => bar.date ? bar.date.substring(5) : `#${index + 1}`);
+  const barPositions = bars.map((_, index) => area.x0 + gap * index + gap / 2);
+  selectAxisTickIndices(barLabels, barPositions, label => ctx.measureText(label).width)
+    .forEach(index => {
+      ctx.fillText(barLabels[index], barPositions[index], area.y0 + area.h + 14);
   });
 
   // Y axis — 0/25/50/75/100%

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -2826,6 +2826,24 @@ function selectAxisTickIndices(labels, positions, measureText, minGap = 10) {
   return selected;
 }
 
+function formatAxisDateLabels(dates) {
+  const distinctDatesByShortLabel = new Map();
+  dates.forEach(date => {
+    if (!date) return;
+    const shortLabel = date.substring(5);
+    if (!distinctDatesByShortLabel.has(shortLabel)) {
+      distinctDatesByShortLabel.set(shortLabel, new Set());
+    }
+    distinctDatesByShortLabel.get(shortLabel).add(date);
+  });
+
+  return dates.map((date, index) => {
+    if (!date) return `#${index + 1}`;
+    const shortLabel = date.substring(5);
+    return distinctDatesByShortLabel.get(shortLabel).size > 1 ? date : shortLabel;
+  });
+}
+
 // Read CSS custom properties for canvas drawing (canvas doesn't support var())
 function cssVar(name) {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
@@ -2996,7 +3014,7 @@ function drawMultiSeriesChart(canvas, seriesArr, allDates, opts = {}) {
 
   // X date labels
   ctx.fillStyle = TEXT_COLOR(); ctx.font = FONT; ctx.textAlign = 'center';
-  const dateLabels = allDates.map(date => date.substring(5));
+  const dateLabels = formatAxisDateLabels(allDates);
   const datePositions = allDates.map(dateToCanvasX);
   selectAxisTickIndices(dateLabels, datePositions, label => ctx.measureText(label).width)
     .forEach(index => {
@@ -3229,7 +3247,7 @@ function drawLineChart(canvas, points, opts = {}) {
 
   // X labels (MM-DD)
   ctx.fillStyle = TEXT_COLOR(); ctx.font = FONT; ctx.textAlign = 'center';
-  const pointLabels = points.map((point, index) => point.date ? point.date.substring(5) : `#${index + 1}`);
+  const pointLabels = formatAxisDateLabels(points.map(point => point.date));
   const pointPositions = points.map((_, index) => toX(index));
   selectAxisTickIndices(pointLabels, pointPositions, label => ctx.measureText(label).width)
     .forEach(index => {
@@ -3339,7 +3357,7 @@ function drawStackedBarChart(canvas, bars) {
 
   // X labels
   ctx.fillStyle = TEXT_COLOR(); ctx.font = FONT; ctx.textAlign = 'center';
-  const barLabels = bars.map((bar, index) => bar.date ? bar.date.substring(5) : `#${index + 1}`);
+  const barLabels = formatAxisDateLabels(bars.map(bar => bar.date));
   const barPositions = bars.map((_, index) => area.x0 + gap * index + gap / 2);
   selectAxisTickIndices(barLabels, barPositions, label => ctx.measureText(label).width)
     .forEach(index => {


### PR DESCRIPTION
## Summary

- define score, placement, and classifier trend changes in percentage points with visible Stable thresholds
- convert placement ratios to percentage points before trend classification
- select Canvas date ticks by measured width and minimum spacing across line and stacked-bar charts
- suppress duplicate date labels while retaining chart points and tooltips
- document the chart language and axis-spacing contract

## Verification

- `git diff --check`
- `node --check extension/dashboard.js`
- `./build.sh qa28`
- focused Node assertions for ±1.0/±1.5 threshold boundaries and sparse, dense, duplicate-date tick selection
- unpacked-extension browser QA at 375px, 1920px, and 2560px in light and dark themes: no label overlap, horizontal overflow, or console errors; tooltips remained functional

Resolves #28

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 2h 11m and 1,357,494 tokens on this with the user in an interactive session.