### PR TITLE
GH#46: Add Last 8 analytics toggle

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -49,10 +49,10 @@ Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter
 - Preserve older cache and Match History entries when a narrower timeline is fetched. Explicit single-match refresh remains unrestricted.
 - Keep the label and select together as controls wrap at narrow widths, with visible focus and no page-level horizontal overflow.
 
-## Master Calendar
+## Last 8 analytics
 
-- Show exactly six chronological calendar-month blocks: the current month and the previous five months. Keep this window independent from the graph date preset.
-- Use three columns on wide screens, two on medium screens, and one at widths up to 640px. Day cells and match entries must remain inside their month block without page-level overflow.
-- Display the match name plus division and score when space allows. Preserve the full date, identity, division, and score in each entry's accessible name.
-- Calendar entries are native buttons that move keyboard focus to the corresponding Match History row. The destination receives a short, restrained highlight.
-- Empty months retain their complete calendar grid. If the whole window is empty, state that clearly without hiding the month blocks.
+- Place a labelled native-checkbox switch beside the analytics date presets. Default it off, persist only a valid boolean, and expose visible keyboard focus and active styling in both themes.
+- Apply Last 8 after the active date range, division, Scored/All view, and manual match selection. Use one shared final-eight dataset for summaries, charts, classifier analysis, and chart CSV export.
+- Treat Last 8 as a post-fetch view preference. Toggling it makes no request and never mutates fetched results, Match History, `matchCache`, or `lastMatchList`.
+- When fewer than eight matches qualify, use all available matches. State the visible and qualifying counts near the switch.
+- Keep the controls wrapping at narrow widths without page-level overflow.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A Chrome extension that pulls your USPSA match results from PractiScore and disp
 - **Match type detection** — identifies USPSA, IDPA, IPSC, Steel Challenge, 3-Gun, PCSL, ICORE matches; non-USPSA matches are shown in history but excluded from charts
 - **Filter matches** — checkboxes let you include or exclude individual matches from charts without deleting them
 - **Readable date ranges** — charts default to six months with one-click presets for one month, three months, six months, one year, three years, and all time
-- **Master Calendar** — scan the current month and previous five months at a glance, then jump from any recent match directly to its Match History row
+- **Last 8 analytics** — focus every chart, summary, classifier view, and CSV export on your eight most recent qualifying matches without re-fetching or trimming Match History
 - **Export as image** — save any match or individual stage as a PNG card (floppy-disk button on each match row)
 - **Export as CSV** — download all chart-visible data as a flat CSV (one row per stage) including CM numbers, USPSA %, HF, hit counts, adjusted %, and the selected reference division, class, HF, normalized HF, and benchmark method
 - **Light/dark theme** — defaults to light mode; toggle in the header; preference syncs across devices via Chrome storage
@@ -126,11 +126,9 @@ The **Non-Classifier Stage Trend** averages your included non-classifier stage p
 
 Analytics open on the most recent **6 mo** so trends stay readable. Use the buttons above the charts to switch to **Last 1 month**, **3 mo**, **6 mo**, **1 yr**, **3 yr**, or **all time**. The active range applies to every chart, summary statistic, classifier-only view, and chart CSV export without re-fetching or deleting older Match History records.
 
-The **Fetch timeline** dropdown beside **Fetch Scores** is separate: it limits network requests before a fetch begins and remembers your last choice. A narrower fetch merges new results with older cached Match History instead of deleting it. Choose a broader timeline to retrieve older uncached matches; changing the dropdown alone does not make a request. **all time** keeps the original unrestricted fetch behavior, and refreshing one match remains unrestricted.
+The **Last 8 matches** switch applies after the active analytics date range, division, Scored/All view, and manually selected matches. Turn it on to use the most recent eight qualifying matches across every chart, summary, classifier analysis, and chart CSV export. If fewer than eight qualify, all available matches are used. The preference is remembered, while Match History and cached records remain complete.
 
