### PR TITLE
GH#40: Remove class bands from regular match scores

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -29,6 +29,8 @@ Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter
 - Axis labels must remain inside the canvas and readable in both themes at narrow, desktop, and wide widths.
 - Non-classifier stage percentages are match-relative comparisons with each stage's top shooter. Present them on a linear 0–100% scale without USPSA classification bands, labels, colours, or warped geometry.
 - Keep same-day non-classifier matches as separate chart points and tooltips while rendering their shared date label only once.
+- Regular Score Over Time uses a linear percentage scale without classification bands, inferred class labels, class colours, or warped geometry. Division % and Adjusted % are match-performance signals, not official classifications.
+- Show GM/M/A/B/C/D context only for nationally normalized `clf_pct` values. Match-relative classifier fallbacks must be identified as such and must not receive inferred class labels.
 
 ## Analytics date range
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A Chrome extension that pulls your USPSA match results from PractiScore and disp
 
 ## Features
 
-- **Score over time** — match percentage plotted chronologically with USPSA classification bands (GM / M / A / B / C / D); Y-axis warped so higher classes get proportional visual space
+- **Score over time** — raw Division % and field-strength Adjusted % plotted chronologically on a readable linear scale
 - **Placement chart** — finish position at each match, normalized to field size
 - **Per-stage breakdown** — expand any match row to see hits, HF, and percentage for every stage; classifier stages show official USPSA % (vs national reference HF) as the primary number; individual stages can be excluded from ratings with an optional note
 - **Division-aware filtering** — automatically detects which division you shot in each match; a persistent selector filters every chart, statistic, classification, history row, and CSV export to one division
@@ -42,7 +42,7 @@ A Chrome extension that pulls your USPSA match results from PractiScore and disp
 
 **Adjusted %** is a field-strength correction for non-classifier stages. For each stage, the extension takes the top hit factor from every represented division, translates each result to your division's equivalent using national HHF ratios from [hitfactor.info](https://hitfactor.info), and uses the strongest normalized result as the reference. Your own division participates without conversion, so the adjusted score remains between 0% and 100% while correcting for divisions with stronger competitors.
 
-A 75% adjusted score means you performed at solid A-class level against the strongest actual stage result at that match after accounting for division equipment differences. Adjusted % is the better indicator of improvement over time because it accounts for the complete match field, not just your division draw. Classifier stages are excluded because official classifier percentages are already normalized against USPSA national division data.
+A 75% adjusted score means your performance was 75% of the strongest normalized stage result at that match after accounting for division equipment differences. Adjusted % is the better indicator of improvement over time because it accounts for the complete match field, not just your division draw. It is still a match-relative estimate, not an official USPSA classification percentage. Classifier stages are excluded because official classifier percentages are already normalized against USPSA national division data; use **Classifiers Only** to see that official class context.
 
 ---
 

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -1450,7 +1450,7 @@
     <div class="chart-note">
       <strong>Division %</strong> is your score relative to the top shooter in your division at that match — it tells you how you placed, but it only reflects who happened to show up in your division that day.
       <strong>Adjusted %</strong> is a field-strength correction: it takes the top stage hit factor from every division at that match, translates each result to your division's equivalent using national HHF ratios from hitfactor.info, and measures you against the strongest normalized result.
