### PR TITLE
GH#61: Reveal detailed hit-zone outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes are documented here. Update this file before pub
 
 ## Unreleased
 
+### Changed
+
+- Hit Zone Breakdown now preserves reported B, separate M/NS, and combined M+NS source data, leaves unavailable legacy fields blank, and uses a disclosed nonlinear visual scale to make smaller outcomes readable without changing raw percentages or exports.
+
 ## v1.6.6 — 2026-08-27
 
 ### Added

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -36,6 +36,10 @@ Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter
 - Show GM/M/A/B/C/D context only for nationally normalized `clf_pct` values. Match-relative classifier fallbacks must be identified as such and must not receive inferred class labels.
 - Place **Adjusted % Only** beside **Classifiers Only** as matching native-checkbox switches. Both controls expose visible keyboard focus, wrap together at narrow widths, and never create page-level overflow.
 - Adjusted-only and classifiers-only modes are mutually exclusive. Adjusted-only displays cached adjusted points without raw fallback and uses a clear multi-line empty state when fewer than two usable points exist.
+- Hit Zone Breakdown stores and exports raw reported counts only. Source-column availability is part of each refreshed stage record; legacy records without it are unknown, and combined M+NS data must never be split into invented M and NS values.
+- The hit-zone denominator is the reported A/B/C/D/M/NS or combined M+NS total. Procedural penalties remain outside it and are disclosed in chart help and tooltips.
+- Hit-zone geometry transforms cumulative boundaries, never individual stored values: raw 0–50% maps linearly to 0–30% visual height, and raw 50–100% maps linearly to 30–100%. Raw ticks render at transformed positions, ordering is stable, and the cumulative endpoint remains 100%.
+- Use distinct theme-safe colours and stable order for A, conditional positive B, C, D, separate M, separate NS, and combined M+NS. Tooltips and exports retain exact raw counts and percentages.
 
 ## Analytics date range
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ Summaries appear automatically once enough data is loaded. Classifier trend requ
 
 The **Non-Classifier Stage Trend** averages your included non-classifier stage percentages for each match. Each percentage compares your hit factor with the top shooter on that stage at that match. It uses a linear 0–100% scale and is useful for tracking match-relative performance, but it is not an official USPSA classification percentage and does not use GM/M/A/B/C/D bands. Its 40%, 60%, 75%, 85%, and 95% lines are numeric percentage references only.
 
+The **Hit Zone Breakdown** uses the reported A/B/C/D/M/NS columns for included stages. B appears only when a positive B count is reported. Separate M and NS source columns remain separate; a combined source column is labelled **M+NS** and is never split. Older cached stages without column-availability metadata show blanks until that match is refreshed, so an unavailable field is not presented as an authoritative zero.
+
+Hit-zone percentages use the **reported hit-zone total** as their denominator. Procedural penalties are disclosed but excluded. Raw counts and percentages remain unchanged in tooltips and exports; only the chart geometry is nonlinear. Cumulative raw boundaries from 0–50% occupy 0–30% of visual height, and boundaries from 50–100% occupy 30–100%, making smaller outcomes easier to distinguish while preserving order and the 100% endpoint.
+
 ### Filtering by date
 
 Analytics open on the most recent **6 mo** so trends stay readable. Use the buttons above the charts to switch to **Last 1 month**, **3 mo**, **6 mo**, **1 yr**, **3 yr**, or **all time**. The active range applies to every chart, summary statistic, classifier-only view, and chart CSV export without re-fetching or deleting older Match History records.
@@ -137,9 +141,9 @@ The **Fetch timeline** dropdown beside **Fetch Scores** is separate: it limits n
 
 ### Exporting data
 
-**As image:** Click the floppy-disk icon on any match row to open the export menu. Choose **Full Match** for a match summary card or any individual stage for a per-stage card. Both download as PNG at 2× resolution.
+**As image:** Click the floppy-disk icon on any match row to open the export menu. Choose **Full Match** for a match summary card or any individual stage for a per-stage card. Both download as PNG at 2× resolution. Stage cards preserve separate M/NS or an explicitly combined M+NS value and omit unavailable hit columns.
 
-**As CSV:** Click **⤓ CSV** in the chart section header to download all currently visible match data as a spreadsheet. One row per stage, includes match name, division, class, overall %, div %, placement, stage HF, time, hit counts (A/C/D/M/NS/P), classifier number, and official USPSA %.
+**As CSV:** Click **⤓ CSV** in the chart section header to download all currently visible match data as a spreadsheet. One row per stage, includes match name, division, class, overall %, div %, placement, stage HF, time, reported hit counts (A/B/C/D/M/NS/M+NS/P), classifier number, and official USPSA %. Unavailable source columns remain blank; reported zeroes remain zero.
 
 ### Filtering matches
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -335,12 +335,18 @@ function getResultsNewState(mem, nm) {
     hf:    ths.findIndex(h => /^(hf|hit\s*factor)$/.test(h)),
     time:  ths.findIndex(h => /^time$/.test(h)),
     a:     ths.findIndex(h => h === 'a'),
+    b:     ths.findIndex(h => h === 'b'),
     c:     ths.findIndex(h => h === 'c'),
     d:     ths.findIndex(h => h === 'd'),
     m:     ths.findIndex(h => h === 'm'),
-    ns:    ths.findIndex(h => h === 'ns' || h === 'n/s' || h === 'ns/m'),
+    ns:    ths.findIndex(h => h === 'ns' || h === 'n/s'),
+    m_ns:  ths.findIndex(h => /^(?:m\s*[+/&]\s*ns|ns\s*[+/&]\s*m)$/.test(h)),
     p:     ths.findIndex(h => h === 'p' || h === 'proc' || h === 'pen'),
   };
