### PR TITLE
GH#39: Add pre-fetch timeline selection

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -41,6 +41,14 @@ Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter
 - Use compact native buttons with a clear keyboard focus ring. The group wraps at narrow widths rather than becoming a dropdown or creating horizontal page overflow.
 - Date-range changes update the existing cached analytics immediately. They do not hide or delete older Match History records.
 
+## Fetch timeline
+
+- Place the labelled native Fetch timeline select immediately before **Fetch Scores**. Use the same six labels as the analytics presets, default to **6 mo**, and persist the latest selection locally.
+- Fetch timeline controls pre-fetch request scope; analytics presets independently filter cached data. Keep that distinction explicit in status and documentation.
+- The current visible select value is the next fetch scope. Changing it alone makes no request.
+- Preserve older cache and Match History entries when a narrower timeline is fetched. Explicit single-match refresh remains unrestricted.
+- Keep the label and select together as controls wrap at narrow widths, with visible focus and no page-level horizontal overflow.
+
 ## Master Calendar
 
 - Show exactly six chronological calendar-month blocks: the current month and the previous five months. Keep this window independent from the graph date preset.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The Hit Factor Charts icon will appear in your Chrome toolbar. Pin it for easy a
 
 3. **Enter your member number and/or name** — type your USPSA member number (e.g. `A12345`) and/or your name as it appears on result sheets (e.g. `Smith, Jane`). At least one is required; providing both improves match accuracy.
 
-4. **Click Fetch Scores** — the extension navigates to your PractiScore history, opens each match's results page, selects your division, and records your score. Progress is shown in the status bar.
+4. **Choose a Fetch timeline and click Fetch Scores** — the timeline defaults to **6 mo** and limits which PractiScore matches receive score and stage requests. The extension opens each in-range match's results page, selects your division, and records your score. Progress is shown in the status bar.
 
 5. **Explore your data** — the summary bar shows matches found, average %, best %, field-strength adjusted average, and your USPSA classification. The **Scored Matches / All Matches** toggle below the cards switches between member-number lookup results and all name-matched results.
 
@@ -125,6 +125,8 @@ The **Non-Classifier Stage Trend** averages your included non-classifier stage p
 ### Filtering by date
 
 Analytics open on the most recent **6 mo** so trends stay readable. Use the buttons above the charts to switch to **Last 1 month**, **3 mo**, **6 mo**, **1 yr**, **3 yr**, or **all time**. The active range applies to every chart, summary statistic, classifier-only view, and chart CSV export without re-fetching or deleting older Match History records.
