### PR TITLE
chore: release v1.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable user-facing changes are documented here. Update this file before pub
 
 ## Unreleased
 
+## v1.6.6 — 2026-08-27
+
+### Added
+
+- A persisted **Last 8** switch focuses charts, summaries, classifier analysis, and CSV exports on the eight most recent qualifying matches without trimming Match History or cached data.
+- A separate **Fetch timeline** control limits new PractiScore requests to one month, three months, six months, one year, three years, or all time while preserving older cached history.
+- **Adjusted % Only** mode plots cached field-strength-adjusted results without falling back to raw match percentages.
+- Unconfirmed Match History rows can now be classified manually as USPSA, IDPA, IPSC, Steel Challenge, 3-Gun, PCSL, or ICORE. Non-USPSA choices prevent unnecessary requests on later full fetches.
+
+### Changed
+
+- Trend summaries now use documented percentage-point thresholds with an explicit **Stable** state, and dense charts space date labels by rendered width while retaining every point and tooltip.
+- Regular match and non-classifier charts now use clear linear 0–100% match-performance scales. USPSA class bands and class metadata remain exclusive to official classifier percentages.
+- Adjusted % summaries identify dominant GM or Master field context only when the underlying stage evidence supports it, with neutral wording for mixed or unavailable references.
+
 ## v1.6.5 — 2026-08-26
 
 ### Added

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hit Factor Charts",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "Track your USPSA match performance: division %, adjusted field-strength scores, classifier trends, and placement over time.",
   "permissions": ["tabs", "scripting", "storage"],
   "host_permissions": ["https://practiscore.com/*", "https://s3.amazonaws.com/*", "https://api.github.com/*", "https://uspsa.org/*", "https://objects.githubusercontent.com/*"],


### PR DESCRIPTION
## Summary

- add reviewed v1.6.6 release notes for all user-facing changes merged since v1.6.5
- bump the Chrome extension manifest from 1.6.5 to 1.6.6
- trigger the repository release workflow after merge

## Verification

- `python3 -m json.tool extension/manifest.json`
- `node --check extension/dashboard.js`
- `node --check extension/background.js`
- `./build.sh` produced `dist/hitfactorcharts-v1.6.6.zip`
- verified the release workflow regex extracts the complete v1.6.6 changelog section
- `git diff --check`
- repository pre-commit and pre-push quality gates

This release includes the merged work from PRs #41, #42, #43, #44, #45, #52, #53, and #54.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.292 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 22h 52m and 3,580,642 tokens on this with the user in an interactive session.