-      Adjusted % is the more meaningful number — a 75% adjusted score means you performed at solid A-class level against the strongest actual stage result at that match, regardless of division.
+      Adjusted % is the more meaningful progress indicator because it compares you with the strongest normalized stage result at that match, regardless of division. Neither match metric is an official USPSA classification percentage; use Classifiers Only for nationally normalized classifier context.
     </div>
     <div class="chart-summary" id="chartTimeSummary" style="display:none"></div>
     <div class="chart-summary chart-summary--adj" id="chartAdjSummary" style="display:none"></div>

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -1182,14 +1182,11 @@ function renderAll() {
   const avg  = overallPcts.length ? _avg(overallPcts) : 0;
   const best = overallPcts.length ? Math.max(...overallPcts) : 0;
 
-  const avgBand  = CLASS_BANDS.find(b => avg  >= b.min && avg  < b.max);
-  const bestBand = CLASS_BANDS.find(b => best >= b.min && best < b.max);
-
   document.getElementById('statMatches').textContent = viewSorted.length;
   document.getElementById('statAvg').textContent     = avg.toFixed(1) + '%';
-  document.getElementById('statAvg').style.color     = avgBand?.text.replace('0.55','1') || '#4a9eff';
+  document.getElementById('statAvg').style.color     = '#4a9eff';
   document.getElementById('statBest').textContent    = best.toFixed(1) + '%';
-  document.getElementById('statBest').style.color    = bestBand?.text.replace('0.55','1') || '#4a9eff';
+  document.getElementById('statBest').style.color    = '#4a9eff';
 
   // Stat box tooltips — explain what each metric measures
   const divLabel = selectedDiv ? ` in ${divisionLabel(selectedDiv)}` : '';
@@ -1204,7 +1201,7 @@ function renderAll() {
   document.getElementById('statBestBox').dataset.tip =
     `Your highest single-match score${divLabel}.\n` +
     `Match score = your points ÷ match winner's points × 100.\n` +
-    `Color indicates the USPSA classification band for that score.` + filteredStageTip;
+    `This is match-relative performance, not an official classification percentage.` + filteredStageTip;
 
   // ── Consistency stat card ─────────────────────────────────────────────────
   // Standard deviation of match %. Low stddev = consistent performer.
@@ -1244,18 +1241,17 @@ function renderAll() {
   }
   if (adjMatchPcts.length >= 1) {
     const adjAvg = adjMatchPcts.reduce((s, v) => s + v, 0) / adjMatchPcts.length;
-    const adjBand = CLASS_BANDS.find(b => adjAvg >= b.min && adjAvg < b.max);
     adjAvgVal.textContent = adjAvg.toFixed(1) + '%';
-    adjAvgVal.style.color = adjBand?.text.replace('0.55', '1') || '#ff4081';
+    adjAvgVal.style.color = '#ff4081';
     const adjAvgLbl = adjAvgBox.querySelector('.lbl');
-    if (adjAvgLbl) adjAvgLbl.textContent = adjBand ? `Adj Avg · ${adjBand.label} Class` : 'Adj Avg %';
+    if (adjAvgLbl) adjAvgLbl.textContent = 'Adj Avg %';
     adjAvgBox.dataset.tip =
       `Field-strength adjusted average (${adjMatchPcts.length} match${adjMatchPcts.length > 1 ? 'es' : ''}).\n` +
       `Uses non-classifier stages and the best HF from any division at each match,\n` +
       `normalized to your division using HHF ratios from hitfactor.info.\n` +
       `Classifier stages are skipped because USPSA % is already nationally normalized.\n` +
-      `This gives a more accurate read when no GM/Master is in your division.\n` +
-      `Raw avg: ${avg.toFixed(1)}% → Adjusted: ${adjAvg.toFixed(1)}% (${adjBand?.label || '?'} class)`;
+      `This gives a more accurate read when the division field varies in strength.\n` +
+      `Raw avg: ${avg.toFixed(1)}% → Adjusted: ${adjAvg.toFixed(1)}%. Neither is an official classification percentage.`;
     adjAvgBox.style.display = '';
   } else {
     adjAvgBox.style.display = 'none';
@@ -1335,8 +1331,9 @@ function renderAll() {
     const statPcts     = officialPcts.length ? officialPcts : clfPoints.map(p => p.y);
     const clfAvg  = statPcts.reduce((s, v) => s + v, 0) / statPcts.length;
     const clfBest = Math.max(...statPcts);
-    const avgBandC  = CLASS_BANDS.find(b => clfAvg  >= b.min && clfAvg  < b.max);
-    const bestBandC = CLASS_BANDS.find(b => clfBest >= b.min && clfBest < b.max);
+    const hasOfficialStats = officialPcts.length > 0;
+    const avgBandC  = hasOfficialStats ? CLASS_BANDS.find(b => clfAvg  >= b.min && clfAvg  < b.max) : null;
+    const bestBandC = hasOfficialStats ? CLASS_BANDS.find(b => clfBest >= b.min && clfBest < b.max) : null;
 
     document.getElementById('statMatches').textContent = clfPoints.length;
     document.getElementById('statAvg').textContent  = clfAvg.toFixed(1) + '%';
@@ -1346,15 +1343,17 @@ function renderAll() {
     if (avgLbl) avgLbl.textContent = avgBandC ? `Avg % · ${avgBandC.label} Class` : 'Avg %';
 
     // Classifier-mode tooltips
-    const clfSource = officialPcts.length ? 'official USPSA % vs national HHF' : 'match % vs match top HF';
+    const clfSource = hasOfficialStats ? 'official USPSA % vs national HHF' : 'match % vs match top HF';
     document.getElementById('statAvgBox').dataset.tip =
       `Your average classifier score (${clfSource}),\n` +
       `averaged across all classifier stages in the current view.\n` +
       `USPSA uses your best 6 classifiers to set your classification.`;
     document.getElementById('statBestBox').dataset.tip =
       `Your highest single classifier score (${clfSource}).\n` +
-      `Color indicates the USPSA classification band for that score.\n` +
-      `GM = 95%+, M = 85–95%, A = 75–85%, B = 60–75%, C = 40–60%.`;
+      (hasOfficialStats
+        ? `Color indicates the USPSA classification band for that official score.\n` +
+          `GM = 95%+, M = 85–95%, A = 75–85%, B = 60–75%, C = 40–60%.`
+        : `Match-relative fallback values do not receive an inferred USPSA class.`);
 
     // Build series grouped by division — gives continuous lines over time
     const DIV_PALETTE = ['#4a9eff','#4caf50','#ff9800','#e91e63','#9c27b0','#00bcd4','#ffeb3b','#ff5722'];
@@ -1389,7 +1388,7 @@ function renderAll() {
   // ── Normal mode ──────────────────────────────────────────────────────────────
   document.getElementById('chartTimeTitle').textContent = 'Score Over Time';
   setPlacementVisible(true);
-  if (avgLbl) avgLbl.textContent = avgBand ? `Avg % · ${avgBand.label} Class` : 'Avg %';
+  if (avgLbl) avgLbl.textContent = 'Avg match %';
 
   const DIV_PALETTE = ['#4a9eff','#4caf50','#ff9800','#e91e63','#9c27b0','#00bcd4','#ffeb3b'];
 

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -1370,11 +1370,17 @@ function renderAll() {
 
     const allClfDates = [...new Set(clfPoints.map(p => p.date))].sort();
 
+    const allClassifierScoresOfficial = clfPoints.every(point => point.isOfficial);
     document.getElementById('chartTimeTitle').textContent = 'Classifier Scores Over Time'
-      + (officialPcts.length ? ' (official %)' : ' (match % — log in to USPSA.org for official %)');
+      + (allClassifierScoresOfficial
+        ? ' (official %)'
+        : officialPcts.length
+        ? ' (official and match-relative %)'
+        : ' (match % — log in to USPSA.org for official %)');
     drawMultiSeriesChart(document.getElementById('chartTime'), series, allClfDates, {
-      yLabel: 'Classifier %', yMin: 0, yMax: 100, invertY: false, trend: series.length === 1, valueUnit: '%',
-      showClassBands: true,
+      yLabel: 'Classifier %', yMin: 0, yMax: 100, invertY: false,
+      trend: series.length === 1, valueUnit: 'classifier%',
+      showClassBands: allClassifierScoresOfficial,
     });
     setPlacementVisible(false);
     return;
@@ -1409,16 +1415,16 @@ function renderAll() {
       const avgY = ys.length ? ys.reduce((s, v) => s + v, 0) / ys.length : null;
       if (group.length === 1) {
         const r = group[0];
-        return { date, y: avgY, label: r.match_name, division: r.division, class_: r.class_,
+        return { date, y: avgY, label: r.match_name, division: r.division,
           overall_pct: effectiveOverallPct(r), div_pct: effectiveDivPct(r),
           place: r.div_place ?? r.place, total: r.div_total ?? r.total,
           foundBy: r.found_by, stages: getMetricStages(r) };
       }
       return { date, y: avgY, label: `${group.length} matches`, multiMatch: group.map(r => ({
         label: r.match_name, y: effectiveDivPct(r), overall_pct: effectiveOverallPct(r),
-        division: r.division, class_: r.class_,
+        division: r.division,
         place: r.div_place ?? r.place, total: r.div_total ?? r.total, foundBy: r.found_by,
-      })), division: group[0].division, class_: group[0].class_, overall_pct: avgY };
+      })), division: group[0].division, overall_pct: avgY };
     });
     return { label: div, color: DIV_PALETTE[i % DIV_PALETTE.length], points };
   });
@@ -1434,7 +1440,7 @@ function renderAll() {
     const adjAvg = adjStages.reduce((sum, a) => sum + a.adjPct, 0) / adjStages.length;
     adjPoints.push({
       date: r.date, y: adjAvg, label: r.match_name,
-      division: r.division, class_: classLetterForPct(adjAvg),
+      division: r.division,
       overall_pct: effectiveOverallPct(r),
     });
   }
@@ -1450,8 +1456,8 @@ function renderAll() {
   }
 
   drawMultiSeriesChart(document.getElementById('chartTime'), scoreSeries, allDates, {
-    yLabel: 'Division %', yMin: 0, yMax: 100, invertY: false, trend: scoreSeries.length <= 2, valueUnit: '%',
-    showClassBands: true,
+    yLabel: 'Match performance %', yMin: 0, yMax: 100, invertY: false,
+    trend: scoreSeries.length <= 2, valueUnit: 'match%',
   });
 
   const placeSeries = Object.entries(byDiv).map(([div, matches], i) => {
@@ -3106,6 +3112,10 @@ function drawMultiSeriesChart(canvas, seriesArr, allDates, opts = {}) {
             return `<div class="tt-stage-row"><span class="tt-stage-name">${escHtml(m.label)}</span>`
               + `<span style="color:${c}">${m.y != null ? m.y.toFixed(1) + '%' + (b ? ' ' + b.label : '') : '—'}</span></div>`;
           }
+          if (unit === 'match%') {
+            return `<div class="tt-stage-row"><span class="tt-stage-name">${escHtml(m.label)}</span>`
+              + `<span style="color:#8a9bb0">${m.y != null ? m.y.toFixed(1) + '%' : '—'}</span></div>`;
+          }
           return `<div class="tt-stage-row"><span class="tt-stage-name">${escHtml(m.label)}</span>`
             + `<span style="color:#8a9bb0">${m.rawPlace}/${m.total} (beat ${m.y.toFixed(1)}%)</span></div>`;
         }).join('') : '';
@@ -3115,6 +3125,8 @@ function drawMultiSeriesChart(canvas, seriesArr, allDates, opts = {}) {
           const classLabel = classBand ? ` <span style="color:${classBand.text};font-size:10px">${classBand.label}</span>` : '';
           const avgLine = unit === '%'
             ? `<div class="tt-score" style="color:${h.color}">${h.y.toFixed(1)}%${classLabel} <span style="font-size:11px;color:#666">avg (div)</span></div>`
+            : unit === 'match%'
+            ? `<div class="tt-score" style="color:${h.color}">${h.y.toFixed(1)}% <span style="font-size:11px;color:#aab3c2">average match score</span></div>`
             : `<div class="tt-score" style="color:${h.color}">${h.y.toFixed(1)}% <span style="font-size:11px;color:#666">avg beaten</span></div>`;
           tooltipEl.innerHTML = `
             <div class="tt-name">${escHtml(h.label)}</div>
@@ -3123,11 +3135,16 @@ function drawMultiSeriesChart(canvas, seriesArr, allDates, opts = {}) {
             <div class="tt-stages">${multiMatchRows}</div>
           `;
         } else {
-          const classBand = unit === '%' ? bandForPct(h.y) : null;
+          const hasOfficialClassContext = unit === '%' || (unit === 'classifier%' && h.isOfficial);
+          const classBand = hasOfficialClassContext ? bandForPct(h.y) : null;
           const classLabel = classBand
             ? `<span style="color:${classBand.text};font-size:10px;margin-left:6px">${classBand.label}</span>` : '';
           const mainVal = unit === '%'
             ? `<div class="tt-score" style="color:${h.color}">${h.y.toFixed(1)}%${classLabel} <span style="font-size:11px;color:#666">(div)</span></div>`
+            : unit === 'classifier%'
+            ? `<div class="tt-score" style="color:${h.color}">${h.y.toFixed(1)}%${classLabel} <span style="font-size:11px;color:#aab3c2">${h.isOfficial ? 'official USPSA' : 'match-relative'}</span></div>`
+            : unit === 'match%'
+            ? `<div class="tt-score" style="color:${h.color}">${h.y.toFixed(1)}% <span style="font-size:11px;color:#aab3c2">match performance</span></div>`
             : unit === 'top%'
             ? `<div class="tt-score" style="color:${h.color}">${h.y.toFixed(1)}% <span style="font-size:11px;color:#aab3c2">compared with top shooter</span></div>`
             : unit === 'place%'
@@ -3135,7 +3152,7 @@ function drawMultiSeriesChart(canvas, seriesArr, allDates, opts = {}) {
             : `<div class="tt-score" style="color:${h.color}">Place ${h.y}${h.total ? ' / ' + h.total : ''}</div>`;
           const divLine = (h.division || h.class_)
             ? `<div class="tt-meta">${escHtml([h.division, h.class_].filter(Boolean).join(' / '))}</div>` : '';
-          const overallLine = (unit === '%' && h.overall_pct != null && Math.abs(h.overall_pct - h.y) > 0.1)
+          const overallLine = ((unit === '%' || unit === 'match%') && h.overall_pct != null && Math.abs(h.overall_pct - h.y) > 0.1)
             ? `<div class="tt-meta">${h.overall_pct.toFixed(1)}% overall</div>` : '';
           const pctLine = (unit === '' && h.overall_pct != null)
             ? `<div class="tt-meta">${h.overall_pct.toFixed(1)}% score</div>` : '';


### PR DESCRIPTION
## Summary

- render regular Score Over Time on a linear 0–100% match-performance scale without class bands or inferred class metadata
- keep Division % and Adjusted % series, summaries, tooltips, presets, and export behavior intact
- identify regular tooltips as match performance rather than official classification
- retain class bands and class tooltip context only when Classifiers Only is plotting exclusively official `clf_pct` values
- label fallback classifier values as match-relative and document the semantic split

## Verification

- `git diff --check`
- `node --check extension/dashboard.js`
- `./build.sh qa40`
- focused source assertions for regular/classifier renderer options and metadata
- unpacked-extension browser QA across all six presets at 375px, 1920px, and 2560px in both themes: regular mode had no class bands; official classifier mode retained them; fallback classifier data did not infer a class; no overflow, label collisions, or console errors

Resolves #40

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 2h 42m and 1,518,705 tokens on this with the user in an interactive session.