### PR TITLE
GH#60: feat: add neutral percentage chart guides

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -32,6 +32,7 @@ Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter
 - Non-classifier stage percentages are match-relative comparisons with each stage's top shooter. Present them on a linear 0–100% scale without USPSA classification bands, labels, colours, or warped geometry.
 - Keep same-day non-classifier matches as separate chart points and tooltips while rendering their shared date label only once.
 - Regular Score Over Time uses a linear percentage scale without classification bands, inferred class labels, class colours, or warped geometry. Division % and Adjusted % are match-performance signals, not official classifications.
+- Score Over Time, Adjusted % Only, Non-Classifier Stage Trend, and Classifier vs Match Score use neutral numeric reference guides at 40%, 60%, 75%, 85%, and 95%. Keep these guides linear, theme-aware, and unlabeled beyond their numeric axis ticks; never present them as classes or class-coloured regions.
 - Show GM/M/A/B/C/D context only for nationally normalized `clf_pct` values. Match-relative classifier fallbacks must be identified as such and must not receive inferred class labels.
 - Place **Adjusted % Only** beside **Classifiers Only** as matching native-checkbox switches. Both controls expose visible keyboard focus, wrap together at narrow widths, and never create page-level overflow.
 - Adjusted-only and classifiers-only modes are mutually exclusive. Adjusted-only displays cached adjusted points without raw fallback and uses a clear multi-line empty state when fewer than two usable points exist.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ When adjusted and raw division averages are nearly identical, the dashboard iden
 
 Use **Adjusted % Only** beside **Classifiers Only** to inspect the adjusted series without raw match percentages. The modes are mutually exclusive because adjusted scores exclude classifier stages. Adjusted-only mode never falls back to raw scores; when fewer than two usable adjusted matches are available, the chart explains that older matches may need to be refreshed to load non-classifier cross-division benchmark data. Switching modes uses cached data and does not fetch or rewrite match history.
 
+Score Over Time, Adjusted % Only, Non-Classifier Stage Trend, and Classifier vs Match Score include neutral numeric reference lines at 40%, 60%, 75%, 85%, and 95%. These lines preserve a linear 0–100% scale for visual comparison only; they do not infer a USPSA class, add class-coloured bands, or change official classifier context.
+
 ---
 
 ## Requirements
@@ -123,7 +125,7 @@ Below the Score Over Time and Placement charts, plain-English summaries show:
 
 Summaries appear automatically once enough data is loaded. Classifier trend requires at least 6 classifier stages.
 
-The **Non-Classifier Stage Trend** averages your included non-classifier stage percentages for each match. Each percentage compares your hit factor with the top shooter on that stage at that match. It uses a linear 0–100% scale and is useful for tracking match-relative performance, but it is not an official USPSA classification percentage and does not use GM/M/A/B/C/D bands.
+The **Non-Classifier Stage Trend** averages your included non-classifier stage percentages for each match. Each percentage compares your hit factor with the top shooter on that stage at that match. It uses a linear 0–100% scale and is useful for tracking match-relative performance, but it is not an official USPSA classification percentage and does not use GM/M/A/B/C/D bands. Its 40%, 60%, 75%, 85%, and 95% lines are numeric percentage references only.
 
 ### Filtering by date
 

--- a/extension/dashboard-charts.js
+++ b/extension/dashboard-charts.js
@@ -6,6 +6,43 @@
 
 const PAD        = { top: 24, right: 52, bottom: 44, left: 48 };
 const FONT       = '11px Inter, system-ui, sans-serif';
