### PR TITLE
GH#27: Add Adjusted % Only chart mode

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -31,6 +31,8 @@ Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter
 - Keep same-day non-classifier matches as separate chart points and tooltips while rendering their shared date label only once.
 - Regular Score Over Time uses a linear percentage scale without classification bands, inferred class labels, class colours, or warped geometry. Division % and Adjusted % are match-performance signals, not official classifications.
 - Show GM/M/A/B/C/D context only for nationally normalized `clf_pct` values. Match-relative classifier fallbacks must be identified as such and must not receive inferred class labels.
+- Place **Adjusted % Only** beside **Classifiers Only** as matching native-checkbox switches. Both controls expose visible keyboard focus, wrap together at narrow widths, and never create page-level overflow.
+- Adjusted-only and classifiers-only modes are mutually exclusive. Adjusted-only displays cached adjusted points without raw fallback and uses a clear multi-line empty state when fewer than two usable points exist.
 
 ## Analytics date range
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ A Chrome extension that pulls your USPSA match results from PractiScore and disp
 
 A 75% adjusted score means your performance was 75% of the strongest normalized stage result at that match after accounting for division equipment differences. Adjusted % is the better indicator of improvement over time because it accounts for the complete match field, not just your division draw. It is still a match-relative estimate, not an official USPSA classification percentage. Classifier stages are excluded because official classifier percentages are already normalized against USPSA national division data; use **Classifiers Only** to see that official class context.
 
+Use **Adjusted % Only** beside **Classifiers Only** to inspect the adjusted series without raw match percentages. The modes are mutually exclusive because adjusted scores exclude classifier stages. Adjusted-only mode never falls back to raw scores; when fewer than two usable adjusted matches are available, the chart explains that older matches may need to be refreshed to load non-classifier cross-division benchmark data. Switching modes uses cached data and does not fetch or rewrite match history.
+
 ---
 
 ## Requirements

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -383,14 +383,20 @@
       margin-bottom: 0;
     }
 
-    #classifiersToggleWrap {
+    #chartModeToggles {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 14px;
+    }
+    .chart-mode-toggle {
       display: none;
       align-items: center;
       gap: 7px;
       cursor: pointer;
       user-select: none;
     }