+
+  const hitColumns = Object.fromEntries(
+    ['a', 'b', 'c', 'd', 'm', 'ns', 'm_ns', 'p'].map(key => [key, hi[key] >= 0])
+  );
 
   let rows = Array.from(table.querySelectorAll('tbody tr'));
   if (!rows.length) rows = Array.from(table.querySelectorAll('tr')).slice(1);
@@ -351,16 +357,18 @@ function getResultsNewState(mem, nm) {
 
   function parseRow(row) {
     const cells = Array.from(row.querySelectorAll('td')).map(td => td.textContent.trim());
-    const out   = { total };
+    const out   = { total, hit_columns: hitColumns };
     if (hi.div  >= 0) out.division = cells[hi.div] || '';
     if (hi.cls  >= 0) out.class_   = cells[hi.cls] || '';
     if (hi.hf   >= 0) out.hf       = parseFloat(cells[hi.hf])   || null;
     if (hi.time >= 0) out.time     = parseFloat(cells[hi.time])  || null;
     if (hi.a    >= 0) out.a        = parseInt(cells[hi.a])   || 0;
+    if (hi.b    >= 0) out.b        = parseInt(cells[hi.b])   || 0;
     if (hi.c    >= 0) out.c        = parseInt(cells[hi.c])   || 0;
     if (hi.d    >= 0) out.d        = parseInt(cells[hi.d])   || 0;
     if (hi.m    >= 0) out.m        = parseInt(cells[hi.m])   || 0;
     if (hi.ns   >= 0) out.ns       = parseInt(cells[hi.ns])  || 0;
+    if (hi.m_ns >= 0) out.m_ns     = parseInt(cells[hi.m_ns]) || 0;
     if (hi.p    >= 0) out.p        = parseInt(cells[hi.p])   || 0;
 
     if (hi.place >= 0) out.place = parseInt(cells[hi.place]) || null;
@@ -481,27 +489,35 @@ function scrapeHTMLResultsPage(mem, nm) {
     hf:    ths.findIndex(h => /^(hf|hit\s*factor)$/.test(h)),
     time:  ths.findIndex(h => /^time$/.test(h)),
     a:     ths.findIndex(h => h === 'a'),
+    b:     ths.findIndex(h => h === 'b'),
     c:     ths.findIndex(h => h === 'c'),
     d:     ths.findIndex(h => h === 'd'),
     m:     ths.findIndex(h => h === 'm'),
-    ns:    ths.findIndex(h => h === 'ns' || h === 'n/s' || h === 'ns/m'),
+    ns:    ths.findIndex(h => h === 'ns' || h === 'n/s'),
+    m_ns:  ths.findIndex(h => /^(?:m\s*[+/&]\s*ns|ns\s*[+/&]\s*m)$/.test(h)),
     p:     ths.findIndex(h => h === 'p' || h === 'proc' || h === 'pen'),
   };
+
+  const hitColumns = Object.fromEntries(
+    ['a', 'b', 'c', 'd', 'm', 'ns', 'm_ns', 'p'].map(key => [key, hi[key] >= 0])
+  );
 
   const total = rows.length;
 
   function parseRow(row) {
     const cells = Array.from(row.querySelectorAll('td')).map(td => td.textContent.trim());
-    const out = { total };
+    const out = { total, hit_columns: hitColumns };
     if (hi.div  >= 0) out.division = cells[hi.div] || '';
     if (hi.cls  >= 0) out.class_   = cells[hi.cls] || '';
     if (hi.hf   >= 0) out.hf       = parseFloat(cells[hi.hf]) || null;
     if (hi.time >= 0) out.time     = parseFloat(cells[hi.time]) || null;
     if (hi.a    >= 0) out.a        = parseInt(cells[hi.a])  || 0;
+    if (hi.b    >= 0) out.b        = parseInt(cells[hi.b])  || 0;
     if (hi.c    >= 0) out.c        = parseInt(cells[hi.c])  || 0;
     if (hi.d    >= 0) out.d        = parseInt(cells[hi.d])  || 0;
     if (hi.m    >= 0) out.m        = parseInt(cells[hi.m])  || 0;
     if (hi.ns   >= 0) out.ns       = parseInt(cells[hi.ns]) || 0;
+    if (hi.m_ns >= 0) out.m_ns     = parseInt(cells[hi.m_ns]) || 0;
     if (hi.p    >= 0) out.p        = parseInt(cells[hi.p])  || 0;
     // Place: dedicated column or leading digits in first cell
     if (hi.place >= 0) out.place = parseInt(cells[hi.place]) || null;
@@ -738,12 +754,15 @@ async function fetchStageData(tabId, matchId, memberNumber, name, divKey, stageO
       time:            d.time ?? null,
       hf:              d.hf   ?? null,
       pct:             d.overall_pct ?? null,
-      a:               d.a  ?? 0,
-      c:               d.c  ?? 0,
-      d:               d.d  ?? 0,
-      m:               d.m  ?? 0,
-      ns:              d.ns ?? 0,
-      p:               d.p  ?? 0,
+      a:               d.a  ?? null,
+      b:               d.b  ?? null,
+      c:               d.c  ?? null,
+      d:               d.d  ?? null,
+      m:               d.m  ?? null,
+      ns:              d.ns ?? null,
+      m_ns:            d.m_ns ?? null,
+      p:               d.p  ?? null,
+      hit_columns:     d.hit_columns,
       gm_median_hf,
       xdiv_benchmarks,
       is_classifier:   null,

--- a/extension/dashboard-charts.js
+++ b/extension/dashboard-charts.js
@@ -437,13 +437,15 @@ function drawMultiSeriesChart(canvas, seriesArr, allDates, opts = {}) {
             ? `<div class="tt-meta">${escHtml(h.match_name)}</div>` : '';
           const hfLine = (h.hf != null && !h.stages?.length)
             ? `<div class="tt-meta">HF ${h.hf.toFixed(4)}</div>` : '';
-          const hitsLine = (!h.stages?.length && (h.a || h.c || h.d || h.m || h.ns || h.p_))
+          const hitsLine = (!h.stages?.length && (h.a || h.b || h.c || h.d || h.m || h.ns || h.m_ns || h.p_))
             ? `<div class="tt-meta">${[
                 h.a  ? `<span style="color:#4caf50">${h.a}A</span>`                    : '',
+                h.b  ? `<span style="color:#3b82f6">${h.b}B</span>`                    : '',
                 h.c  ? `<span style="color:#fdd835">${h.c}C</span>`                    : '',
                 h.d  ? `<span style="color:#ff9800">${h.d}D</span>`                    : '',
                 h.m  ? `<span style="color:#f44336;font-weight:600">${h.m}M</span>`   : '',
-                h.ns ? `<span style="color:#f44336;font-weight:600">${h.ns}NS</span>` : '',
+                h.ns ? `<span style="color:#d946ef;font-weight:600">${h.ns}NS</span>` : '',
+                h.m_ns ? `<span style="color:#8b5cf6;font-weight:600">${h.m_ns} M+NS</span>` : '',
                 h.p_ ? `<span style="color:#f44336">${h.p_}P</span>`                  : '',
               ].filter(Boolean).join(' ')}</div>` : '';
           const stagesHtml = (h.stages && h.stages.length > 0)
@@ -454,7 +456,7 @@ function drawMultiSeriesChart(canvas, seriesArr, allDates, opts = {}) {
                 <div class="tt-stage-row">
                   <span class="tt-stage-name">${clfBadge}${escHtml(s.name)}</span>
                   <span class="tt-stage-hf">${s.hf != null ? s.hf.toFixed(4) : '—'}</span>
-                  <span class="tt-stage-hits">${s.a ? '<span style="color:#4caf50">' + s.a + 'A</span> ' : ''}${s.c ? '<span style="color:#fdd835">' + s.c + 'C</span> ' : ''}${s.d ? '<span style="color:#ff9800">' + s.d + 'D</span>' : ''}${s.m ? ' <span style="color:#f44336;font-weight:600">' + s.m + 'M</span>' : ''}${s.ns ? ' <span style="color:#f44336;font-weight:600">' + s.ns + 'NS</span>' : ''}${s.p ? ' <span style="color:#f44336">' + s.p + 'P</span>' : ''}</span>
+                  <span class="tt-stage-hits">${reportedStageHit(s, 'a') ? '<span style="color:#4caf50">' + reportedStageHit(s, 'a') + 'A</span> ' : ''}${reportedStageHit(s, 'b') ? '<span style="color:#3b82f6">' + reportedStageHit(s, 'b') + 'B</span> ' : ''}${reportedStageHit(s, 'c') ? '<span style="color:#fdd835">' + reportedStageHit(s, 'c') + 'C</span> ' : ''}${reportedStageHit(s, 'd') ? '<span style="color:#ff9800">' + reportedStageHit(s, 'd') + 'D</span>' : ''}${reportedStageHit(s, 'm') ? ' <span style="color:#f44336;font-weight:600">' + reportedStageHit(s, 'm') + 'M</span>' : ''}${reportedStageHit(s, 'ns') ? ' <span style="color:#d946ef;font-weight:600">' + reportedStageHit(s, 'ns') + 'NS</span>' : ''}${reportedStageHit(s, 'm_ns') ? ' <span style="color:#8b5cf6;font-weight:600">' + reportedStageHit(s, 'm_ns') + ' M+NS</span>' : ''}${reportedStageHit(s, 'p') ? ' <span style="color:#f44336">' + reportedStageHit(s, 'p') + 'P</span>' : ''}</span>
                 </div>`;
               }).join('')}</div>` : '';
           tooltipEl.innerHTML = `
@@ -622,23 +624,34 @@ function drawMessage(canvas, msg) {
 }
 
 // ── Stacked bar chart — hit zone breakdown ────────────────────────────────────
-// bars: [{ date, label, aPct, cPct, dPct, badPct, a, c, d, bad, total }]
-// Segments: A (green) / C (yellow) / D (orange) / M+NS (red)
+// Raw shares are stored on each bar. Only cumulative display boundaries are
+// transformed: 0–50% raw maps to 0–30% visual; 50–100% maps to 30–100%.
+function hitZoneVisualPct(rawPct) {
+  const bounded = Math.max(0, Math.min(100, rawPct));
+  return bounded <= 50 ? bounded * 0.6 : 30 + (bounded - 50) * 1.4;
+}
+
 function drawStackedBarChart(canvas, bars) {
   if (!bars.length) { drawMessage(canvas, 'No data.'); return; }
 
   const ctx  = prepareChartContext(canvas);
   const area = chartArea(canvas);
+  area.h -= 18;
   clearCanvas(ctx, canvas);
 
   const COLORS = {
-    a:   '#4caf50',
-    c:   '#fdd835',
-    d:   '#ff9800',
-    bad: '#f44336',
+    a:    '#2eaf65',
+    b:    '#3b82f6',
+    c:    '#d4a900',
+    d:    '#f97316',
+    m:    '#ef4444',
+    ns:   '#d946ef',
+    m_ns: '#8b5cf6',
   };
-  const SEGMENTS = ['a', 'c', 'd', 'bad'];
-  const SEG_LABELS = { a: 'A', c: 'C', d: 'D', bad: 'M+NS' };
+  const SEG_LABELS = { a: 'A', b: 'B', c: 'C', d: 'D', m: 'M', ns: 'NS', m_ns: 'M+NS' };
+  const SEGMENTS = ['a', 'b', 'c', 'd', 'm', 'ns', 'm_ns'].filter(seg =>
+    seg === 'b' ? bars.some(bar => bar.b > 0) : bars.some(bar => bar[seg] != null)
+  );
 
   const n       = bars.length;
   const barW    = Math.max(4, Math.min(40, (area.w / n) * 0.7));
@@ -647,16 +660,18 @@ function drawStackedBarChart(canvas, bars) {
 
   bars.forEach((bar, i) => {
     const cx = area.x0 + gap * i + gap / 2;
-    let yBottom = area.y0 + area.h;
+    let cumulativeRaw = 0;
 
     SEGMENTS.forEach(seg => {
       const pct = bar[seg + 'Pct'];
       if (!pct) return;
-      const segH = (pct / 100) * area.h;
-      const yTop = yBottom - segH;
+      const lowerVisual = hitZoneVisualPct(cumulativeRaw);
+      cumulativeRaw += pct;
+      const upperVisual = hitZoneVisualPct(cumulativeRaw);
+      const yBottom = area.y0 + area.h - (lowerVisual / 100) * area.h;
+      const yTop = area.y0 + area.h - (upperVisual / 100) * area.h;
       ctx.fillStyle = COLORS[seg];
-      ctx.fillRect(cx - barW / 2, yTop, barW, segH);
-      yBottom = yTop;
+      ctx.fillRect(cx - barW / 2, yTop, barW, yBottom - yTop);
     });
 
     hitMap.push({ cx, cy: area.y0 + area.h / 2, bar });
@@ -675,7 +690,7 @@ function drawStackedBarChart(canvas, bars) {
   // Y axis — 0/25/50/75/100%
   ctx.strokeStyle = GRID_COLOR(); ctx.lineWidth = 1;
   [0, 25, 50, 75, 100].forEach(v => {
-    const cy = area.y0 + area.h - (v / 100) * area.h;
+    const cy = area.y0 + area.h - (hitZoneVisualPct(v) / 100) * area.h;
     ctx.beginPath(); ctx.moveTo(area.x0, cy); ctx.lineTo(area.x0 + area.w, cy); ctx.stroke();
     ctx.fillStyle = TEXT_COLOR(); ctx.font = FONT; ctx.textAlign = 'right';
     ctx.fillText(v + '%', area.x0 - 5, cy + 3);
@@ -691,19 +706,27 @@ function drawStackedBarChart(canvas, bars) {
 
   // Legend
   let lx = area.x0 + 8;
-  const ly = area.y0 + area.h + 30;
+  let ly = area.y0 + area.h + 30;
   SEGMENTS.forEach(seg => {
+    const itemWidth = 14 + ctx.measureText(SEG_LABELS[seg]).width + 14;
+    if (lx + itemWidth > area.x0 + area.w && lx > area.x0 + 8) {
+      lx = area.x0 + 8;
+      ly += 14;
+    }
     ctx.fillStyle = COLORS[seg];
     ctx.fillRect(lx, ly - 7, 10, 8);
     ctx.fillStyle = TEXT_COLOR(); ctx.font = FONT; ctx.textAlign = 'left';
     ctx.fillText(SEG_LABELS[seg], lx + 14, ly);
-    lx += 14 + ctx.measureText(SEG_LABELS[seg]).width + 14;
+    lx += itemWidth;
   });
 
   // Tooltip
   canvas._hitMap    = hitMap;
   canvas._valueUnit = 'hitzones';
   canvas._barHitTolerance = gap / 2;
+  canvas._hitZoneSegments = SEGMENTS;
+  canvas._hitZoneColors = COLORS;
+  canvas._hitZoneLabels = SEG_LABELS;
   if (!canvas._tooltipBound) {
     canvas._tooltipBound = true;
     canvas.addEventListener('mousemove', e => {
@@ -711,18 +734,23 @@ function drawStackedBarChart(canvas, bars) {
       const h = (canvas._hitMap || []).find(hit => Math.abs(hit.cx - mx) < canvas._barHitTolerance);
       if (h) {
         const b = h.bar;
+        const hitRows = (canvas._hitZoneSegments || []).map(seg => {
+          if (b[seg] == null) return '';
+          const color = canvas._hitZoneColors[seg];
+          const label = canvas._hitZoneLabels[seg];
+          return `<span style="color:${color};font-weight:${seg === 'a' ? '400' : '600'}">${b[seg]} ${label} (${b[seg + 'Pct'].toFixed(2)}%)</span>`;
+        }).filter(Boolean).join(' &nbsp; ');
+        const proceduralLine = b.procedurals == null
+          ? 'Procedural-penalty column unavailable'
+          : `${b.procedurals} procedural ${b.procedurals === 1 ? 'penalty' : 'penalties'} excluded from denominator`;
         tooltipEl.innerHTML = `
           <div class="tt-name">${escHtml(b.label)}</div>
           <div class="tt-date">${escHtml(b.date || '')}</div>
-          <div class="tt-meta" style="margin-top:4px">
-            <span style="color:#4caf50">${b.a}A (${b.aPct.toFixed(0)}%)</span> &nbsp;
-            <span style="color:#fdd835">${b.c}C (${b.cPct.toFixed(0)}%)</span> &nbsp;
-            <span style="color:#ff9800">${b.d}D (${b.dPct.toFixed(0)}%)</span> &nbsp;
-            <span style="color:#f44336;font-weight:600">${b.bad} M+NS (${b.badPct.toFixed(0)}%)</span>
-          </div>
-          <div class="tt-meta" style="color:#666">${b.total} total hits</div>
+          <div class="tt-meta" style="margin-top:4px">${hitRows}</div>
+          <div class="tt-meta" style="color:#aab3c2">${b.total} reported hit-zone total</div>
+          <div class="tt-meta" style="color:#666">${proceduralLine}</div>
         `;
-        const tw = 280, th = 110;
+        const tw = 320, th = 140;
         const tx = e.clientX + 14 + tw > window.innerWidth  ? e.clientX - tw - 8 : e.clientX + 14;
         const ty = e.clientY - 10 + th > window.innerHeight ? e.clientY - th      : e.clientY - 10;
         tooltipEl.style.left    = tx + 'px';

--- a/extension/dashboard-exports.js
+++ b/extension/dashboard-exports.js
@@ -233,13 +233,20 @@ function exportStageCard(match, stage) {
   const officialPct = clf && stage.clf_pct != null ? stage.clf_pct : null;
   const displayPct  = officialPct ?? stage.pct;
   const showMatchPct = officialPct != null && stage.pct != null;
+  const hit = (key, label, color, positiveOnly = false) => {
+    const value = reportedStageHit(stage, key);
+    if (value == null || (positiveOnly && value <= 0)) return false;
+    return { t: `${value}${label}`, c: color };
+  };
   const hits = [
-    stage.a  > 0 && { t: `${stage.a}A`,   c: '#4caf50' },
-    stage.c  > 0 && { t: `${stage.c}C`,   c: '#fdd835' },
-    stage.d  > 0 && { t: `${stage.d}D`,   c: '#ff9800' },
-    stage.m  > 0 && { t: `${stage.m}M`,   c: '#f44336' },
-    stage.ns > 0 && { t: `${stage.ns}NS`, c: '#f44336' },
-    stage.p  > 0 && { t: `${stage.p}P`,   c: '#f44336' },
+    hit('a', 'A', '#2eaf65'),
+    hit('b', 'B', '#3b82f6', true),
+    hit('c', 'C', '#d4a900'),
+    hit('d', 'D', '#f97316'),
+    hit('m', 'M', '#ef4444'),
+    hit('ns', 'NS', '#d946ef'),
+    !stageReportsHit(stage, 'm') && !stageReportsHit(stage, 'ns') && hit('m_ns', ' M+NS', '#8b5cf6'),
+    hit('p', 'P', '#f44336'),
   ].filter(Boolean);
 
   let H = PAD;
@@ -351,7 +358,7 @@ function exportChartCSV() {
   // In classifiersOnly mode, only classifier stages are included.
   const headers = [
     'Date', 'Match', 'Division', 'Class', 'Overall %', 'Div %', 'Place', 'Div Place',
-    'Stage', 'Stage HF', 'Stage Match %', 'Stage Time', 'A', 'C', 'D', 'M', 'NS', 'P',
+    'Stage', 'Stage HF', 'Stage Match %', 'Stage Time', 'A', 'B', 'C', 'D', 'M', 'NS', 'M+NS', 'P',
     'Stage Included', 'Stage Note', 'CM #', 'CM Name', 'USPSA %',
     'Adjusted %', 'Adjusted Ref Division', 'Adjusted Ref Class', 'Adjusted Ref HF',
     'Adjusted Normalized HF', 'Adjusted Method',
@@ -387,8 +394,14 @@ function exportChartCSV() {
         s.hf    != null ? s.hf.toFixed(4)   : '',
         s.pct   != null ? s.pct.toFixed(2)  : '',
         s.time  != null ? s.time.toFixed(2) : '',
-        s.a  ?? '', s.c  ?? '', s.d  ?? '',
-        s.m  ?? '', s.ns ?? '', s.p  ?? '',
+        reportedStageHit(s, 'a') ?? '',
+        reportedStageHit(s, 'b') ?? '',
+        reportedStageHit(s, 'c') ?? '',
+        reportedStageHit(s, 'd') ?? '',
+        reportedStageHit(s, 'm') ?? '',
+        reportedStageHit(s, 'ns') ?? '',
+        stageReportsHit(s, 'm') || stageReportsHit(s, 'ns') ? '' : (reportedStageHit(s, 'm_ns') ?? ''),
+        reportedStageHit(s, 'p') ?? '',
         included ? 'Yes' : 'No',
         override.note || '',
         clf?.number || '',

--- a/extension/dashboard-history.js
+++ b/extension/dashboard-history.js
@@ -143,7 +143,15 @@ function renderMatchList() {
       // Speed gap vs GM: how many seconds behind GM pace (gm_median_hf - your_hf) / gm_median_hf * time
       function stageAccLoss(s) {
         if (!s.hf || s.hf <= 0) return null;
-        const penaltyPts = (s.c || 0) * 1 + (s.d || 0) * 2 + (s.m || 0) * 5 + (s.ns || 0) * 5;
+        const b = reportedStageHit(s, 'b');
+        const c = reportedStageHit(s, 'c');
+        const d = reportedStageHit(s, 'd');
+        const m = reportedStageHit(s, 'm');
+        const ns = reportedStageHit(s, 'ns');
+        const combined = m == null && ns == null ? reportedStageHit(s, 'm_ns') : null;
+        if ([b, c, d, m, ns, combined].every(value => value == null)) return null;
+        const penaltyPts = (b || 0) + (c || 0) + (d || 0) * 2
+          + (m || 0) * 5 + (ns || 0) * 5 + (combined || 0) * 5;
         return penaltyPts / s.hf;
       }
       function stageGmPct(s) {
@@ -153,6 +161,10 @@ function renderMatchList() {
 
       const hasGM = match.stages.some(s => s.gm_median_hf != null);
       const hasXdiv = match.stages.some(s => s.xdiv_benchmarks != null);
+      const hasB = match.stages.some(s => (reportedStageHit(s, 'b') || 0) > 0);
+      const hasM = match.stages.some(s => stageReportsHit(s, 'm'));
+      const hasNS = match.stages.some(s => stageReportsHit(s, 'ns'));
+      const hasCombined = match.stages.some(s => stageReportsHit(s, 'm_ns') && !stageReportsHit(s, 'm') && !stageReportsHit(s, 'ns'));
 
       // Build table using DOM to avoid XSS on stage names (F1)
       const table = document.createElement('table');
@@ -163,12 +175,18 @@ function renderMatchList() {
       const headers = ['Stage', 'Time', 'HF', '%'];
       if (hasXdiv) headers.push('Adj%');
       if (hasGM) headers.push('GM%', 'Acc Loss');
-      headers.push('A', 'C', 'D', 'M', 'NS', 'P');
+      headers.push('A');
+      if (hasB) headers.push('B');
+      headers.push('C', 'D');
+      if (hasM) headers.push('M');
+      if (hasNS) headers.push('NS');
+      if (hasCombined) headers.push('M+NS');
+      headers.push('P');
       headers.forEach((h, i) => {
         const th = document.createElement('th');
         th.textContent = h;
         if (i > 0) th.style.textAlign = 'right';
-        const colClass = { A: 'col-a', C: 'col-c', D: 'col-d', M: 'col-m', NS: 'col-ns', P: 'col-p' }[h];
+        const colClass = { A: 'col-a', B: 'col-b', C: 'col-c', D: 'col-d', M: 'col-m', NS: 'col-ns', 'M+NS': 'col-mns', P: 'col-p' }[h];
         if (colClass) th.className = colClass;
         if (h === 'Adj%') {
           th.title = 'Field-strength adjusted %\nNormalizes the best HF from any division at this match to your division using HHF ratios, giving you a more accurate classification read regardless of who showed up.';
@@ -298,7 +316,7 @@ function renderMatchList() {
           const accTd = document.createElement('td');
           if (accLoss != null) {
             const color = accLoss < 0.5 ? '#4caf50' : accLoss < 1.5 ? '#fdd835' : '#f44336';
-            accTd.innerHTML = `<span style="color:${color}" title="Seconds lost to non-A hits: (C×1 + D×2 + M×5 + NS×5) / HF">−${accLoss.toFixed(2)}s</span>`;
+            accTd.innerHTML = `<span style="color:${color}" title="Estimated seconds lost from reported non-A hits; combined M+NS remains combined">−${accLoss.toFixed(2)}s</span>`;
           } else {
             accTd.textContent = '—';
           }
@@ -307,17 +325,19 @@ function renderMatchList() {
 
         // Hit columns
         const hitCols = [
-          { val: s.a,  cls: 'col-a' },
-          { val: s.c,  cls: 'col-c' },
-          { val: s.d,  cls: 'col-d' },
-          { val: s.m,  cls: 'col-m' },
-          { val: s.ns, cls: 'col-ns' },
-          { val: s.p,  cls: 'col-p' },
-        ];
+          { val: reportedStageHit(s, 'a'), cls: 'col-a' },
+          hasB && { val: reportedStageHit(s, 'b'), cls: 'col-b' },
+          { val: reportedStageHit(s, 'c'), cls: 'col-c' },
+          { val: reportedStageHit(s, 'd'), cls: 'col-d' },
+          hasM && { val: reportedStageHit(s, 'm'), cls: 'col-m' },
+          hasNS && { val: reportedStageHit(s, 'ns'), cls: 'col-ns' },
+          hasCombined && { val: stageReportsHit(s, 'm') || stageReportsHit(s, 'ns') ? null : reportedStageHit(s, 'm_ns'), cls: 'col-mns' },
+          { val: reportedStageHit(s, 'p'), cls: 'col-p' },
+        ].filter(Boolean);
         hitCols.forEach(({ val, cls }) => {
           const td = document.createElement('td');
           td.className = cls;
-          td.textContent = val || '—';
+          td.textContent = val == null ? '—' : String(val);
           tr.appendChild(td);
         });
 

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -393,6 +393,12 @@
       text-transform: uppercase;
       letter-spacing: 0.5px;
     }
+    .chart-scale-note {
+      margin: -6px 0 4px;
+      color: #8a9bb0;
+      font-size: 11px;
+      line-height: 1.45;
+    }
 
     /* ── Chart explanatory note ── */
     .chart-note {
@@ -674,11 +680,13 @@
     .classifier-badge { display: inline-block; font-size: 0.65rem; font-weight: 700; letter-spacing: 0.03em; padding: 1px 5px; border-radius: 3px; background: #1a3a5c; color: #5ba3f5; border: 1px solid #2a5a8c; margin-right: 5px; vertical-align: middle; flex-shrink: 0; text-decoration: none; }
     a.classifier-badge:hover { background: #1e4a7a; border-color: #4a9eff; color: #90c8ff; text-decoration: none; }
     .stage-table tr:hover td { background: #1a1d27; }
-    .col-a  { color: #4caf50; }
-    .col-c  { color: #fdd835; }
-    .col-d  { color: #ff9800; }
-    .col-m  { color: #f44336; font-weight: 600; }
-    .col-ns { color: #f44336; font-weight: 600; }
+    .col-a  { color: #2eaf65; }
+    .col-b  { color: #3b82f6; }
+    .col-c  { color: #d4a900; }
+    .col-d  { color: #f97316; }
+    .col-m  { color: #ef4444; font-weight: 600; }
+    .col-ns { color: #d946ef; font-weight: 600; }
+    .col-mns { color: #8b5cf6; font-weight: 600; }
     .col-p  { color: #f44336; }
 
     /* ── Tooltip stage list ── */
@@ -1172,6 +1180,7 @@
     [data-theme="light"] .chart-summary .s-val { color: #1a1d27; }
     [data-theme="light"] .chart-summary .s-note { color: #4f596b; }
     [data-theme="light"] .chart-subtitle { color: #4f596b; }
+    [data-theme="light"] .chart-scale-note { color: #5a6478; }
     [data-theme="light"] #exportCsvBtn { color: #8a9bb0; border-color: #d0d4dc; }
     [data-theme="light"] #exportCsvBtn:hover { color: #16a34a; border-color: #16a34a; }
     [data-theme="light"] .match-list-header { border-bottom-color: #e0e2e8; color: #5a6478; }
@@ -1463,8 +1472,9 @@
   <div class="chart-section" id="chartHitZoneSection" style="display:none">
     <div class="chart-section-header">
       <h3>Hit Zone Breakdown</h3>
-      <span style="font-size:12px;color:#666;text-transform:uppercase;letter-spacing:0.5px">A / C / D / M+NS distribution per match</span>
+      <span class="chart-subtitle">Reported hit-zone distribution per match · nonlinear visual scale</span>
     </div>
+    <div class="chart-scale-note">Raw 0–50% maps to 0–30% of visual height; raw 50–100% maps to 30–100%. Tooltips show exact raw counts and percentages. Procedural penalties are excluded from the reported hit-zone total.</div>
     <canvas id="chartHitZone" height="380"></canvas>
   </div>
 </div>

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -643,6 +643,16 @@ function getMetricStages(match) {
   return match.stages.filter((stage, index) => isStageIncluded(match, stage, index));
 }
 
+function stageReportsHit(stage, key) {
+  return stage?.hit_columns?.[key] === true;
+}
+
+function reportedStageHit(stage, key) {
+  if (!stageReportsHit(stage, key)) return null;
+  const value = Number(stage[key]);
+  return Number.isFinite(value) && value >= 0 ? value : 0;
+}
+
 function excludedStageCount(match) {
   if (!match?.stages?.length) return 0;
   return match.stages.length - getMetricStages(match).length;
@@ -1307,7 +1317,10 @@ function renderAll() {
           match_name: r.match_name,
           division: divisionLabel(r.division),
           code: clf.number,
-          a: s.a, c: s.c, d: s.d, m: s.m, ns: s.ns, p: s.p,
+          a: reportedStageHit(s, 'a'), b: reportedStageHit(s, 'b'),
+          c: reportedStageHit(s, 'c'), d: reportedStageHit(s, 'd'),
+          m: reportedStageHit(s, 'm'), ns: reportedStageHit(s, 'ns'),
+          m_ns: reportedStageHit(s, 'm_ns'), p: reportedStageHit(s, 'p'),
         });
       }
     }
@@ -1370,7 +1383,8 @@ function renderAll() {
       points: clfPoints
         .filter(p => p.division === div)
         .map(p => ({ date: p.date, y: p.y, label: p.label, match_name: p.match_name, hf: p.hf,
-                     isOfficial: p.isOfficial, a: p.a, c: p.c, d: p.d, m: p.m, ns: p.ns, p_: p.p })),
+                     isOfficial: p.isOfficial, a: p.a, b: p.b, c: p.c, d: p.d,
+                     m: p.m, ns: p.ns, m_ns: p.m_ns, p_: p.p })),
     }));
 
     const allClfDates = [...new Set(clfPoints.map(p => p.date))].sort();
@@ -1628,21 +1642,29 @@ function renderAll() {
   const accuracyPoints  = [];
   for (const r of viewSorted) {
     if (!r.stages?.length) continue;
-    let totalM = 0, totalNS = 0, stagesWithHits = 0;
+    let totalM = 0, totalNS = 0, totalCombined = 0, stagesWithHits = 0;
     for (const s of getMetricStages(r)) {
-      if (s.m == null && s.ns == null) continue;
-      totalM  += s.m  || 0;
-      totalNS += s.ns || 0;
+      const stageM = reportedStageHit(s, 'm');
+      const stageNS = reportedStageHit(s, 'ns');
+      if (stageM != null || stageNS != null) {
+        totalM += stageM || 0;
+        totalNS += stageNS || 0;
+      } else {
+        const stageCombined = reportedStageHit(s, 'm_ns');
+        if (stageCombined == null) continue;
+        totalCombined += stageCombined;
+      }
       stagesWithHits++;
     }
     if (!stagesWithHits) continue;
     accuracyPoints.push({
       date: r.date,
-      y: totalM + totalNS,
+      y: totalM + totalNS + totalCombined,
       label: r.match_name,
       division: r.division,
       m: totalM,
       ns: totalNS,
+      m_ns: totalCombined,
     });
   }
   accuracyPoints.sort((a, b) => (a.date || '').localeCompare(b.date || ''));
@@ -1660,34 +1682,49 @@ function renderAll() {
   }
 
   // ── Hit zone breakdown ────────────────────────────────────────────────────
-  // Stacked bar chart: A / C / D / M+NS per match as % of total hits.
-  // Shows whether the shooter is cleaning up hit zones over time.
+  // Stacked bar chart of reported hit-zone outcomes per match. Raw values stay
+  // unchanged; the renderer transforms cumulative boundaries for readability.
   const hitZoneSection = document.getElementById('chartHitZoneSection');
   const hitZoneBars    = [];
   for (const r of viewSorted) {
     if (!r.stages?.length) continue;
-    let a = 0, c = 0, d = 0, m = 0, ns = 0;
-    let hasHits = false;
+    const totals = { a: 0, b: 0, c: 0, d: 0, m: 0, ns: 0, m_ns: 0, p: 0 };
+    const available = { a: false, b: false, c: false, d: false, m: false, ns: false, m_ns: false, p: false };
     for (const s of getMetricStages(r)) {
-      if (s.a == null && s.c == null) continue;
-      a  += s.a  || 0;
-      c  += s.c  || 0;
-      d  += s.d  || 0;
-      m  += s.m  || 0;
-      ns += s.ns || 0;
-      hasHits = true;
+      for (const key of ['a', 'b', 'c', 'd', 'p']) {
+        const value = reportedStageHit(s, key);
+        if (value == null) continue;
+        available[key] = true;
+        totals[key] += value;
+      }
+
+      const stageM = reportedStageHit(s, 'm');
+      const stageNS = reportedStageHit(s, 'ns');
+      if (stageM != null || stageNS != null) {
+        if (stageM != null) { available.m = true; totals.m += stageM; }
+        if (stageNS != null) { available.ns = true; totals.ns += stageNS; }
+      } else {
+        const stageCombined = reportedStageHit(s, 'm_ns');
+        if (stageCombined != null) {
+          available.m_ns = true;
+          totals.m_ns += stageCombined;
+        }
+      }
     }
-    if (!hasHits) continue;
-    const total = a + c + d + m + ns;
+
+    const zoneKeys = ['a', 'b', 'c', 'd', 'm', 'ns', 'm_ns'];
+    if (!zoneKeys.some(key => available[key])) continue;
+    const total = zoneKeys.reduce((sum, key) => sum + totals[key], 0);
     if (!total) continue;
+    const values = Object.fromEntries(zoneKeys.map(key => [key, available[key] ? totals[key] : null]));
+    const percentages = Object.fromEntries(zoneKeys.map(key => [key + 'Pct', available[key] ? (totals[key] / total) * 100 : null]));
     hitZoneBars.push({
       date: r.date,
       label: r.match_name,
-      a, c, d, bad: m + ns, total,
-      aPct:   (a / total) * 100,
-      cPct:   (c / total) * 100,
-      dPct:   (d / total) * 100,
-      badPct: ((m + ns) / total) * 100,
+      ...values,
+      ...percentages,
+      total,
+      procedurals: available.p ? totals.p : null,
     });
   }
   hitZoneBars.sort((a, b) => (a.date || '').localeCompare(b.date || ''));


### PR DESCRIPTION
## Summary

Preserve source hit-column availability and render truthful B, M, NS, and combined M+NS outcomes on a disclosed nonlinear scale.

## Files Changed

CHANGELOG.md, DESIGN.md, README.md, extension/background.js, extension/dashboard-charts.js, extension/dashboard-exports.js, extension/dashboard-history.js, extension/dashboard.html, extension/dashboard.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Scoped JavaScript syntax checks and git diff --check pass; full build verification remains in progress.

Resolves #61


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.292 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 9m and 149,613 tokens on this as a headless worker.