+// Neutral reference percentages for match-performance charts. These are numeric
+// guides only; official classifier charts retain their separate class semantics.
+const USPSA_PERCENTAGE_REFERENCE_GUIDES = [40, 60, 75, 85, 95];
+
+function chartYAxisTicks(rawMin, rawMax, showPercentageReferenceGuides = false) {
+  if (!showPercentageReferenceGuides) {
+    return Array.from({ length: 6 }, (_, index) => rawMin + (rawMax - rawMin) * index / 5);
+  }
+
+  return [...new Set([
+    rawMin,
+    ...USPSA_PERCENTAGE_REFERENCE_GUIDES.filter(value => value > rawMin && value < rawMax),
+    rawMax,
+  ])].sort((left, right) => left - right);
+}
+
+function drawYAxisTicks(ctx, area, toY, ticks) {
+  ctx.save();
+  ctx.strokeStyle = GRID_COLOR();
+  ctx.lineWidth = 1;
+  ctx.setLineDash([]);
+  ctx.globalAlpha = 1;
+
+  ticks.forEach(value => {
+    const cy = toY(value);
+    ctx.beginPath();
+    ctx.moveTo(area.x0, cy);
+    ctx.lineTo(area.x0 + area.w, cy);
+    ctx.stroke();
+    ctx.fillStyle = TEXT_COLOR();
+    ctx.font = FONT;
+    ctx.textAlign = 'right';
+    ctx.fillText(value.toFixed(0), area.x0 - 5, cy + 3);
+  });
+
+  ctx.restore();
+}
 
 function selectAxisTickIndices(labels, positions, measureText, minGap = 10) {
   if (!labels.length || labels.length !== positions.length) return [];
@@ -183,7 +220,8 @@ function drawMultiSeriesChart(canvas, seriesArr, allDates, opts = {}) {
 
   const {
     yLabel = '', yMin, yMax, invertY = false, trend = false, valueUnit = '%',
-    showClassBands = false, preserveDuplicateDates = false,
+    showClassBands = false, showPercentageReferenceGuides = false,
+    preserveDuplicateDates = false,
   } = opts;
 
   const allY   = seriesArr.flatMap(s => s.points.map(p => p.y)).filter(v => v != null);
@@ -239,14 +277,12 @@ function drawMultiSeriesChart(canvas, seriesArr, allDates, opts = {}) {
     });
   }
 
-  // Grid
-  ctx.strokeStyle = GRID_COLOR(); ctx.lineWidth = 1;
-  for (let i = 0; i <= 5; i++) {
-    const v = rawMin + yRange * i / 5, cy = toY(v);
-    ctx.beginPath(); ctx.moveTo(area.x0, cy); ctx.lineTo(area.x0 + area.w, cy); ctx.stroke();
-    ctx.fillStyle = TEXT_COLOR(); ctx.font = FONT; ctx.textAlign = 'right';
-    ctx.fillText(v.toFixed(0), area.x0 - 5, cy + 3);
-  }
+  drawYAxisTicks(
+    ctx,
+    area,
+    toY,
+    chartYAxisTicks(rawMin, rawMax, showPercentageReferenceGuides)
+  );
 
   // Axes
   ctx.strokeStyle = AXIS_COLOR(); ctx.lineWidth = 1;
