### PR TITLE
GH#48: Classify unconfirmed match types

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -56,3 +56,11 @@ Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter
 - Treat Last 8 as a post-fetch view preference. Toggling it makes no request and never mutates fetched results, Match History, `matchCache`, or `lastMatchList`.
 - When fewer than eight matches qualify, use all available matches. State the visible and qualifying counts near the switch.
 - Keep the controls wrapping at narrow widths without page-level overflow.
+
+## Manual match type
+
+- Show a compact labelled native select only on Match History rows that remain unconfirmed after automatic detection. Offer **Keep unconfirmed**, USPSA, IDPA, IPSC, Steel Challenge, 3-Gun, PCSL, and ICORE.
+- Keep the effective-type badge and include checkbox synchronized with the saved choice. Confirmed page or detected types take precedence over stale overrides.
+- Persist overrides separately by match ID. Changing or resetting a type rerenders cached data locally without deleting history, scores, stages, or cache entries.
+- A saved non-USPSA choice suppresses later full-fetch score and stage requests for that match; explicit single-match refresh remains unrestricted.
+- Keep the selector keyboard-accessible and visible in both themes. Match History actions and controls wrap without page-level overflow at narrow widths.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A Chrome extension that pulls your USPSA match results from PractiScore and disp
 - **Consistency card** — match-to-match score variance and accuracy loss metrics
 - **Accuracy trend** — hit factor breakdown over time (A/C/D/M/NS/P)
 - **Match type detection** — identifies USPSA, IDPA, IPSC, Steel Challenge, 3-Gun, PCSL, ICORE matches; non-USPSA matches are shown in history but excluded from charts
+- **Manual type correction** — classify an unconfirmed Match History row as USPSA or another supported sport; later full fetches skip manually confirmed non-USPSA matches
 - **Filter matches** — checkboxes let you include or exclude individual matches from charts without deleting them
 - **Readable date ranges** — charts default to six months with one-click presets for one month, three months, six months, one year, three years, and all time
 - **Last 8 analytics** — focus every chart, summary, classifier view, and CSV export on your eight most recent qualifying matches without re-fetching or trimming Match History
@@ -141,6 +142,8 @@ The **Fetch timeline** dropdown beside **Fetch Scores** is separate: it limits n
 ### Filtering matches
 
 Each USPSA match row has a checkbox. Uncheck a match to exclude it from charts without deleting it.
+
+Rows that remain **Unknown** after automatic match-type detection include a **Type** selector. Choose USPSA, IDPA, IPSC, Steel Challenge, 3-Gun, PCSL, or ICORE to update chart inclusion, badges, and status counts immediately without fetching. The choice is stored separately from score history; **Keep unconfirmed** resets to automatic behavior without deleting cached scores or stages. Later full Fetch Scores runs skip matches manually classified as non-USPSA, reducing unnecessary PractiScore requests, while explicit single-match refresh remains available.
 
 ### Filtering stages
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -173,6 +173,31 @@ function detectMatchType(name) {
   return 'Unknown';
 }
 
+const MANUAL_MATCH_TYPES = Object.freeze(['USPSA', 'IDPA', 'IPSC', 'Steel Challenge', '3-Gun', 'PCSL', 'ICORE']);
+const SOURCE_MATCH_TYPES = new Set([...MANUAL_MATCH_TYPES, 'Hit Factor', 'SCSA', 'Unknown']);
+
+function normalizeMatchTypeOverrides(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  const normalized = {};
+  for (const [matchId, matchType] of Object.entries(value)) {
+    if (!matchId || ['__proto__', 'prototype', 'constructor'].includes(matchId)) continue;
+    if (MANUAL_MATCH_TYPES.includes(matchType)) normalized[matchId] = matchType;
+  }
+  return normalized;
+}
+
+function baseMatchType(match) {
+  const storedType = typeof match?.match_type === 'string' ? match.match_type.trim() : '';
+  if (SOURCE_MATCH_TYPES.has(storedType) && storedType !== 'Unknown') return storedType;
+  return detectMatchType(match?.match_name);
+}
+
+function effectiveMatchType(match, overrides) {
+  const detectedType = baseMatchType(match);
+  if (detectedType !== 'Unknown') return detectedType;
+  return overrides?.[match?.match_id] || detectedType;
+}
+
 // Types confirmed as non-USPSA — skip score fetching for these
 const NON_USPSA_TYPES = new Set(['IDPA', 'IPSC', 'Steel Challenge', '3-Gun', 'PCSL', 'ICORE', 'SCSA']);
 
