### PR TITLE
GH#47: Explain elite competition in Adjusted % summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ A Chrome extension that pulls your USPSA match results from PractiScore and disp
 
 A 75% adjusted score means your performance was 75% of the strongest normalized stage result at that match after accounting for division equipment differences. Adjusted % is the better indicator of improvement over time because it accounts for the complete match field, not just your division draw. It is still a match-relative estimate, not an official USPSA classification percentage. Classifier stages are excluded because official classifier percentages are already normalized against USPSA national division data; use **Classifiers Only** to see that official class context.
 
+When adjusted and raw division averages are nearly identical, the dashboard identifies a dominant GM/M reference class and division only when the contributing stage data supports that conclusion. Mixed or missing reference metadata keeps the explanation neutral.
+
 Use **Adjusted % Only** beside **Classifiers Only** to inspect the adjusted series without raw match percentages. The modes are mutually exclusive because adjusted scores exclude classifier stages. Adjusted-only mode never falls back to raw scores; when fewer than two usable adjusted matches are available, the chart explains that older matches may need to be refreshed to load non-classifier cross-division benchmark data. Switching modes uses cached data and does not fetch or rewrite match history.
 
 ---

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -1660,6 +1660,29 @@ function _trendLabel(delta, threshold = 1.0) {
     `<span class="s-note">(within ±${threshold.toFixed(1)} ${unit} of baseline)</span>`;
 }
 
+function dominantEliteReference(pairs) {
+  const knownReferences = pairs
+    .flatMap(pair => pair.references || [])
+    .map(reference => ({
+      refClass: String(reference.refClass || '').trim().toUpperCase(),
+      refDiv: String(reference.refDiv || '').trim(),
+    }))
+    .filter(reference => /^[A-Z]{1,2}$/.test(reference.refClass) && reference.refDiv);
+  if (!knownReferences.length) return null;
+
+  const counts = new Map();
+  for (const reference of knownReferences) {
+    const key = `${reference.refClass}\u0000${reference.refDiv}`;
+    counts.set(key, (counts.get(key) || 0) + 1);
+  }
+  const ranked = [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+  const [topKey, topCount] = ranked[0];
+  if (ranked[1]?.[1] === topCount || topCount <= knownReferences.length / 2) return null;
+
+  const [refClass, refDiv] = topKey.split('\u0000');
+  return ['GM', 'M'].includes(refClass) ? { refClass, refDiv } : null;
+}
+
 function generateSummaries(viewSorted) {
   const sorted = [...viewSorted].sort((a, b) => {
     const da = parseDate(a.date), db = parseDate(b.date);
@@ -1697,17 +1720,24 @@ function generateSummaries(viewSorted) {
       if (!adjs.length) continue;
       const rawPct = effectiveDivPct(r) ?? effectiveOverallPct(r);
       if (rawPct == null) continue;
-      pairs.push({ adj: _avg(adjs.map(a => a.adjPct)), raw: rawPct });
+      pairs.push({
+        adj: _avg(adjs.map(a => a.adjPct)),
+        raw: rawPct,
+        references: adjs.map(({ refClass, refDiv }) => ({ refClass, refDiv })),
+      });
     }
     if (pairs.length >= 3) {
       const meanAdj = _avg(pairs.map(p => p.adj));
       const meanRaw = _avg(pairs.map(p => p.raw));
       const diff    = meanAdj - meanRaw;
       const sign    = diff >= 0 ? '+' : '';
+      const eliteReference = dominantEliteReference(pairs);
       const context = diff > 1.5
         ? `You're regularly competing against stronger fields than your division draw alone suggests.`
         : diff < -1.5
         ? `Your division tends to draw competitive shooters relative to the overall match field.`
+        : eliteReference
+        ? `Your raw division % was already measured against predominantly ${escHtml(eliteReference.refClass)}-class competition in ${escHtml(divisionLabel(eliteReference.refDiv))}, so little field-strength adjustment was needed.`
         : `Your division's field strength closely mirrors the overall match field.`;
       adjEl.innerHTML =
         `Adjusted avg <span class="s-val">${meanAdj.toFixed(1)}%</span> ` +


### PR DESCRIPTION
## Summary

Retain stage reference class and division metadata during summary aggregation, then show dominant GM/M context only for near-zero adjusted gaps with majority evidence and neutral fallback for mixed or missing metadata.

## Files Changed

README.md, extension/dashboard.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — node --check extension/dashboard.js; ./build.sh qa-adjusted-summary; git diff --check; Playwright fixture QA covered GM, M, mixed-tie, unknown, stronger-field, and weaker-field branches with zero runtime messages and no console errors.

Resolves #47


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.292 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 22h 14m and 3,196,301 tokens on this with the user in an interactive session.