### PR TITLE
GH#56: Reuse cached matches on broader fetches

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -47,6 +47,7 @@ Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter
 - Fetch timeline controls pre-fetch request scope; analytics presets independently filter cached data. Keep that distinction explicit in status and documentation.
 - The current visible select value is the next fetch scope. Changing it alone makes no request.
 - Preserve older cache and Match History entries when a narrower timeline is fetched. Explicit single-match refresh remains unrestricted.
+- On a broader later fetch, reuse valid per-match cache entries for the same member before the score/stage loop and request only missing matches. Report reused and requested counts in the progress log.
 - Keep the label and select together as controls wrap at narrow widths, with visible focus and no page-level horizontal overflow.
 
 ## Last 8 analytics

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Analytics open on the most recent **6 mo** so trends stay readable. Use the butt
 
 The **Last 8 matches** switch applies after the active analytics date range, division, Scored/All view, and manually selected matches. Turn it on to use the most recent eight qualifying matches across every chart, summary, classifier analysis, and chart CSV export. If fewer than eight qualify, all available matches are used. The preference is remembered, while Match History and cached records remain complete.
 
-The **Fetch timeline** dropdown beside **Fetch Scores** is separate: it limits network requests before a fetch begins and remembers your last choice. A narrower fetch merges new results with older cached Match History instead of deleting it. Choose a broader timeline to retrieve older uncached matches; changing the dropdown or Last 8 switch alone does not make a request. **all time** keeps the original unrestricted fetch behavior, and refreshing one match remains unrestricted.
+The **Fetch timeline** dropdown beside **Fetch Scores** is separate: it limits network requests before a fetch begins and remembers your last choice. A narrower fetch merges new results with older cached Match History instead of deleting it. When you later choose a broader timeline, matches already cached for the same member are reused and only missing matches receive score and stage requests; the progress log reports both counts. Changing the dropdown or Last 8 switch alone does not make a request. **all time** expands discovery without discarding reusable cached matches, and refreshing one match remains unrestricted.
 
 ### Exporting data
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -261,6 +261,12 @@ function buildResult(match, score, memberNumber) {
   };
 }
 
+function isReusableMatchCache(cached, memberNumber) {
+  if (!cached || typeof cached !== 'object') return false;
+  const expectedOwner = (memberNumber || '').toUpperCase() || null;
+  return cached.cached_for === expectedOwner;
+}
+
 // ── results/new/{matchId} scraper — injected into tab ─────────────────────────
 // Reads the dynamically-rendered table in #mainResultsDiv plus the dropdown
 // options for #resultLevel and #divisionLevel.
@@ -985,7 +991,6 @@ async function fetchScores(memberNumber, name, requestedTimeline) {
       push(`Skipping ${skipped} non-USPSA match(es): ${names}`);
     }
 
-    push(`Fetching scores for ${uspsaMatches.length} in-range USPSA match(es)…`);
     const results = [];
 
     // Include non-USPSA matches in results (without scores) for history display
@@ -993,17 +998,26 @@ async function fetchScores(memberNumber, name, requestedTimeline) {
       results.push(buildResult(m, {}, memberNumber));
     }
 
-    for (let i = 0; i < uspsaMatches.length; i++) {
-      const match = uspsaMatches[i];
-      push(`  → [${i + 1}/${uspsaMatches.length}] ${match.match_name} (${match.date})`);
-
+    const cachedMatches = [];
+    const uncachedMatches = [];
+    for (const match of uspsaMatches) {
       const cached = cache[match.match_id];
-      // Only use cache if it was fetched for the same member number
-      if (cached && cached.cached_for === (memberNumber || '').toUpperCase()) {
-        push('     (cached)');
-        results.push({ ...match, ...cached, _cached: true });
-        continue;
-      }
+      if (isReusableMatchCache(cached, memberNumber)) cachedMatches.push(match);
+      else uncachedMatches.push(match);
+    }
+
+    for (const match of cachedMatches) {
+      results.push({ ...match, ...cache[match.match_id], _cached: true });
+    }
+    if (cachedMatches.length > 0) {
+      push(`Reusing ${cachedMatches.length} cached in-range match(es).`);
+    }
+
+    push(`Fetching scores for ${uncachedMatches.length} uncached in-range USPSA match(es)…`);
+
+    for (let i = 0; i < uncachedMatches.length; i++) {
+      const match = uncachedMatches[i];
+      push(`  → [${i + 1}/${uncachedMatches.length}] ${match.match_name} (${match.date})`);
 
       const score  = await fetchMatchScore(tabId, match.match_id, memberNumber, name, push);
 
@@ -1031,12 +1045,13 @@ async function fetchScores(memberNumber, name, requestedTimeline) {
     await chrome.storage.local.set({ lastMatchList: mergedMatchList });
 
     const n = results.filter(r => r.overall_pct != null).length;
-    push(`Done — ${n}/${uspsaMatches.length} matches with scores.`);
+    const newlyScoredCount = results.filter(r => r._cached === false && r.overall_pct != null).length;
+    push(`Done — ${n}/${uspsaMatches.length} matches with scores; ${cachedMatches.length} reused, ${uncachedMatches.length} requested.`);
 
-    // Fetch USPSA classification only if at least one scored match was found
+    // Refresh USPSA classification only when this run fetched at least one new score.
     let classificationData = null;
     let _not_logged_in_uspsa = false;
-    if (memberNumber && n > 0) {
+    if (memberNumber && newlyScoredCount > 0) {
       const clfResult = await fetchUSPSAClassification(memberNumber, push);
       if (clfResult?._not_logged_in) {
         _not_logged_in_uspsa = true;
@@ -1050,7 +1065,7 @@ async function fetchScores(memberNumber, name, requestedTimeline) {
     const combinedResults = mergedMatchList.map(match => {
       if (fetchedById.has(match.match_id)) return fetchedById.get(match.match_id);
       const cached = cache[match.match_id];
-      if (cached && cached.cached_for === (memberNumber || '').toUpperCase()) {
+      if (isReusableMatchCache(cached, memberNumber)) {
         return { ...match, ...cached, _cached: true };
       }
       return buildResult(match, {}, memberNumber);


### PR DESCRIPTION
## Summary

Partition reusable and missing matches before the score/stage loop so broader timelines request only uncached data, while reporting reuse and preserving explicit refresh behavior.

## Files Changed

DESIGN.md, README.md, extension/background.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — node syntax check, release-style build, git diff check, and instrumented two-pass cache assertions covering same-member reuse, mismatched owners, name-only cache, score/stage request counts, and classification refresh suppression

Resolves #56


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.292 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 23h 21m and 3,653,239 tokens on this with the user in an interactive session.