### PR TITLE
GH#35: Clarify non-classifier stage trend

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -27,6 +27,8 @@ Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter
 - Date ticks use measured text width and a minimum 10px gap. Keep the final date only when it does not collide with the preceding retained label.
 - Suppress labels for duplicate source dates while preserving distinct same-day data points and tooltips. If different years share the same month and day, include the year so useful dates remain distinguishable.
 - Axis labels must remain inside the canvas and readable in both themes at narrow, desktop, and wide widths.
+- Non-classifier stage percentages are match-relative comparisons with each stage's top shooter. Present them on a linear 0–100% scale without USPSA classification bands, labels, colours, or warped geometry.
+- Keep same-day non-classifier matches as separate chart points and tooltips while rendering their shared date label only once.
 
 ## Analytics date range
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Below the Score Over Time and Placement charts, plain-English summaries show:
 
 Summaries appear automatically once enough data is loaded. Classifier trend requires at least 6 classifier stages.
 
+The **Non-Classifier Stage Trend** averages your included non-classifier stage percentages for each match. Each percentage compares your hit factor with the top shooter on that stage at that match. It uses a linear 0–100% scale and is useful for tracking match-relative performance, but it is not an official USPSA classification percentage and does not use GM/M/A/B/C/D bands.
+
 ### Filtering by date
 
 Analytics open on the most recent **6 mo** so trends stay readable. Use the buttons above the charts to switch to **Last 1 month**, **3 mo**, **6 mo**, **1 yr**, **3 yr**, or **all time**. The active range applies to every chart, summary statistic, classifier-only view, and chart CSV export without re-fetching or deleting older Match History records.

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -443,6 +443,12 @@
     .chart-summary .s-down { color: #ff6b6b; font-weight: 600; }
     .chart-summary .s-flat { color: #888;    font-weight: 500; }
     .chart-summary .s-note { font-size: 12px; color: #aab3c2; }
+    .chart-subtitle {
+      font-size: 12px;
+      color: #aab3c2;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
 
     /* ── Chart explanatory note ── */
     .chart-note {
@@ -1213,6 +1219,7 @@
     [data-theme="light"] .chart-summary--adj { border-top-color: #e0e2e8; }
     [data-theme="light"] .chart-summary .s-val { color: #1a1d27; }
     [data-theme="light"] .chart-summary .s-note { color: #4f596b; }
+    [data-theme="light"] .chart-subtitle { color: #4f596b; }
     [data-theme="light"] #exportCsvBtn { color: #8a9bb0; border-color: #d0d4dc; }
     [data-theme="light"] #exportCsvBtn:hover { color: #16a34a; border-color: #16a34a; }
     [data-theme="light"] .match-list-header { border-bottom-color: #e0e2e8; color: #5a6478; }
@@ -1459,9 +1466,9 @@
   <div class="chart-section" id="chartNonClfSection" style="display:none">
     <div class="chart-section-header">
       <h3>Non-Classifier Stage Trend</h3>
-      <span style="font-size:12px;color:#666;text-transform:uppercase;letter-spacing:0.5px">Avg HF% across non-classifier stages per match</span>
+      <span class="chart-subtitle">Average stage % compared with each match's top shooter — not a USPSA classification</span>
     </div>
-    <canvas id="chartNonClf" height="180"></canvas>
+    <canvas id="chartNonClf" height="220"></canvas>
   </div>
   <div class="chart-section" id="chartClfOverlaySection" style="display:none">
     <div class="chart-section-header">

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -1505,8 +1505,8 @@ function renderAll() {
   }
 
   // ── Non-classifier stage trend ────────────────────────────────────────────
-  // Shows avg HF% across non-classifier stages per match — a stable cross-match
-  // progression signal since classifier stages are one-off courses.
+  // Shows average match-relative stage percentage for non-classifier stages.
+  // Each stage is compared with that match's top shooter, not a national HHF.
   // Only shown when at least 2 matches have non-classifier stage data.
   const nonClfSection = document.getElementById('chartNonClfSection');
   const nonClfPoints = [];
@@ -1523,7 +1523,6 @@ function renderAll() {
       y: avgPct,
       label: r.match_name,
       division: r.division,
-      class_: r.class_,
       stageCount: nonClfStages.length,
     });
   }
@@ -1531,11 +1530,11 @@ function renderAll() {
 
   if (nonClfPoints.length >= 2) {
     nonClfSection.style.display = '';
-    const nonClfSeries = [{ label: 'Non-Clf Avg %', color: '#00bcd4', points: nonClfPoints }];
+    const nonClfSeries = [{ label: 'Avg vs top shooter', color: '#00bcd4', points: nonClfPoints }];
     const nonClfDates  = nonClfPoints.map(p => p.date);
     drawMultiSeriesChart(document.getElementById('chartNonClf'), nonClfSeries, nonClfDates, {
-      yLabel: 'Avg Stage %', yMin: 0, yMax: 100, invertY: false, trend: true, valueUnit: '%',
-      showClassBands: true,
+      yLabel: '% compared with top shooter', yMin: 0, yMax: 100, invertY: false,
+      trend: true, valueUnit: 'top%', preserveDuplicateDates: true,
     });
   } else {
     nonClfSection.style.display = 'none';
@@ -2937,7 +2936,10 @@ function drawMultiSeriesChart(canvas, seriesArr, allDates, opts = {}) {
   const area = chartArea(canvas);
   clearCanvas(ctx, canvas);
 
-  const { yLabel = '', yMin, yMax, invertY = false, trend = false, valueUnit = '%', showClassBands = false } = opts;
+  const {
+    yLabel = '', yMin, yMax, invertY = false, trend = false, valueUnit = '%',
+    showClassBands = false, preserveDuplicateDates = false,
+  } = opts;
 
   const allY   = seriesArr.flatMap(s => s.points.map(p => p.y)).filter(v => v != null);
   const rawMin = yMin != null ? yMin : Math.min(...allY);
@@ -2948,8 +2950,8 @@ function drawMultiSeriesChart(canvas, seriesArr, allDates, opts = {}) {
   // Falls back to null (linear scale) when fewer than two bands are visible.
   const warpMap = showClassBands ? buildWarpMap(rawMin, rawMax) : null;
 
-  const dateToCanvasX = date => {
-    const idx = allDates.indexOf(date);
+  const dateToCanvasX = (date, pointIndex = null) => {
+    const idx = preserveDuplicateDates && pointIndex != null ? pointIndex : allDates.indexOf(date);
     return area.x0 + (idx / Math.max(allDates.length - 1, 1)) * area.w;
   };
   const toY = v => {
@@ -3015,7 +3017,7 @@ function drawMultiSeriesChart(canvas, seriesArr, allDates, opts = {}) {
   // X date labels
   ctx.fillStyle = TEXT_COLOR(); ctx.font = FONT; ctx.textAlign = 'center';
   const dateLabels = formatAxisDateLabels(allDates);
-  const datePositions = allDates.map(dateToCanvasX);
+  const datePositions = allDates.map((date, index) => dateToCanvasX(date, index));
   selectAxisTickIndices(dateLabels, datePositions, label => ctx.measureText(label).width)
     .forEach(index => {
       ctx.fillText(dateLabels[index], datePositions[index], area.y0 + area.h + 14);
@@ -3047,8 +3049,8 @@ function drawMultiSeriesChart(canvas, seriesArr, allDates, opts = {}) {
       const inter = (sy - slope * sx) / n;
       ctx.strokeStyle = 'rgba(255,152,0,0.45)'; ctx.lineWidth = 1.5; ctx.setLineDash([4, 3]);
       ctx.beginPath();
-      ctx.moveTo(dateToCanvasX(pts[0].date),          toY(inter));
-      ctx.lineTo(dateToCanvasX(pts[n - 1].date),      toY(slope * (n - 1) + inter));
+      ctx.moveTo(dateToCanvasX(pts[0].date, 0),          toY(inter));
+      ctx.lineTo(dateToCanvasX(pts[n - 1].date, n - 1), toY(slope * (n - 1) + inter));
       ctx.stroke(); ctx.setLineDash([]);
     }
   }
@@ -3063,14 +3065,14 @@ function drawMultiSeriesChart(canvas, seriesArr, allDates, opts = {}) {
     if (s.dash) ctx.setLineDash([6, 4]);
     ctx.beginPath();
     pts.forEach((p, i) => {
-      const cx = dateToCanvasX(p.date), cy = toY(p.y);
+      const cx = dateToCanvasX(p.date, i), cy = toY(p.y);
       i === 0 ? ctx.moveTo(cx, cy) : ctx.lineTo(cx, cy);
     });
     ctx.stroke();
     if (s.dash) ctx.setLineDash([]);
 
-    pts.forEach(p => {
-      const cx = dateToCanvasX(p.date), cy = toY(p.y);
+    pts.forEach((p, index) => {
+      const cx = dateToCanvasX(p.date, index), cy = toY(p.y);
       ctx.fillStyle = s.color;
       ctx.beginPath(); ctx.arc(cx, cy, s.dash ? 3 : 4, 0, Math.PI * 2); ctx.fill();
       hitMap.push({ cx, cy, color: s.color, seriesLabel: s.label, valueUnit, ...p });
@@ -3119,6 +3121,8 @@ function drawMultiSeriesChart(canvas, seriesArr, allDates, opts = {}) {
             ? `<span style="color:${classBand.text};font-size:10px;margin-left:6px">${classBand.label}</span>` : '';
           const mainVal = unit === '%'
             ? `<div class="tt-score" style="color:${h.color}">${h.y.toFixed(1)}%${classLabel} <span style="font-size:11px;color:#666">(div)</span></div>`
+            : unit === 'top%'
+            ? `<div class="tt-score" style="color:${h.color}">${h.y.toFixed(1)}% <span style="font-size:11px;color:#aab3c2">compared with top shooter</span></div>`
             : unit === 'place%'
             ? `<div class="tt-score" style="color:${h.color}">Place ${h.rawPlace} / ${h.total} <span style="font-size:11px;color:#666">(beat ${h.y.toFixed(1)}% of field)</span></div>`
             : `<div class="tt-score" style="color:${h.color}">Place ${h.y}${h.total ? ' / ' + h.total : ''}</div>`;

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -3088,7 +3088,14 @@ function drawMultiSeriesChart(canvas, seriesArr, allDates, opts = {}) {
       const r  = canvas.getBoundingClientRect();
       const mx = (e.clientX - r.left) * (canvas.width  / r.width);
       const my = (e.clientY - r.top)  * (canvas.height / r.height);
-      const h  = (canvas._hitMap || []).find(h => Math.hypot(h.cx - mx, h.cy - my) < 16);
+      let h = null;
+      let nearestDistance = 16;
+      for (const candidate of canvas._hitMap || []) {
+        const distance = Math.hypot(candidate.cx - mx, candidate.cy - my);
+        if (distance >= nearestDistance) continue;
+        h = candidate;
+        nearestDistance = distance;
+      }
       if (h) {
         const unit = h.valueUnit;
         // Use escHtml for untrusted strings (match names, stage names) in tooltip innerHTML (F1)


### PR DESCRIPTION
## Summary

- render Non-Classifier Stage Trend on a linear 0–100% scale without USPSA class bands or warped geometry
- label the chart, y-axis, and tooltip as percentages compared with each match's top shooter
- keep same-day matches as separate points and tooltips while drawing one shared date tick
- improve subtitle contrast and chart height across responsive layouts
- document the match-relative metric semantics

## Verification

- `git diff --check`
- `node --check extension/dashboard.js`
- `./build.sh qa35`
- focused source assertions for linear rendering options and absence of class-band options
- unpacked-extension browser QA at 375px, 1920px, and 2560px in both themes: linear ticks, no non-classifier class bands, separate same-day points, one shared date label, no overflow, and zero console errors

Resolves #35

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 2h 27m and 1,478,083 tokens on this with the user in an interactive session.