-    #classifiersToggleWrap .toggle-lbl {
+    .chart-mode-toggle .toggle-lbl {
       font-size: 12px;
       font-weight: 600;
       color: #888;
@@ -422,9 +428,10 @@
     }
     .toggle-switch input:checked ~ .toggle-track { background: #1e3a5f; }
     .toggle-switch input:checked ~ .toggle-track .toggle-thumb { transform: translateX(14px); background: #4a9eff; }
-    #classifiersToggleWrap:hover .toggle-track { background: #3a3d4a; }
-    #classifiersToggleWrap:hover .toggle-lbl { color: #888; }
-    #classifiersToggleWrap.active .toggle-lbl { color: #4a9eff; }
+    .toggle-switch input:focus-visible ~ .toggle-track { outline: 2px solid #4a9eff; outline-offset: 3px; }
+    .chart-mode-toggle:hover .toggle-track { background: #3a3d4a; }
+    .chart-mode-toggle:hover .toggle-lbl { color: #888; }
+    .chart-mode-toggle.active .toggle-lbl { color: #4a9eff; }
 
     canvas { display: block; width: 100% !important; }
 
@@ -1438,13 +1445,22 @@
     <div class="chart-section-header">
       <h3 id="chartTimeTitle">Score Over Time</h3>
       <button id="exportCsvBtn" title="Export chart data as CSV">⤓ CSV</button>
-      <label id="classifiersToggleWrap">
-        <span class="toggle-lbl">Classifiers Only</span>
-        <span class="toggle-switch">
-          <input type="checkbox" id="classifiersOnlyChk">
-          <span class="toggle-track"><span class="toggle-thumb"></span></span>
-        </span>
-      </label>
+      <div id="chartModeToggles">
+        <label id="classifiersToggleWrap" class="chart-mode-toggle">
+          <span class="toggle-lbl">Classifiers Only</span>
+          <span class="toggle-switch">
+            <input type="checkbox" id="classifiersOnlyChk">
+            <span class="toggle-track"><span class="toggle-thumb"></span></span>
+          </span>
+        </label>
+        <label id="adjustedToggleWrap" class="chart-mode-toggle">
+          <span class="toggle-lbl">Adjusted % Only</span>
+          <span class="toggle-switch">
+            <input type="checkbox" id="adjustedOnlyChk">
+            <span class="toggle-track"><span class="toggle-thumb"></span></span>
+          </span>
+        </label>
+      </div>
     </div>
     <canvas id="chartTime" height="380"></canvas>
     <div class="chart-note">

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -224,6 +224,7 @@ let selectedDiv       = null;     // canonical division key (null = All)
 let selectedDatePreset = '6m';   // analytics range; resets to six months on dashboard load
 let classificationData = null;  // data from uspsa.org/classification/[memberNumber]
 let classifiersOnly  = false;   // when true, charts show only classifier stage scores
+let adjustedOnly     = false;   // when true, Score Over Time shows only adjusted match points
 
 const NON_USPSA_TYPES = new Set(['IDPA', 'IPSC', 'Steel Challenge', '3-Gun', 'PCSL', 'ICORE', 'SCSA']);
 // Confirmed USPSA types — only these count toward the USPSA match total in the status line.
@@ -733,15 +734,36 @@ chrome.storage.local.get(['memberNumber', 'name', 'lastMatchList', 'matchCache',
 function switchView(view) {
   currentView = view;
   document.querySelectorAll('.view-btn').forEach(b => b.classList.toggle('active', b.dataset.view === view));
-  const toggleWrap = document.getElementById('classifiersToggleWrap');
   if (view !== 'ranked') {
     classifiersOnly = false;
-    document.getElementById('classifiersOnlyChk').checked = false;
-    toggleWrap.classList.remove('active');
-    toggleWrap.style.display = 'none';
-  } else {
-    toggleWrap.style.display = 'flex';
+    adjustedOnly = false;
   }
+  syncChartModeControls();
+}
+
+function syncChartModeControls() {
+  const modes = [
+    ['classifiersOnlyChk', 'classifiersToggleWrap', classifiersOnly],
+    ['adjustedOnlyChk', 'adjustedToggleWrap', adjustedOnly],
+  ];
+  modes.forEach(([inputId, wrapId, active]) => {
+    document.getElementById(inputId).checked = active;
+    const wrap = document.getElementById(wrapId);
+    wrap.classList.toggle('active', active);
+    wrap.style.display = currentView === 'ranked' ? 'flex' : 'none';
+  });
+}
+
+function setChartMode(mode, enabled) {
+  if (mode === 'classifiers') {
+    classifiersOnly = enabled;
+    if (enabled) adjustedOnly = false;
+  } else {
+    adjustedOnly = enabled;
+    if (enabled) classifiersOnly = false;
+  }
+  syncChartModeControls();
+  renderAll();
 }
 
 document.querySelectorAll('.view-btn').forEach(btn => {
@@ -752,9 +774,11 @@ document.querySelectorAll('.view-btn').forEach(btn => {
 });
 
 document.getElementById('classifiersOnlyChk').addEventListener('change', e => {
-  classifiersOnly = e.target.checked;
-  document.getElementById('classifiersToggleWrap').classList.toggle('active', classifiersOnly);
-  renderAll();
+  setChartMode('classifiers', e.target.checked);
+});
+
+document.getElementById('adjustedOnlyChk').addEventListener('change', e => {
+  setChartMode('adjusted', e.target.checked);
 });
 
 document.getElementById('exportCsvBtn').addEventListener('click', () => {
@@ -1119,7 +1143,7 @@ function renderAll() {
   summaryBar.classList.add('visible');
   chartsEl.classList.add('visible');
   sizeCanvases();
-  document.getElementById('classifiersToggleWrap').style.display = currentView === 'ranked' ? 'flex' : 'none';
+  syncChartModeControls();
 
   if (sorted.length === 0) {
     const msg = selectedDiv
@@ -1137,6 +1161,8 @@ function renderAll() {
     document.getElementById('statAdjAvgBox').style.display = 'none';
     document.getElementById('chartTimeTitle').textContent = classifiersOnly
       ? 'Classifier Scores Over Time'
+      : adjustedOnly
+      ? 'Adjusted % Over Time'
       : 'Score Over Time';
     document.getElementById('chartPlaceSubtitle').textContent = '';
     setPlacementVisible(!classifiersOnly);
@@ -1167,6 +1193,8 @@ function renderAll() {
     document.getElementById('statAdjAvgBox').style.display = 'none';
     document.getElementById('chartTimeTitle').textContent = classifiersOnly
       ? 'Classifier Scores Over Time'
+      : adjustedOnly
+      ? 'Adjusted % Over Time'
       : 'Score Over Time';
     document.getElementById('chartPlaceSubtitle').textContent = '';
     setPlacementVisible(!classifiersOnly);
@@ -1444,20 +1472,41 @@ function renderAll() {
     });
   }
 
-  // Add adjusted series if we have data (dashed line, distinct color)
-  if (adjPoints.length >= 2) {
-    scoreSeries.push({
-      label: 'Adjusted %',
-      color: '#ff4081',
-      dash: true,
-      points: adjPoints,
+  const adjustedSeries = {
+    label: 'Adjusted %',
+    color: '#ff4081',
+    dash: true,
+    points: adjPoints,
+  };
+
+  if (adjustedOnly) {
+    document.getElementById('chartTimeTitle').textContent = 'Adjusted % Over Time';
+    if (adjPoints.length >= 2) {
+      drawMultiSeriesChart(
+        document.getElementById('chartTime'),
+        [adjustedSeries],
+        adjPoints.map(point => point.date),
+        {
+          yLabel: 'Adjusted match %', yMin: 0, yMax: 100, invertY: false,
+          trend: true, valueUnit: 'match%', preserveDuplicateDates: true,
+        }
+      );
+    } else {
+      drawMessage(
+        document.getElementById('chartTime'),
+        'Adjusted % needs 2 usable matches.\n' +
+        'Refresh older matches for non-classifier\n' +
+        'cross-division benchmark data.'
+      );
+    }
+  } else {
+    // Add adjusted series if we have data (dashed line, distinct color)
+    if (adjPoints.length >= 2) scoreSeries.push(adjustedSeries);
+    drawMultiSeriesChart(document.getElementById('chartTime'), scoreSeries, allDates, {
+      yLabel: 'Match performance %', yMin: 0, yMax: 100, invertY: false,
+      trend: scoreSeries.length <= 2, valueUnit: 'match%',
     });
   }
-
-  drawMultiSeriesChart(document.getElementById('chartTime'), scoreSeries, allDates, {
-    yLabel: 'Match performance %', yMin: 0, yMax: 100, invertY: false,
-    trend: scoreSeries.length <= 2, valueUnit: 'match%',
-  });
 
   const placeSeries = Object.entries(byDiv).map(([div, matches], i) => {
     const placeMatches = matches.filter(r => {
@@ -3336,8 +3385,15 @@ function drawLineChart(canvas, points, opts = {}) {
 function drawMessage(canvas, msg) {
   const ctx = canvas.getContext('2d');
   clearCanvas(ctx, canvas);
+  canvas._hitMap = [];
+  canvas._valueUnit = '';
+  canvas.style.cursor = '';
+  tooltipEl.style.display = 'none';
   ctx.fillStyle = TEXT_COLOR(); ctx.font = '13px Inter, system-ui, sans-serif'; ctx.textAlign = 'center';
-  ctx.fillText(msg, canvas.width / 2, canvas.height / 2);
+  const lines = String(msg).split('\n');
+  const lineHeight = 19;
+  const firstY = canvas.height / 2 - ((lines.length - 1) * lineHeight) / 2;
+  lines.forEach((line, index) => ctx.fillText(line, canvas.width / 2, firstY + index * lineHeight));
 }
 
 // ── Stacked bar chart — hit zone breakdown ────────────────────────────────────


### PR DESCRIPTION
## Summary

- add a keyboard-accessible Adjusted % Only switch beside Classifiers Only
- enforce mutual exclusion through one chart-mode state transition
- render only cached adjusted points with an Adjusted % Over Time title and no raw fallback
- show a responsive multi-line explanation when fewer than two adjusted matches are usable
- preserve filters, summaries, CSV fields, cache, and Match History behavior
- clear stale chart hit maps whenever an empty-state message replaces plotted data

## Verification

- `git diff --check`
- `node --check extension/dashboard.js`
- `./build.sh qa27`
- focused assertions for mutual exclusion, no network/storage calls in mode transitions, adjusted-only rendering, and empty-state interaction reset
- unpacked-extension keyboard/browser QA at 375px, 1920px, and 2560px in both themes: mutual exclusion, adjusted-only point isolation, responsive wrapping/focus, date/division/match/stage filters, zero/one/two-point states, unchanged CSV fields, unchanged storage hashes, zero runtime messages, and zero console errors

Resolves #27

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 3h 4m and 1,605,502 tokens on this with the user in an interactive session.