@@ -450,7 +486,10 @@ function drawLineChart(canvas, points, opts = {}) {
   const area = chartArea(canvas);
   clearCanvas(ctx, canvas);
 
-  const { yLabel = '', yMin, yMax, invertY = false, color = '#4a9eff', trend = false } = opts;
+  const {
+    yLabel = '', yMin, yMax, invertY = false, color = '#4a9eff', trend = false,
+    showPercentageReferenceGuides = false,
+  } = opts;
 
   const xs     = points.map((_, i) => i);
   const ys     = points.map(p => p.y);
@@ -464,14 +503,12 @@ function drawLineChart(canvas, points, opts = {}) {
     return invertY ? area.y0 + norm * area.h : area.y0 + (1 - norm) * area.h;
   };
 
-  // Grid
-  ctx.strokeStyle = GRID_COLOR(); ctx.lineWidth = 1;
-  for (let i = 0; i <= 5; i++) {
-    const v = rawMin + yRange * i / 5, cy = toY(v);
-    ctx.beginPath(); ctx.moveTo(area.x0, cy); ctx.lineTo(area.x0 + area.w, cy); ctx.stroke();
-    ctx.fillStyle = TEXT_COLOR(); ctx.font = FONT; ctx.textAlign = 'right';
-    ctx.fillText(v.toFixed(0), area.x0 - 5, cy + 3);
-  }
+  drawYAxisTicks(
+    ctx,
+    area,
+    toY,
+    chartYAxisTicks(rawMin, rawMax, showPercentageReferenceGuides)
+  );
 
   // Axes
   ctx.strokeStyle = AXIS_COLOR(); ctx.lineWidth = 1;

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -1423,8 +1423,9 @@
     <canvas id="chartTime" height="380"></canvas>
     <div class="chart-note">
       <strong>Division %</strong> is your score relative to the top shooter in your division at that match — it tells you how you placed, but it only reflects who happened to show up in your division that day.
-      <strong>Adjusted %</strong> is a field-strength correction: it takes the top stage hit factor from every division at that match, translates each result to your division's equivalent using national HHF ratios from hitfactor.info, and measures you against the strongest normalized result.
-      Adjusted % is the more meaningful progress indicator because it compares you with the strongest normalized stage result at that match, regardless of division. Neither match metric is an official USPSA classification percentage; use Classifiers Only for nationally normalized classifier context.
+       <strong>Adjusted %</strong> is a field-strength correction: it takes the top stage hit factor from every division at that match, translates each result to your division's equivalent using national HHF ratios from hitfactor.info, and measures you against the strongest normalized result.
+       Adjusted % is the more meaningful progress indicator because it compares you with the strongest normalized stage result at that match, regardless of division. Neither match metric is an official USPSA classification percentage; use Classifiers Only for nationally normalized classifier context.
+       The numeric 40%, 60%, 75%, 85%, and 95% lines are neutral percentage references, not inferred USPSA classifications.
     </div>
     <div class="chart-summary" id="chartTimeSummary" style="display:none"></div>
     <div class="chart-summary chart-summary--adj" id="chartAdjSummary" style="display:none"></div>
@@ -1440,14 +1441,14 @@
   <div class="chart-section" id="chartNonClfSection" style="display:none">
     <div class="chart-section-header">
       <h3>Non-Classifier Stage Trend</h3>
-      <span class="chart-subtitle">Average stage % compared with each match's top shooter — not a USPSA classification</span>
+      <span class="chart-subtitle">Average stage % compared with each match's top shooter — neutral numeric guides, not USPSA classifications</span>
     </div>
     <canvas id="chartNonClf" height="380"></canvas>
   </div>
   <div class="chart-section" id="chartClfOverlaySection" style="display:none">
     <div class="chart-section-header">
       <h3>Classifier vs Match Score</h3>
-      <span style="font-size:12px;color:#666;text-transform:uppercase;letter-spacing:0.5px">Are your classifier scores tracking your match performance?</span>
+      <span style="font-size:12px;color:#666;text-transform:uppercase;letter-spacing:0.5px">Numeric guides compare percentage references; they are not class bands</span>
     </div>
     <canvas id="chartClfOverlay" height="380"></canvas>
     <div class="chart-summary" id="chartClfSummary" style="display:none"></div>

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -1467,6 +1467,7 @@ function renderAll() {
         {
           yLabel: 'Adjusted match %', yMin: 0, yMax: 100, invertY: false,
           trend: true, valueUnit: 'match%', preserveDuplicateDates: true,
+          showPercentageReferenceGuides: true,
         }
       );
     } else {
@@ -1483,6 +1484,7 @@ function renderAll() {
     drawMultiSeriesChart(document.getElementById('chartTime'), scoreSeries, allDates, {
       yLabel: 'Match performance %', yMin: 0, yMax: 100, invertY: false,
       trend: scoreSeries.length <= 2, valueUnit: 'match%',
+      showPercentageReferenceGuides: true,
     });
   }
 
@@ -1567,6 +1569,7 @@ function renderAll() {
     drawMultiSeriesChart(document.getElementById('chartNonClf'), nonClfSeries, nonClfDates, {
       yLabel: '% compared with top shooter', yMin: 0, yMax: 100, invertY: false,
       trend: true, valueUnit: 'top%', preserveDuplicateDates: true,
+      showPercentageReferenceGuides: true,
     });
   } else {
     nonClfSection.style.display = 'none';
@@ -1612,7 +1615,7 @@ function renderAll() {
     ];
     drawMultiSeriesChart(document.getElementById('chartClfOverlay'), overlaySeries, allOverlayDates, {
       yLabel: '%', yMin: 0, yMax: 100, invertY: false, trend: false, valueUnit: '%',
-      showClassBands: true,
+      showPercentageReferenceGuides: true,
     });
   } else {
     clfOverlaySection.style.display = 'none';


### PR DESCRIPTION
## Summary

Adds shared neutral 40/60/75/85/95 percentage ticks to applicable match-performance charts, removes mixed chart class bands, and clarifies the semantics in the UI and documentation.

## Files Changed

DESIGN.md, README.md, extension/dashboard-charts.js, extension/dashboard.html, extension/dashboard.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — node --check extension/dashboard.js; node --check extension/dashboard-charts.js; ./build.sh qa60; git diff --check

Resolves #60


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.292 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-terra spent 4m and 110,745 tokens on this as a headless worker.