@@ -937,22 +962,26 @@ async function fetchScores(memberNumber, name, requestedTimeline) {
     if (filtered.futureDateCount) push(`Skipping ${filtered.futureDateCount} future-dated match(es).`);
     if (filtered.beforeCutoffCount) push(`Skipping ${filtered.beforeCutoffCount} match(es) before ${fetchScope.start}.`);
 
-    const stored = await chrome.storage.local.get(['lastMatchList', 'matchCache']);
+    const stored = await chrome.storage.local.get(['lastMatchList', 'matchCache', 'matchTypeOverrides']);
     const previousMatchList = stored.lastMatchList || [];
     const cache = stored.matchCache || {};
+    const matchTypeOverrides = normalizeMatchTypeOverrides(stored.matchTypeOverrides);
     const preserveMissingHistory = fetchScope.value !== 'all' || rawMatchList.length === 0;
     let mergedMatchList = mergeMatchLists(previousMatchList, matchList, { preserveMissing: preserveMissingHistory });
     await chrome.storage.local.set({ lastMatchList: mergedMatchList });
+    const mergedById = new Map(mergedMatchList.map(match => [match.match_id, match]));
+    const workMatches = matchList.map(match => mergedById.get(match.match_id) || match);
 
     if (rawMatchList.length === 0) {
       push('No matches extracted — preserving previously cached history.');
     }
 
     // Level 1: skip confirmed non-USPSA matches before fetching scores
-    const uspsaMatches = matchList.filter(m => isLikelyUSPSA(m.match_type));
-    const skipped = matchList.length - uspsaMatches.length;
+    const uspsaMatches = workMatches.filter(m => isLikelyUSPSA(effectiveMatchType(m, matchTypeOverrides)));
+    const skippedMatches = workMatches.filter(m => !isLikelyUSPSA(effectiveMatchType(m, matchTypeOverrides)));
+    const skipped = skippedMatches.length;
     if (skipped > 0) {
-      const names = matchList.filter(m => !isLikelyUSPSA(m.match_type)).map(m => `${m.match_name} (${m.match_type})`).join(', ');
+      const names = skippedMatches.map(m => `${m.match_name} (${effectiveMatchType(m, matchTypeOverrides)})`).join(', ');
       push(`Skipping ${skipped} non-USPSA match(es): ${names}`);
     }
 
@@ -960,7 +989,7 @@ async function fetchScores(memberNumber, name, requestedTimeline) {
     const results = [];
 
     // Include non-USPSA matches in results (without scores) for history display
-    for (const m of matchList.filter(m => !isLikelyUSPSA(m.match_type))) {
+    for (const m of skippedMatches) {
       results.push(buildResult(m, {}, memberNumber));
     }
 
@@ -998,7 +1027,7 @@ async function fetchScores(memberNumber, name, requestedTimeline) {
     }
 
     // Re-save the merged list with any match types confirmed from results pages.
-    mergedMatchList = mergeMatchLists(previousMatchList, matchList, { preserveMissing: preserveMissingHistory });
+    mergedMatchList = mergeMatchLists(previousMatchList, workMatches, { preserveMissing: preserveMissingHistory });
     await chrome.storage.local.set({ lastMatchList: mergedMatchList });
 
     const n = results.filter(r => r.overall_pct != null).length;

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -461,6 +461,29 @@
       text-overflow: ellipsis;
     }
     .match-meta { font-size: 12px; color: #888; margin-top: 3px; }
+    .match-type-control {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+      color: #777;
+      font-size: 10px;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+    .match-type-select {
+      max-width: 145px;
+      padding: 5px 7px;
+      border: 1px solid #3a3d4a;
+      border-radius: 4px;
+      background: #131620;
+      color: #bbb;
+      font: inherit;
+      font-size: 11px;
+      text-transform: none;
+      letter-spacing: 0;
+    }
+    .match-type-select:focus-visible { outline: 2px solid #4a9eff; outline-offset: 2px; }
+    .match-type-select:disabled { opacity: 0.55; }
 
     .match-score { font-size: 14px; font-weight: 600; color: #4a9eff; white-space: nowrap; flex-shrink: 0; }
     .match-score.none { color: #555; font-weight: 400; font-size: 13px; }
@@ -1052,6 +1075,8 @@
       .match-row { flex-wrap: wrap; gap: 6px; padding: 10px 12px; }
       .match-info { flex: 1 1 calc(100% - 55px); }
       .match-type-badge { display: none; }
+      .match-type-control { margin-left: 29px; }
+      .match-type-select { max-width: 132px; }
       .match-score { margin-left: 29px; font-size: 12px; }
       .refresh-btn,
       .export-btn,
@@ -1158,6 +1183,8 @@
     [data-theme="light"] .match-row:hover { background: #f0f1f4; }
     [data-theme="light"] .match-name { color: #1a1d27; }
     [data-theme="light"] .match-meta { color: #5a6478; }
+    [data-theme="light"] .match-type-control { color: #5a6478; }
+    [data-theme="light"] .match-type-select { background: #ffffff; border-color: #c0c4cc; color: #2c3040; }
     [data-theme="light"] .match-score { color: #2563eb; }
     [data-theme="light"] .match-score.none { color: #8a9bb0; }
     [data-theme="light"] .refresh-btn,

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -228,6 +228,7 @@ let classifiersOnly  = false;   // when true, charts show only classifier stage 
 let adjustedOnly     = false;   // when true, Score Over Time shows only adjusted match points
 let selectedFetchTimeline = '6m'; // pre-fetch request scope; independent of analytics range
 let last8Matches = false;       // post-fetch analytics limit; never truncates cached history
+let matchTypeOverrides = {};    // match_id -> manual type for otherwise unconfirmed matches
 let lastFetchScope = null;
 
 const FETCH_TIMELINE_PRESETS = Object.freeze({
@@ -252,14 +253,55 @@ function resolveFetchTimeline(value, referenceDate = new Date()) {
 }
 
 const NON_USPSA_TYPES = new Set(['IDPA', 'IPSC', 'Steel Challenge', '3-Gun', 'PCSL', 'ICORE', 'SCSA']);
+const MANUAL_MATCH_TYPES = Object.freeze(['USPSA', 'IDPA', 'IPSC', 'Steel Challenge', '3-Gun', 'PCSL', 'ICORE']);
+const SOURCE_MATCH_TYPES = new Set([...MANUAL_MATCH_TYPES, 'Hit Factor', 'SCSA', 'Unknown']);
 // Confirmed USPSA types — only these count toward the USPSA match total in the status line.
-// 'Unknown' and 'Hit Factor' are unconfirmed and shown separately.
 const CONFIRMED_USPSA_TYPES = new Set(['USPSA', 'Hit Factor']);
+
+function detectMatchType(name) {
+  const normalized = String(name || '').toUpperCase();
+  if (/\bIDPA\b/.test(normalized)) return 'IDPA';
+  if (/\bIPSC\b/.test(normalized)) return 'IPSC';
+  if (/\bSTEEL[\s-]?CHALLENGE\b|\bSCSA\b/.test(normalized)) return 'Steel Challenge';
+  if (/\b3[\s-]?GUN\b/.test(normalized)) return '3-Gun';
+  if (/\bPCSL\b/.test(normalized)) return 'PCSL';
+  if (/\bICORE\b/.test(normalized)) return 'ICORE';
+  if (/\bUSPSA\b/.test(normalized)) return 'USPSA';
+  if (/\b(CARRY[\s-]?OPTICS|CARRYOPTICS|SINGLE[\s-]?STACK|SINGLESTACK|LIMITED[\s-]?OPTICS|LIMITEDOPTICS)\b/.test(normalized)) return 'USPSA';
+  return 'Unknown';
+}
+
+function normalizeMatchTypeOverrides(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  const normalized = {};
+  for (const [matchId, matchType] of Object.entries(value)) {
+    if (!matchId || ['__proto__', 'prototype', 'constructor'].includes(matchId)) continue;
+    if (MANUAL_MATCH_TYPES.includes(matchType)) normalized[matchId] = matchType;
+  }
+  return normalized;
+}
+
+function baseMatchType(match) {
+  const storedType = typeof match?.match_type === 'string' ? match.match_type.trim() : '';
+  if (SOURCE_MATCH_TYPES.has(storedType) && storedType !== 'Unknown') return storedType;
+  return detectMatchType(match?.match_name);
+}
+
+function isUnconfirmedMatchType(match) {
+  return baseMatchType(match) === 'Unknown';
+}
+
+function effectiveMatchType(match) {
+  const detectedType = baseMatchType(match);
+  if (detectedType !== 'Unknown') return detectedType;
+  return matchTypeOverrides[match?.match_id] || detectedType;
+}
+
 function isLikelyUSPSA(matchType) { return !NON_USPSA_TYPES.has(matchType); }
 function isConfirmedUSPSA(matchType) { return CONFIRMED_USPSA_TYPES.has(matchType); }
 
 function isChartable(r) {
-  return isLikelyUSPSA(r.match_type || 'Unknown');
+  return isLikelyUSPSA(effectiveMatchType(r));
 }
 
 // ── Cross-division HHF normalization (field-strength adjustment) ──────────────
@@ -708,7 +750,7 @@ function hideOnboarding() {
 }
 
 // ── Restore persisted state on load ──────────────────────────────────────────
-chrome.storage.local.get(['memberNumber', 'name', 'lastMatchList', 'matchCache', 'deselectedMatches', 'stageOverrides', 'classificationData', 'selectedDivision', 'fetchTimeline', 'last8Matches'], async d => {
+chrome.storage.local.get(['memberNumber', 'name', 'lastMatchList', 'matchCache', 'deselectedMatches', 'stageOverrides', 'classificationData', 'selectedDivision', 'fetchTimeline', 'last8Matches', 'matchTypeOverrides'], async d => {
   // Try restoring from sync if local has no credentials (e.g. after reinstall)
   if (!d.memberNumber && !d.name) {
     await restoreFromSync();
@@ -727,6 +769,7 @@ chrome.storage.local.get(['memberNumber', 'name', 'lastMatchList', 'matchCache',
   selectedFetchTimeline = normalizeFetchTimeline(d.fetchTimeline);
   fetchTimelineSelect.value = selectedFetchTimeline;
   last8Matches = d.last8Matches === true;
+  matchTypeOverrides = normalizeMatchTypeOverrides(d.matchTypeOverrides);
   renderLast8Control();
 
   // Lock inputs if we already have saved credentials
@@ -1835,7 +1878,8 @@ function renderMatchList() {
 
   sorted.forEach(match => {
     const hasStages  = !!(match.stages && match.stages.length > 0);
-    const matchType  = match.match_type || 'Unknown';
+    const matchType  = effectiveMatchType(match);
+    const isUnconfirmed = isUnconfirmedMatchType(match);
     const isUSPSA    = isChartable(match);
     const isDeselected = deselectedMatches.has(match.match_id);
     const isExcluded = !isUSPSA || isDeselected;
@@ -1874,9 +1918,9 @@ function renderMatchList() {
     }
     if (!isUSPSA) metaParts.push('excluded from charts');
 
-    const typeBadgeClass = !isChartable(match)                    ? 'type-other'    // red  — non-USPSA/non-HF sport
-                         : match.found_by === 'member_number'    ? 'type-uspsa'    // green — confirmed by member #
-                         : 'type-unknown';                                          // orange — name-only or not found
+    const typeBadgeClass = !isLikelyUSPSA(matchType)              ? 'type-other'
+                         : isConfirmedUSPSA(matchType)            ? 'type-uspsa'
+                         : 'type-unknown';
 
     const item = document.createElement('div');
     item.className = 'match-item' + (isExcluded ? ' excluded' : '');
@@ -1906,6 +1950,44 @@ function renderMatchList() {
     row.querySelector('.match-name').textContent = match.match_name;
     row.querySelector('.match-meta').textContent = metaParts.join(' · ');
     row.querySelector('.match-type-badge').textContent = matchType;
+
+    if (isUnconfirmed) {
+      const typeControl = document.createElement('label');
+      typeControl.className = 'match-type-control';
+      const typeLabel = document.createElement('span');
+      typeLabel.textContent = 'Type';
+      const typeSelect = document.createElement('select');
+      typeSelect.className = 'match-type-select';
+      typeSelect.setAttribute('aria-label', `Classify ${match.match_name || 'unconfirmed match'}`);
+      const resetOption = document.createElement('option');
+      resetOption.value = '';
+      resetOption.textContent = 'Keep unconfirmed';
+      typeSelect.appendChild(resetOption);
+      for (const supportedType of MANUAL_MATCH_TYPES) {
+        const option = document.createElement('option');
+        option.value = supportedType;
+        option.textContent = supportedType;
+        typeSelect.appendChild(option);
+      }
+      typeSelect.value = matchTypeOverrides[match.match_id] || '';
+      typeSelect.addEventListener('change', async () => {
+        typeSelect.disabled = true;
+        const stored = await chrome.storage.local.get('matchTypeOverrides');
+        const latestOverrides = normalizeMatchTypeOverrides(stored.matchTypeOverrides);
+        if (MANUAL_MATCH_TYPES.includes(typeSelect.value)) {
+          latestOverrides[match.match_id] = typeSelect.value;
+        } else {
+          delete latestOverrides[match.match_id];
+        }
+        await chrome.storage.local.set({ matchTypeOverrides: latestOverrides });
+        matchTypeOverrides = latestOverrides;
+        renderAll();
+        renderMatchList();
+        updateStatusCounts();
+      });
+      typeControl.append(typeLabel, typeSelect);
+      row.insertBefore(typeControl, row.querySelector('.match-type-badge'));
+    }
 
     if (hasStages) {
       const panel = document.createElement('div');
@@ -2342,9 +2424,9 @@ function setStatus(msg, type = '', loading = false) {
 function updateStatusCounts(verb) {
   if (!allResults.length) return;
   const visibleResults  = allResults.filter(matchesSelectedDivision);
-  const confirmedUSPSA  = visibleResults.filter(r => isConfirmedUSPSA(r.match_type || 'Unknown'));
-  const unconfirmed     = visibleResults.filter(r => isLikelyUSPSA(r.match_type || 'Unknown') && !isConfirmedUSPSA(r.match_type || 'Unknown'));
-  const nonUspsa        = visibleResults.filter(r => !isLikelyUSPSA(r.match_type || 'Unknown'));
+  const confirmedUSPSA  = visibleResults.filter(r => isConfirmedUSPSA(effectiveMatchType(r)));
+  const unconfirmed     = visibleResults.filter(r => effectiveMatchType(r) === 'Unknown');
+  const nonUspsa        = visibleResults.filter(r => !isLikelyUSPSA(effectiveMatchType(r)));
   const uspsa           = confirmedUSPSA.length;
   const scored          = confirmedUSPSA.filter(r => r.overall_pct != null).length;
   const checked         = confirmedUSPSA.filter(r => !deselectedMatches.has(r.match_id)).length;


### PR DESCRIPTION
## Summary

Add durable per-match type overrides for otherwise unconfirmed Match History rows and apply the effective type to dashboard analytics and full-fetch eligibility.

## Files Changed

DESIGN.md, README.md, extension/background.js, extension/dashboard.html, extension/dashboard.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — node syntax checks, build.sh qa-match-types, git diff --check, instrumented background fetch/refresh assertions, and browser QA at 375px and 1920px in both themes

Resolves #48


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.292 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 22h 26m and 3,505,077 tokens on this with the user in an interactive session.