+
+The **Fetch timeline** dropdown beside **Fetch Scores** is separate: it limits network requests before a fetch begins and remembers your last choice. A narrower fetch merges new results with older cached Match History instead of deleting it. Choose a broader timeline to retrieve older uncached matches; changing the dropdown alone does not make a request. **all time** keeps the original unrestricted fetch behavior, and refreshing one match remains unrestricted.
 
 ### Using the Master Calendar
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -18,7 +18,7 @@ chrome.action.onClicked.addListener(async () => {
 // ── Message handler ───────────────────────────────────────────────────────────
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg.action === 'fetchScores') {
-    fetchScores(msg.memberNumber, msg.name)
+    fetchScores(msg.memberNumber, msg.name, msg.fetchTimeline)
       .then(data  => sendResponse({ ok: true,  data }))
       .catch(err  => sendResponse({ ok: false, error: err.message }));
     return true;
@@ -57,6 +57,106 @@ async function updateMatchCache(matchId, scoreData) {
 
 // ── Utilities ─────────────────────────────────────────────────────────────────
 function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+const FETCH_TIMELINES = Object.freeze({
+  '1m':  { label: 'Last 1 month', months: 1 },
+  '3m':  { label: '3 mo',         months: 3 },
+  '6m':  { label: '6 mo',         months: 6 },
+  '1y':  { label: '1 yr',         months: 12 },
+  '3y':  { label: '3 yr',         months: 36 },
+  'all': { label: 'all time',     months: null },
+});
+
+function localDateOnly(date = new Date()) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function subtractCalendarMonths(dateOnly, months) {
+  const [year, month, day] = dateOnly.split('-').map(Number);
+  const monthIndex = month - 1 - months;
+  const targetYear = year + Math.floor(monthIndex / 12);
+  const targetMonth = ((monthIndex % 12) + 12) % 12;
+  const lastDay = new Date(targetYear, targetMonth + 1, 0).getDate();
+  return localDateOnly(new Date(targetYear, targetMonth, Math.min(day, lastDay)));
+}
+
+function normalizeDateOnly(value) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(value || ''));
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(year, month - 1, day);
+  if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) return null;
+  return `${match[1]}-${match[2]}-${match[3]}`;
+}
+
+function resolveFetchTimeline(requested, referenceDate = new Date()) {
+  const requestedValue = typeof requested === 'object' ? requested?.value : requested;
+  const value = Object.hasOwn(FETCH_TIMELINES, requestedValue) ? requestedValue : '6m';
+  const preset = FETCH_TIMELINES[value];
+  const end = preset.months == null ? null : localDateOnly(referenceDate);
+  const start = end == null ? null : subtractCalendarMonths(end, preset.months);
+  return { value, label: preset.label, start, end };
+}
+
+function filterMatchListByTimeline(matchList, scope) {
+  let invalidDateCount = 0;
+  let futureDateCount = 0;
+  let beforeCutoffCount = 0;
+
+  if (scope.value === 'all') {
+    invalidDateCount = matchList.filter(match => normalizeDateOnly(match.date) == null).length;
+    return { matches: [...matchList], invalidDateCount, futureDateCount, beforeCutoffCount };
+  }
+
+  const matches = matchList.filter(match => {
+    const date = normalizeDateOnly(match.date);
+    if (!date) {
+      invalidDateCount++;
+      return false;
+    }
+    if (date > scope.end) {
+      futureDateCount++;
+      return false;
+    }
+    if (date < scope.start) {
+      beforeCutoffCount++;
+      return false;
+    }
+    return true;
+  });
+  return { matches, invalidDateCount, futureDateCount, beforeCutoffCount };
+}
+
+function mergeMatchLists(existing, incoming, { preserveMissing = true } = {}) {
+  const existingById = new Map((existing || []).filter(match => match?.match_id).map(match => [match.match_id, match]));
+  const incomingIds = new Set();
+  const merged = [];
+
+  for (const match of incoming || []) {
+    if (!match?.match_id || incomingIds.has(match.match_id)) continue;
+    incomingIds.add(match.match_id);
+    const prior = existingById.get(match.match_id) || {};
+    const next = { ...prior, ...match };
+    if (next.match_type === 'Unknown' && prior.match_type && prior.match_type !== 'Unknown') {
+      next.match_type = prior.match_type;
+    }
+    merged.push(next);
+  }
+
+  if (preserveMissing) {
+    for (const match of existing || []) {
+      if (!match?.match_id || incomingIds.has(match.match_id)) continue;
+      incomingIds.add(match.match_id);
+      merged.push(match);
+    }
+  }
+  return merged;
+}
 
 // ── Match type detection ──────────────────────────────────────────────────────
 function detectMatchType(name) {
@@ -792,13 +892,15 @@ async function fetchUSPSAClassification(memberNumber, push) {
 }
 
 // ── Fetch all match scores ────────────────────────────────────────────────────
-async function fetchScores(memberNumber, name) {
+async function fetchScores(memberNumber, name, requestedTimeline) {
   const log = [];
   const push = m => { log.push(m); console.log('[HFC]', m); };
   let tabId = null;
+  const fetchScope = resolveFetchTimeline(requestedTimeline);
 
   try {
-    push('Loading match history…');
+    const bounds = fetchScope.value === 'all' ? '' : ` (${fetchScope.start} through ${fetchScope.end})`;
+    push(`Loading match history — fetch timeline: ${fetchScope.label}${bounds}…`);
     const tab = await chrome.tabs.create({ url: `${PS_BASE}/associate/step2`, active: false });
     tabId = tab.id;
     await waitForTabLoad(tabId);
@@ -815,13 +917,36 @@ async function fetchScores(memberNumber, name) {
     push(`Found ${rawMatchList.length} match(es).`);
     console.log('[HFC] matchList:', JSON.stringify(rawMatchList, null, 2));
 
-    if (rawMatchList.length === 0) {
-      push('No matches found — are you logged into PractiScore?');
-      return { results: [], log };
-    }
-
     // Annotate every match with its detected type
-    const matchList = rawMatchList.map(m => ({ ...m, match_type: detectMatchType(m.match_name) }));
+    const annotatedMatchList = rawMatchList.map(m => ({ ...m, match_type: detectMatchType(m.match_name) }));
+    const filtered = filterMatchListByTimeline(annotatedMatchList, fetchScope);
+    const matchList = filtered.matches;
+    Object.assign(fetchScope, {
+      extractedCount: rawMatchList.length,
+      inRangeCount: matchList.length,
+      invalidDateCount: filtered.invalidDateCount,
+      futureDateCount: filtered.futureDateCount,
+      beforeCutoffCount: filtered.beforeCutoffCount,
+    });
+    push(`Fetch timeline ${fetchScope.label}: ${matchList.length}/${rawMatchList.length} match(es) in range.`);
+    if (filtered.invalidDateCount && fetchScope.value === 'all') {
+      push(`Retaining ${filtered.invalidDateCount} match(es) with missing or malformed dates for this all-time fetch.`);
+    } else if (filtered.invalidDateCount) {
+      push(`Skipping ${filtered.invalidDateCount} match(es) with missing or malformed dates for this bounded fetch.`);
+    }
+    if (filtered.futureDateCount) push(`Skipping ${filtered.futureDateCount} future-dated match(es).`);
+    if (filtered.beforeCutoffCount) push(`Skipping ${filtered.beforeCutoffCount} match(es) before ${fetchScope.start}.`);
+
+    const stored = await chrome.storage.local.get(['lastMatchList', 'matchCache']);
+    const previousMatchList = stored.lastMatchList || [];
+    const cache = stored.matchCache || {};
+    const preserveMissingHistory = fetchScope.value !== 'all' || rawMatchList.length === 0;
+    let mergedMatchList = mergeMatchLists(previousMatchList, matchList, { preserveMissing: preserveMissingHistory });
+    await chrome.storage.local.set({ lastMatchList: mergedMatchList });
+
+    if (rawMatchList.length === 0) {
+      push('No matches extracted — preserving previously cached history.');
+    }
 
     // Level 1: skip confirmed non-USPSA matches before fetching scores
     const uspsaMatches = matchList.filter(m => isLikelyUSPSA(m.match_type));
@@ -831,11 +956,7 @@ async function fetchScores(memberNumber, name) {
       push(`Skipping ${skipped} non-USPSA match(es): ${names}`);
     }
 
-    // Save ALL matches (with types) so users can see and manage their full history
-    await chrome.storage.local.set({ lastMatchList: matchList });
-
-    push('Fetching scores…');
-    const cache = await getCache();
+    push(`Fetching scores for ${uspsaMatches.length} in-range USPSA match(es)…`);
     const results = [];
 
     // Include non-USPSA matches in results (without scores) for history display
@@ -876,8 +997,9 @@ async function fetchScores(memberNumber, name) {
       push(`     score: ${score.overall_pct != null ? score.overall_pct + '%' : 'not found'} [${score.found_by || 'none'}]`);
     }
 
-    // Re-save lastMatchList with any match_type values confirmed from the results pages
-    await chrome.storage.local.set({ lastMatchList: matchList });
+    // Re-save the merged list with any match types confirmed from results pages.
+    mergedMatchList = mergeMatchLists(previousMatchList, matchList, { preserveMissing: preserveMissingHistory });
+    await chrome.storage.local.set({ lastMatchList: mergedMatchList });
 
     const n = results.filter(r => r.overall_pct != null).length;
     push(`Done — ${n}/${uspsaMatches.length} matches with scores.`);
@@ -895,7 +1017,17 @@ async function fetchScores(memberNumber, name) {
       }
     }
 
-    return { results, log, classificationData, _not_logged_in_uspsa };
+    const fetchedById = new Map(results.map(result => [result.match_id, result]));
+    const combinedResults = mergedMatchList.map(match => {
+      if (fetchedById.has(match.match_id)) return fetchedById.get(match.match_id);
+      const cached = cache[match.match_id];
+      if (cached && cached.cached_for === (memberNumber || '').toUpperCase()) {
+        return { ...match, ...cached, _cached: true };
+      }
+      return buildResult(match, {}, memberNumber);
+    });
+
+    return { results: combinedResults, log, classificationData, _not_logged_in_uspsa, fetchScope };
 
   } finally {
     if (tabId) chrome.tabs.remove(tabId).catch(() => {});

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -104,6 +104,21 @@
       cursor: default;
       border-color: #1e2130;
     }
+    .fetch-timeline-control {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex: 0 1 auto;
+      color: #aab3c2;
+      font-size: 12px;
+      font-weight: 600;
+      white-space: nowrap;
+    }
+    .controls #fetchTimeline {
+      flex: 0 1 150px;
+      min-width: 130px;
+      padding: 10px 12px;
+    }
 
     .ctrl-btn {
       padding: 10px 18px;
@@ -1168,7 +1183,10 @@
       border-color: #c0c4cc;
       color: #2c3040;
     }
+    [data-theme="light"] .controls input:focus,
+    [data-theme="light"] .controls select:focus { border-color: #2563eb; }
     [data-theme="light"] .controls input::placeholder { color: #999; }
+    [data-theme="light"] .fetch-timeline-control { color: #4f596b; }
     [data-theme="light"] .ctrl-btn {
       background: #f0f1f4;
       border-color: #c0c4cc;
@@ -1316,6 +1334,17 @@
   <button id="editBtn"   class="ctrl-btn">Edit</button>
   <button id="saveBtn"   class="ctrl-btn">Save</button>
   <button id="cancelBtn" class="ctrl-btn">Cancel</button>
+  <label class="fetch-timeline-control" for="fetchTimeline">
+    <span>Fetch timeline</span>
+    <select id="fetchTimeline">
+      <option value="1m">Last 1 month</option>
+      <option value="3m">3 mo</option>
+      <option value="6m" selected>6 mo</option>
+      <option value="1y">1 yr</option>
+      <option value="3y">3 yr</option>
+      <option value="all">all time</option>
+    </select>
+  </label>
   <button id="fetchBtn"  class="ctrl-btn">Fetch Scores</button>
 </div>
 

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -32,6 +32,7 @@ document.getElementById('headerVersion').textContent = 'v' + chrome.runtime.getM
 const memberInput  = document.getElementById('memberInput');
 const nameInput    = document.getElementById('nameInput');
 const divisionFilter = document.getElementById('divisionFilter');
+const fetchTimelineSelect = document.getElementById('fetchTimeline');
 const fetchBtn     = document.getElementById('fetchBtn');
 const editBtn      = document.getElementById('editBtn');
 const saveBtn      = document.getElementById('saveBtn');
@@ -225,6 +226,29 @@ let selectedDatePreset = '6m';   // analytics range; resets to six months on das
 let classificationData = null;  // data from uspsa.org/classification/[memberNumber]
 let classifiersOnly  = false;   // when true, charts show only classifier stage scores
 let adjustedOnly     = false;   // when true, Score Over Time shows only adjusted match points
+let selectedFetchTimeline = '6m'; // pre-fetch request scope; independent of analytics range
+let lastFetchScope = null;
+
+const FETCH_TIMELINE_PRESETS = Object.freeze({
+  '1m':  { label: 'Last 1 month', months: 1 },
+  '3m':  { label: '3 mo',         months: 3 },
+  '6m':  { label: '6 mo',         months: 6 },
+  '1y':  { label: '1 yr',         months: 12 },
+  '3y':  { label: '3 yr',         months: 36 },
+  'all': { label: 'all time',     months: null },
+});
+
+function normalizeFetchTimeline(value) {
+  return Object.hasOwn(FETCH_TIMELINE_PRESETS, value) ? value : '6m';
+}
+
+function resolveFetchTimeline(value, referenceDate = new Date()) {
+  const normalized = normalizeFetchTimeline(value);
+  const preset = FETCH_TIMELINE_PRESETS[normalized];
+  const end = preset.months == null ? null : localDateOnly(referenceDate);
+  const start = end == null ? null : subtractCalendarMonths(end, preset.months);
+  return { value: normalized, label: preset.label, start, end };
+}
 
 const NON_USPSA_TYPES = new Set(['IDPA', 'IPSC', 'Steel Challenge', '3-Gun', 'PCSL', 'ICORE', 'SCSA']);
 // Confirmed USPSA types — only these count toward the USPSA match total in the status line.
@@ -683,7 +707,7 @@ function hideOnboarding() {
 }
 
 // ── Restore persisted state on load ──────────────────────────────────────────
-chrome.storage.local.get(['memberNumber', 'name', 'lastMatchList', 'matchCache', 'deselectedMatches', 'stageOverrides', 'classificationData', 'selectedDivision'], async d => {
+chrome.storage.local.get(['memberNumber', 'name', 'lastMatchList', 'matchCache', 'deselectedMatches', 'stageOverrides', 'classificationData', 'selectedDivision', 'fetchTimeline'], async d => {
   // Try restoring from sync if local has no credentials (e.g. after reinstall)
   if (!d.memberNumber && !d.name) {
     await restoreFromSync();
@@ -699,6 +723,8 @@ chrome.storage.local.get(['memberNumber', 'name', 'lastMatchList', 'matchCache',
   if (d.stageOverrides && typeof d.stageOverrides === 'object') stageOverrides = d.stageOverrides;
   selectedDiv = normalizeDivision(d.selectedDivision);
   divisionFilter.value = selectedDiv || '';
+  selectedFetchTimeline = normalizeFetchTimeline(d.fetchTimeline);
+  fetchTimelineSelect.value = selectedFetchTimeline;
 
   // Lock inputs if we already have saved credentials
   if (d.memberNumber || d.name) {
@@ -793,10 +819,18 @@ divisionFilter.addEventListener('change', () => {
   updateStatusCounts();
 });
 
+fetchTimelineSelect.addEventListener('change', () => {
+  selectedFetchTimeline = normalizeFetchTimeline(fetchTimelineSelect.value);
+  fetchTimelineSelect.value = selectedFetchTimeline;
+  chrome.storage.local.set({ fetchTimeline: selectedFetchTimeline });
+});
+
 // ── Fetch button ──────────────────────────────────────────────────────────────
 fetchBtn.addEventListener('click', async () => {
   const memberNumber = memberInput.value.trim().toUpperCase();
   const name         = nameInput.value.trim();
+  selectedFetchTimeline = normalizeFetchTimeline(fetchTimelineSelect.value);
+  const fetchTimeline = resolveFetchTimeline(selectedFetchTimeline);
   if (!memberNumber && !name) { setStatus('Please enter your USPSA member number and/or your name.', 'error'); return; }
 
   // Dismiss onboarding permanently once the user initiates a fetch
@@ -829,16 +863,18 @@ fetchBtn.addEventListener('click', async () => {
     matchHistory.classList.remove('visible');
   }
 
-  chrome.storage.local.set({ memberNumber, name });
+  chrome.storage.local.set({ memberNumber, name, fetchTimeline: selectedFetchTimeline });
   lockInputs();
-  setStatus('Opening PractiScore tab…', '', true);
+  setStatus(`Opening PractiScore tab — fetch timeline: ${fetchTimeline.label}…`, '', true);
   fetchBtn.disabled = true;
   noDataEl.style.display   = 'none';
   debugLogEl.style.display = 'none';
   allResults = [];
 
   try {
-    const response = await chrome.runtime.sendMessage({ action: 'fetchScores', memberNumber, name });
+    const response = await chrome.runtime.sendMessage({
+      action: 'fetchScores', memberNumber, name, fetchTimeline,
+    });
     if (!response.ok) throw new Error(response.error || 'Unknown error');
     if (response.data._not_logged_in_ps) {
       document.getElementById('psLoginWarning').style.display = 'block';
@@ -847,7 +883,8 @@ fetchBtn.addEventListener('click', async () => {
     }
     document.getElementById('psLoginWarning').style.display = 'none';
 
-    const { results, log } = response.data;
+    const { results, log, fetchScope } = response.data;
+    lastFetchScope = fetchScope || fetchTimeline;
 
     if (log?.length) {
       debugLogEl.textContent = log.join('\n');
@@ -856,7 +893,7 @@ fetchBtn.addEventListener('click', async () => {
 
     if (!results?.length) {
       noDataEl.style.display = 'block';
-      setStatus('No matches found.', 'error');
+      setStatus(`No matches found in ${lastFetchScope.label} (${lastFetchScope.inRangeCount || 0} in range).`, 'error');
       return;
     }
 
@@ -2400,7 +2437,10 @@ function updateStatusCounts(verb) {
   const checkedNote      = checked < uspsa ? ` · ${checked} checked` : '';
   const unconfirmedNote  = unconfirmed.length > 0 ? ` · ${unconfirmed.length} unconfirmed type` : '';
   const skippedNote      = nonUspsa.length > 0    ? ` · ${nonUspsa.length} non-USPSA excluded` : '';
-  setStatus(`${prefix}${divisionNote} ${uspsa} USPSA match(es) — ${scored} with scores${checkedNote}.${unconfirmedNote}${skippedNote}`, 'success');
+  const fetchNote        = lastFetchScope
+    ? ` · Fetch ${lastFetchScope.label}: ${lastFetchScope.inRangeCount ?? '?'} in range`
+    : '';
+  setStatus(`${prefix}${divisionNote} ${uspsa} USPSA match(es) — ${scored} with scores${checkedNote}.${unconfirmedNote}${skippedNote}${fetchNote}`, 'success');
 }
 
 // ── Save icon SVG (floppy disk, feather-style) ────────────────────────────────


### PR DESCRIPTION
## Summary

- add a persisted six-option Fetch timeline control immediately before Fetch Scores
- validate and apply inclusive local-date bounds before per-match cache lookup and score/stage requests
- preserve older cached history for bounded fetches while retaining authoritative all-time behavior
- keep analytics date presets and explicit single-match refresh independent
- report the selected scope and in-range count, with responsive light/dark styling and documentation

## Verification

- `git diff --check`
- `node --check extension/dashboard.js`
- `node --check extension/background.js`
- `./build.sh qa39`
- focused leap-year, cutoff, malformed-date, merge, request-boundary, and broad-to-narrow assertions
- unpacked-extension browser QA at 375px, 1920px, and 2560px in both themes: six options/default/persistence/request payload verified; no overflow or console errors; keyboard focus verified
- focused read-only code review: no findings after compatibility correction

Resolves #39

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 3h 25m and 950,063 tokens on this with the user in an interactive session. Solved in 1h 31m.