-### Using the Master Calendar
-
-The **Master Calendar** always shows six chronological month blocks: the current month and the previous five months. It follows the current division, view, and match selections but stays independent from the graph date preset. Select any calendar entry to jump to that match in Match History; older records remain cached and available there.
+The **Fetch timeline** dropdown beside **Fetch Scores** is separate: it limits network requests before a fetch begins and remembers your last choice. A narrower fetch merges new results with older cached Match History instead of deleting it. Choose a broader timeline to retrieve older uncached matches; changing the dropdown or Last 8 switch alone does not make a request. **all time** keeps the original unrestricted fetch behavior, and refreshing one match remains unrestricted.
 
 ### Exporting data
 

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -238,7 +238,7 @@
     .div-dropdown-item:hover { background: #2a2d3a; }
     .div-dropdown-item.selected { color: #4a9eff; }
     #timeFilter {
-      display: flex; gap: 6px; padding: 0 24px 14px; flex-wrap: wrap;
+      display: flex; align-items: center; gap: 6px; padding: 0 24px 14px; flex-wrap: wrap;
     }
     .time-btn {
       padding: 6px 12px; border-radius: 6px; font-size: 12px;
@@ -248,104 +248,26 @@
     .time-btn:hover { border-color: #4a9eff; color: #ccc; }
     .time-btn.active { background: #1e3a5f; border-color: #4a9eff; color: #4a9eff; }
     .time-btn:focus-visible { outline: 2px solid #4a9eff; outline-offset: 2px; }
-
-    /* ── Master Calendar ── */
-    #masterCalendar {
-      display: none;
-      padding: 24px 28px;
-      border-top: 1px solid #252838;
-    }
-    #masterCalendar.visible { display: block; }
-    .calendar-header {
+    .last8-toggle {
       display: flex;
-      align-items: baseline;
-      justify-content: space-between;
-      gap: 16px;
-      margin-bottom: 16px;
+      align-items: center;
+      gap: 7px;
+      margin-left: 8px;
+      padding-left: 14px;
+      border-left: 1px solid #2a2d3a;
+      cursor: pointer;
+      user-select: none;
     }
-    .calendar-header h2 {
-      font-size: 13px;
-      font-weight: 600;
+    .last8-toggle .toggle-lbl {
       color: #888;
+      font-size: 12px;
+      font-weight: 600;
       text-transform: uppercase;
       letter-spacing: 0.8px;
     }
-    #calendarStatus { color: #666; font-size: 12px; text-align: right; }
-    #calendarMonths {
-      display: grid;
-      grid-template-columns: repeat(3, minmax(0, 1fr));
-      gap: 16px;
-    }
-    .calendar-month {
-      min-width: 0;
-      overflow: hidden;
-      border: 1px solid #252838;
-      border-radius: 8px;
-      background: #131620;
-    }
-    .calendar-month h3 {
-      padding: 10px 12px;
-      border-bottom: 1px solid #252838;
-      color: #aeb8c8;
-      font-size: 13px;
-      font-weight: 600;
-    }
-    .calendar-weekdays,
-    .calendar-days { display: grid; grid-template-columns: repeat(7, minmax(0, 1fr)); }
-    .calendar-weekdays span {
-      padding: 6px 2px;
-      color: #555;
-      font-size: 9px;
-      font-weight: 600;
-      text-align: center;
-      text-transform: uppercase;
-    }
-    .calendar-day {
-      min-width: 0;
-      min-height: 82px;
-      padding: 5px;
-      border-top: 1px solid #202330;
-      border-right: 1px solid #202330;
-      background: #10131b;
-    }
-    .calendar-day:nth-child(7n) { border-right: 0; }
-    .calendar-day.empty { background: #0f1117; }
-    .calendar-day.today { background: #131d2d; }
-    .calendar-day-number {
-      display: block;
-      margin-bottom: 4px;
-      color: #667085;
-      font-size: 10px;
-      line-height: 1;
-    }
-    .calendar-day.today .calendar-day-number { color: #4a9eff; font-weight: 700; }
-    .calendar-entry {
-      display: block;
-      width: 100%;
-      margin-top: 4px;
-      padding: 5px 6px;
-      overflow: hidden;
-      border: 0;
-      border-left: 2px solid #4a9eff;
-      border-radius: 3px;
-      background: #1a2435;
-      color: #d6dfed;
-      cursor: pointer;
-      font: inherit;
-      text-align: left;
-    }
-    .calendar-entry:hover { background: #21324a; }
-    .calendar-entry:focus-visible { outline: 2px solid #4a9eff; outline-offset: -1px; }
-    .calendar-entry-name,
-    .calendar-entry-meta {
-      display: block;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-    .calendar-entry-name { font-size: 10px; font-weight: 600; }
-    .calendar-entry-meta { margin-top: 2px; color: #91a0b5; font-size: 9px; }
-    .match-row.calendar-target { border-color: #4a9eff; box-shadow: 0 0 0 2px rgba(74,158,255,0.18); }
+    .last8-toggle:hover .toggle-track { background: #3a3d4a; }
+    .last8-toggle.active .toggle-lbl { color: #4a9eff; }
+    #last8Status { flex-basis: 100%; color: #666; font-size: 11px; }
 
     #viewToggle { display: flex; flex-direction: row; gap: 8px; width: 100%; }
     .view-btn {
@@ -1115,10 +1037,6 @@
     .match-row:focus-within .delete-btn { opacity: 1; }
 
     /* ── Responsive layout ── */
-    @media (min-width: 641px) and (max-width: 1200px) {
-      #calendarMonths { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-    }
-
     @media (max-width: 640px) {
       header,
       .controls { padding-left: 16px; padding-right: 16px; }
@@ -1127,13 +1045,7 @@
       .summary-bar { padding-left: 16px; padding-right: 16px; }
       #stats { gap: 10px; }
       #timeFilter { padding-left: 16px; padding-right: 16px; }
-      #masterCalendar { padding: 20px 16px; }
-      .calendar-header { align-items: flex-start; flex-direction: column; gap: 4px; }
-      #calendarStatus { text-align: left; }
-      #calendarMonths { grid-template-columns: minmax(0, 1fr); gap: 12px; }
-      .calendar-day { min-height: 64px; padding: 3px; }
-      .calendar-entry { padding: 4px; }
-      .calendar-entry-meta { display: none; }
+      .last8-toggle { margin-left: 0; padding-left: 0; border-left: 0; }
       .chart-section { padding: 20px 16px; }
       .chart-section-header { align-items: flex-start; flex-wrap: wrap; gap: 8px; }
       #matchHistory { margin-left: 16px; margin-right: 16px; }
@@ -1220,18 +1132,8 @@
       color: #4a5060;
     }
     [data-theme="light"] .time-btn.active { background: #dbeafe; border-color: #2563eb; color: #2563eb; }
-    [data-theme="light"] #masterCalendar { border-top-color: #e0e2e8; }
-    [data-theme="light"] #calendarStatus { color: #5a6478; }
-    [data-theme="light"] .calendar-month { background: #ffffff; border-color: #d8dce6; }
-    [data-theme="light"] .calendar-month h3 { color: #2c3040; border-bottom-color: #d8dce6; }
-    [data-theme="light"] .calendar-weekdays span { color: #7b8495; }
-    [data-theme="light"] .calendar-day { background: #ffffff; border-color: #e6e8ed; }
-    [data-theme="light"] .calendar-day.empty { background: #f6f7f9; }
-    [data-theme="light"] .calendar-day.today { background: #eff6ff; }
-    [data-theme="light"] .calendar-day-number { color: #7b8495; }
-    [data-theme="light"] .calendar-entry { background: #e9f2ff; color: #1f3658; }
-    [data-theme="light"] .calendar-entry:hover { background: #dbeafe; }
-    [data-theme="light"] .calendar-entry-meta { color: #52647d; }
+    [data-theme="light"] .last8-toggle { border-left-color: #c0c4cc; }
+    [data-theme="light"] #last8Status { color: #5a6478; }
     [data-theme="light"] .view-btn { background: #f0f1f4; border-color: #c0c4cc; color: #4a5060; }
     [data-theme="light"] .view-btn:hover { color: #1a1d27; border-color: #8a9bb0; }
     [data-theme="light"] .view-btn.active { background: #2563eb; border-color: #2563eb; color: #fff; }
@@ -1452,14 +1354,6 @@
   </div>
 </div>
 
-<section id="masterCalendar" aria-labelledby="masterCalendarTitle">
-  <div class="calendar-header">
-    <h2 id="masterCalendarTitle">Master Calendar</h2>
-    <p id="calendarStatus" role="status"></p>
-  </div>
-  <div id="calendarMonths"></div>
-</section>
-
 <div id="timeFilter" role="group" aria-label="Analytics date range">
   <button class="time-btn" type="button" data-date-preset="1m" aria-pressed="false">Last 1 month</button>
   <button class="time-btn" type="button" data-date-preset="3m" aria-pressed="false">3 mo</button>
@@ -1467,6 +1361,14 @@
   <button class="time-btn" type="button" data-date-preset="1y" aria-pressed="false">1 yr</button>
   <button class="time-btn" type="button" data-date-preset="3y" aria-pressed="false">3 yr</button>
   <button class="time-btn" type="button" data-date-preset="all" aria-pressed="false">all time</button>
+  <label id="last8ToggleWrap" class="last8-toggle">
+    <span class="toggle-lbl">Last 8 matches</span>
+    <span class="toggle-switch">
+      <input type="checkbox" id="last8MatchesChk">
+      <span class="toggle-track"><span class="toggle-thumb"></span></span>
+    </span>
+  </label>
+  <span id="last8Status" role="status">All matches in range</span>
 </div>
 
 <div id="charts">

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -44,9 +44,9 @@ const chartsEl     = document.getElementById('charts');
 const debugLogEl   = document.getElementById('debugLog');
 const matchHistory = document.getElementById('matchHistory');
 const matchRowsEl  = document.getElementById('matchRows');
-const masterCalendar = document.getElementById('masterCalendar');
-const calendarMonthsEl = document.getElementById('calendarMonths');
-const calendarStatusEl = document.getElementById('calendarStatus');
+const last8MatchesChk = document.getElementById('last8MatchesChk');
+const last8ToggleWrap = document.getElementById('last8ToggleWrap');
+const last8StatusEl = document.getElementById('last8Status');
 const tooltipEl    = document.getElementById('tooltip');
 
 // ── Update check ─────────────────────────────────────────────────────────────
@@ -227,6 +227,7 @@ let classificationData = null;  // data from uspsa.org/classification/[memberNum
 let classifiersOnly  = false;   // when true, charts show only classifier stage scores
 let adjustedOnly     = false;   // when true, Score Over Time shows only adjusted match points
 let selectedFetchTimeline = '6m'; // pre-fetch request scope; independent of analytics range
+let last8Matches = false;       // post-fetch analytics limit; never truncates cached history
 let lastFetchScope = null;
 
 const FETCH_TIMELINE_PRESETS = Object.freeze({
@@ -707,7 +708,7 @@ function hideOnboarding() {
 }
 
 // ── Restore persisted state on load ──────────────────────────────────────────
-chrome.storage.local.get(['memberNumber', 'name', 'lastMatchList', 'matchCache', 'deselectedMatches', 'stageOverrides', 'classificationData', 'selectedDivision', 'fetchTimeline'], async d => {
+chrome.storage.local.get(['memberNumber', 'name', 'lastMatchList', 'matchCache', 'deselectedMatches', 'stageOverrides', 'classificationData', 'selectedDivision', 'fetchTimeline', 'last8Matches'], async d => {
   // Try restoring from sync if local has no credentials (e.g. after reinstall)
   if (!d.memberNumber && !d.name) {
     await restoreFromSync();
@@ -725,6 +726,8 @@ chrome.storage.local.get(['memberNumber', 'name', 'lastMatchList', 'matchCache',
   divisionFilter.value = selectedDiv || '';
   selectedFetchTimeline = normalizeFetchTimeline(d.fetchTimeline);
   fetchTimelineSelect.value = selectedFetchTimeline;
+  last8Matches = d.last8Matches === true;
+  renderLast8Control();
 
   // Lock inputs if we already have saved credentials
   if (d.memberNumber || d.name) {
@@ -979,145 +982,21 @@ function filterByActiveDateRange(records, referenceDate = new Date()) {
   });
 }
 
-function calendarMonthStarts(referenceDate = new Date()) {
-  const currentMonth = new Date(referenceDate.getFullYear(), referenceDate.getMonth(), 1);
-  return Array.from({ length: 6 }, (_, index) =>
-    new Date(currentMonth.getFullYear(), currentMonth.getMonth() - (5 - index), 1)
-  );
+function applyLast8Limit(records) {
+  return last8Matches ? records.slice(-8) : records;
 }
 
-function calendarWindow(records, referenceDate = new Date()) {
-  const months = calendarMonthStarts(referenceDate);
-  const start = localDateOnly(months[0]);
-  const end = localDateOnly(referenceDate);
-  const matchesByDate = new Map();
-  let invalidDateCount = 0;
-
-  for (const match of records) {
-    const date = normalizeDateOnly(match.date);
-    if (!date) {
-      invalidDateCount++;
-      continue;
-    }
-    if (date < start || date > end) continue;
-    if (!matchesByDate.has(date)) matchesByDate.set(date, []);
-    matchesByDate.get(date).push(match);
+function renderLast8Control(totalCount = null, visibleCount = null) {
+  last8MatchesChk.checked = last8Matches;
+  last8ToggleWrap.classList.toggle('active', last8Matches);
+  if (totalCount == null || visibleCount == null) {
+    last8StatusEl.textContent = last8Matches ? 'Last 8 enabled' : 'All matches in range';
+    return;
   }
-
-  return { months, start, end, matchesByDate, invalidDateCount };
-}
-
-function focusMatchHistory(matchId) {
-  const row = [...document.querySelectorAll('.match-row')]
-    .find(candidate => candidate.dataset.matchId === String(matchId));
-  if (!row) return;
-  row.scrollIntoView({ behavior: 'smooth', block: 'center' });
-  row.focus({ preventScroll: true });
-  row.classList.add('calendar-target');
-  window.setTimeout(() => row.classList.remove('calendar-target'), 1800);
-}
-
-function renderMasterCalendar(records, referenceDate = new Date()) {
-  masterCalendar.classList.add('visible');
-  calendarMonthsEl.innerHTML = '';
-
-  const { months, end, matchesByDate, invalidDateCount } = calendarWindow(records, referenceDate);
-
-  const monthFormatter = new Intl.DateTimeFormat(undefined, { month: 'long', year: 'numeric' });
-  const dateFormatter = new Intl.DateTimeFormat(undefined, { month: 'long', day: 'numeric', year: 'numeric' });
-  const weekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-  let visibleCount = 0;
-
-  for (const monthStart of months) {
-    const year = monthStart.getFullYear();
-    const month = monthStart.getMonth();
-    const daysInMonth = new Date(year, month + 1, 0).getDate();
-    const block = document.createElement('section');
-    block.className = 'calendar-month';
-    block.setAttribute('aria-label', monthFormatter.format(monthStart));
-
-    const heading = document.createElement('h3');
-    heading.textContent = monthFormatter.format(monthStart);
-    block.appendChild(heading);
-
-    const weekdayRow = document.createElement('div');
-    weekdayRow.className = 'calendar-weekdays';
-    weekdayRow.setAttribute('aria-hidden', 'true');
-    for (const weekday of weekdays) {
-      const label = document.createElement('span');
-      label.textContent = weekday;
-      weekdayRow.appendChild(label);
-    }
-    block.appendChild(weekdayRow);
-
-    const days = document.createElement('div');
-    days.className = 'calendar-days';
-    for (let blank = 0; blank < monthStart.getDay(); blank++) {
-      const spacer = document.createElement('div');
-      spacer.className = 'calendar-day empty';
-      spacer.setAttribute('aria-hidden', 'true');
-      days.appendChild(spacer);
-    }
-
-    for (let day = 1; day <= daysInMonth; day++) {
-      const dateObject = new Date(year, month, day);
-      const date = localDateOnly(dateObject);
-      const cell = document.createElement('div');
-      cell.className = 'calendar-day' + (date === end ? ' today' : '');
-
-      const dayNumber = document.createElement('span');
-      dayNumber.className = 'calendar-day-number';
-      dayNumber.textContent = String(day);
-      cell.appendChild(dayNumber);
-
-      for (const match of matchesByDate.get(date) || []) {
-        visibleCount++;
-        const name = match.match_name || 'Untitled match';
-        const division = divisionLabel(match.division);
-        const score = effectiveOverallPct(match);
-        const scoreText = score != null ? `${score.toFixed(1)}%` : 'No score';
-
-        const entry = document.createElement('button');
-        entry.type = 'button';
-        entry.className = 'calendar-entry';
-        entry.setAttribute('aria-label', `View ${name} in Match History — ${dateFormatter.format(dateObject)}, ${division}, ${scoreText}`);
-        entry.addEventListener('click', () => focusMatchHistory(match.match_id));
-
-        const nameEl = document.createElement('span');
-        nameEl.className = 'calendar-entry-name';
-        nameEl.textContent = name;
-        entry.appendChild(nameEl);
-
-        const metaEl = document.createElement('span');
-        metaEl.className = 'calendar-entry-meta';
-        metaEl.textContent = `${division} · ${scoreText}`;
-        entry.appendChild(metaEl);
-        cell.appendChild(entry);
-      }
-
-      days.appendChild(cell);
-    }
-
-    const renderedCellCount = monthStart.getDay() + daysInMonth;
-    for (let blank = renderedCellCount; blank % 7 !== 0; blank++) {
-      const spacer = document.createElement('div');
-      spacer.className = 'calendar-day empty';
-      spacer.setAttribute('aria-hidden', 'true');
-      days.appendChild(spacer);
-    }
-
-    block.appendChild(days);
-    calendarMonthsEl.appendChild(block);
-  }
-
-  const rangeLabel = `${monthFormatter.format(months[0])}–${monthFormatter.format(months[5])}`;
-  const matchLabel = visibleCount
-    ? `${visibleCount} match${visibleCount === 1 ? '' : 'es'} · ${rangeLabel}`
-    : `No chartable matches · ${rangeLabel}`;
-  const invalidLabel = invalidDateCount
-    ? ` · ${invalidDateCount} record${invalidDateCount === 1 ? '' : 's'} without a valid date omitted`
-    : '';
-  calendarStatusEl.textContent = matchLabel + invalidLabel;
+  const noun = totalCount === 1 ? 'match' : 'matches';
+  last8StatusEl.textContent = last8Matches
+    ? `Showing ${visibleCount} of ${totalCount} ${noun} in range`
+    : `${totalCount} ${noun} in range`;
 }
 
 function renderDateRangeFilter() {
@@ -1138,6 +1017,13 @@ document.querySelectorAll('[data-date-preset]').forEach(button => {
 });
 renderDateRangeFilter();
 
+last8MatchesChk.addEventListener('change', () => {
+  last8Matches = last8MatchesChk.checked;
+  chrome.storage.local.set({ last8Matches });
+  renderAll();
+});
+renderLast8Control();
+
 // ── Render charts + stats ─────────────────────────────────────────────────────
 function setPlacementVisible(visible) {
   const el = document.getElementById('chartPlaceSection');
@@ -1153,7 +1039,7 @@ function setPlacementVisible(visible) {
 function renderAll() {
   renderDateRangeFilter();
   if (!allResults.length) {
-    masterCalendar.classList.remove('visible');
+    renderLast8Control(0, 0);
     return;
   }
 
@@ -1175,14 +1061,13 @@ function renderAll() {
     const da = parseDate(a.date), db = parseDate(b.date);
     return (da && db) ? da - db : 0;
   });
-  renderMasterCalendar(sorted);
-
   summaryBar.classList.add('visible');
   chartsEl.classList.add('visible');
   sizeCanvases();
   syncChartModeControls();
 
   if (sorted.length === 0) {
+    renderLast8Control(0, 0);
     const msg = selectedDiv
       ? `No ${divisionLabel(selectedDiv)} matches found in the current view.`
       : currentView === 'ranked'
@@ -1211,8 +1096,10 @@ function renderAll() {
     return;
   }
 
-  // Apply one shared range to stats, every chart, summaries, classifier mode, and CSV export.
-  const viewSorted = filterByActiveDateRange(sorted);
+  // Apply one shared range and optional recent-match limit to every analytics surface.
+  const rangeSorted = filterByActiveDateRange(sorted);
+  const viewSorted = applyLast8Limit(rangeSorted);
+  renderLast8Control(rangeSorted.length, viewSorted.length);
 
   if (viewSorted.length === 0) {
     const msg = selectedDiv
@@ -2777,7 +2664,7 @@ function exportStageCard(match, stage) {
 
 // ── CSV Export ────────────────────────────────────────────────────────────────
 // Exports chart-visible match data as a flat CSV (one row per stage).
-// Respects the active division and date-range preset.
+// Respects the active division, date-range preset, and Last 8 preference.
 // Includes USPSA clf_pct when available (official % vs national reference HF).
 function exportChartCSV() {
   const uspsaBase = allResults.filter(r => isChartable(r) && !deselectedMatches.has(r.match_id));
@@ -2788,7 +2675,7 @@ function exportChartCSV() {
     const da = parseDate(a.date), db = parseDate(b.date);
     return (da && db) ? da - db : 0;
   });
-  const viewSorted = filterByActiveDateRange(sorted);
+  const viewSorted = applyLast8Limit(filterByActiveDateRange(sorted));
 
   // Flat format: one row per stage (match-level fields repeated).
   // In classifiersOnly mode, only classifier stages are included.
@@ -2850,7 +2737,8 @@ function exportChartCSV() {
   const csv      = rows.map(r => r.map(v => `"${String(v).replace(/"/g, '""')}"`).join(',')).join('\n');
   const dateTag  = (DATE_RANGE_PRESETS[selectedDatePreset] || DATE_RANGE_PRESETS['6m']).fileTag;
   const divisionTag = selectedDiv ? ` ${divisionLabel(selectedDiv)}` : '';
-  const filename = (classifiersOnly ? 'hfc_classifiers' : 'hfc_scores') + `${divisionTag} ${dateTag}.csv`;
+  const last8Tag = last8Matches ? ' last 8' : '';
+  const filename = (classifiersOnly ? 'hfc_classifiers' : 'hfc_scores') + `${divisionTag} ${dateTag}${last8Tag}.csv`;
   const blob     = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
   const url      = URL.createObjectURL(blob);
   const a        = document.createElement('a');


### PR DESCRIPTION
## Summary

Replace the Master Calendar with a persisted post-fetch Last 8 control shared by charts, summaries, classifier analysis, and CSV while preserving full Match History and cache data.

## Files Changed

DESIGN.md, README.md, extension/dashboard.html, extension/dashboard.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — node --check extension/dashboard.js; ./build.sh qa46-final; git diff --check; Playwright fixture QA verified 10-to-8 filtering, 10 retained history rows, zero runtime messages, keyboard operation, persistence writes, exact CSV rows, no console errors, and no 375px overflow.

Resolves #46


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.292 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 22h 7m and 3,155,493 tokens on this with the user in an interactive session.