### PR TITLE
GH#57: fix: limit analytics ranges to fetched coverage

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -47,6 +47,9 @@ Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter
 - Activate **6 mo** on every dashboard load. Exactly one preset must expose a visible active state and `aria-pressed="true"`.
 - Use compact native buttons with a clear keyboard focus ring. The group wraps at narrow widths rather than becoming a dropdown or creating horizontal page overflow.
 - Date-range changes update the existing cached analytics immediately. They do not hide or delete older Match History records.
+- After a successful match-list extraction, persist validated cumulative fetch intervals (or an explicit successful all-time fetch). A later narrower fetch must not erase broader coverage; malformed or missing metadata preserves legacy range behavior until a successful fetch establishes coverage.
+- Only presets fully contained by verified coverage are selectable. Unavailable presets remain focusable with `aria-disabled="true"`, a greyed state, and the hover/focus explanation: “Fetch a longer timeline to use this range.” Do not use native `disabled`, which would hide that help from keyboard users.
+- If a bounded fetch makes the active preset unavailable, select the broadest verified available preset. Last 8, division, match selection, cache contents, and single-match refresh never affect coverage.
 
 ## Fetch timeline
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Hit-zone percentages use the **reported hit-zone total** as their denominator. P
 
 ### Filtering by date
 
-Analytics open on the most recent **6 mo** so trends stay readable. Use the buttons above the charts to switch to **Last 1 month**, **3 mo**, **6 mo**, **1 yr**, **3 yr**, or **all time**. The active range applies to every chart, summary statistic, classifier-only view, and chart CSV export without re-fetching or deleting older Match History records.
+Analytics open on the most recent **6 mo** so trends stay readable. Use the buttons above the charts to switch to **Last 1 month**, **3 mo**, **6 mo**, **1 yr**, **3 yr**, or **all time**. The active range applies to every chart, summary statistic, classifier-only view, and chart CSV export without re-fetching or deleting older Match History records. After a successful fetch, ranges outside the verified fetched timeline are greyed out and explain on hover or keyboard focus that a longer Fetch timeline is required. Successful broader fetches remain available after later narrower fetches and after reload.
 
 The **Last 8 matches** switch applies after the active analytics date range, division, Scored/All view, and manually selected matches. Turn it on to use the most recent eight qualifying matches across every chart, summary, classifier analysis, and chart CSV export. If fewer than eight qualify, all available matches are used. The preference is remembered, while Match History and cached records remain complete.
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -94,6 +94,48 @@ function normalizeDateOnly(value) {
   return `${match[1]}-${match[2]}-${match[3]}`;
 }
 
+function addCalendarDays(dateOnly, days) {
+  const [year, month, day] = dateOnly.split('-').map(Number);
+  return localDateOnly(new Date(year, month - 1, day + days));
+}
+
+function normalizeFetchCoverage(value, today = localDateOnly()) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  if (value.allTime === true) return { allTime: true, intervals: [] };
+  if (!Array.isArray(value.intervals) || value.intervals.length === 0) return null;
+
+  const intervals = [];
+  for (const interval of value.intervals) {
+    const start = normalizeDateOnly(interval?.start);
+    const end = normalizeDateOnly(interval?.end);
+    if (!start || !end || start > end || end > today) return null;
+    intervals.push({ start, end });
+  }
+
+  intervals.sort((left, right) => left.start.localeCompare(right.start));
+  return {
+    allTime: false,
+    intervals: intervals.reduce((merged, interval) => {
+      const previous = merged.at(-1);
+      if (previous && interval.start <= addCalendarDays(previous.end, 1)) {
+        if (interval.end > previous.end) previous.end = interval.end;
+      } else {
+        merged.push({ ...interval });
+      }
+      return merged;
+    }, []),
+  };
+}
+
+function mergeFetchCoverage(existing, scope) {
+  const coverage = normalizeFetchCoverage(existing);
+  if (coverage?.allTime || scope.value === 'all') return { allTime: true, intervals: [] };
+  return normalizeFetchCoverage({
+    allTime: false,
+    intervals: [...(coverage?.intervals || []), { start: scope.start, end: scope.end }],
+  });
+}
+
 function resolveFetchTimeline(requested, referenceDate = new Date()) {
   const requestedValue = typeof requested === 'object' ? requested?.value : requested;
   const value = Object.hasOwn(FETCH_TIMELINES, requestedValue) ? requestedValue : '6m';
@@ -987,13 +1029,23 @@ async function fetchScores(memberNumber, name, requestedTimeline) {
     if (filtered.futureDateCount) push(`Skipping ${filtered.futureDateCount} future-dated match(es).`);
     if (filtered.beforeCutoffCount) push(`Skipping ${filtered.beforeCutoffCount} match(es) before ${fetchScope.start}.`);
 
-    const stored = await chrome.storage.local.get(['lastMatchList', 'matchCache', 'matchTypeOverrides']);
+    const stored = await chrome.storage.local.get(['lastMatchList', 'matchCache', 'matchTypeOverrides', 'fetchCoverage']);
     const previousMatchList = stored.lastMatchList || [];
     const cache = stored.matchCache || {};
     const matchTypeOverrides = normalizeMatchTypeOverrides(stored.matchTypeOverrides);
     const preserveMissingHistory = fetchScope.value !== 'all' || rawMatchList.length === 0;
     let mergedMatchList = mergeMatchLists(previousMatchList, matchList, { preserveMissing: preserveMissingHistory });
-    await chrome.storage.local.set({ lastMatchList: mergedMatchList });
+    const hasUsableMatchDate = annotatedMatchList.some(match => {
+      const date = normalizeDateOnly(match.date);
+      return date && date <= localDateOnly();
+    });
+    const fetchCoverage = hasUsableMatchDate
+      ? mergeFetchCoverage(stored.fetchCoverage, fetchScope)
+      : normalizeFetchCoverage(stored.fetchCoverage);
+    await chrome.storage.local.set({
+      lastMatchList: mergedMatchList,
+      ...(fetchCoverage ? { fetchCoverage } : {}),
+    });
     const mergedById = new Map(mergedMatchList.map(match => [match.match_id, match]));
     const workMatches = matchList.map(match => mergedById.get(match.match_id) || match);
 
@@ -1090,7 +1142,7 @@ async function fetchScores(memberNumber, name, requestedTimeline) {
       return buildResult(match, {}, memberNumber);
     });
 
-    return { results: combinedResults, log, classificationData, _not_logged_in_uspsa, fetchScope };
+    return { results: combinedResults, log, classificationData, _not_logged_in_uspsa, fetchScope, fetchCoverage };
 
   } finally {
     if (tabId) chrome.tabs.remove(tabId).catch(() => {});

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -240,14 +240,52 @@
     #timeFilter {
       display: flex; align-items: center; gap: 6px; padding: 0 24px 14px; flex-wrap: wrap;
     }
+    .visually-hidden {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
     .time-btn {
       padding: 6px 12px; border-radius: 6px; font-size: 12px;
       border: 1px solid #2a2d3a; background: #1a1d27; color: #888;
       cursor: pointer; user-select: none;
     }
-    .time-btn:hover { border-color: #4a9eff; color: #ccc; }
+    .time-btn:not(.unavailable):hover { border-color: #4a9eff; color: #ccc; }
     .time-btn.active { background: #1e3a5f; border-color: #4a9eff; color: #4a9eff; }
     .time-btn:focus-visible { outline: 2px solid #4a9eff; outline-offset: 2px; }
+    .time-btn.unavailable {
+      border-color: #343845;
+      color: #626877;
+      cursor: not-allowed;
+      position: relative;
+    }
+    .time-btn.unavailable:hover::after,
+    .time-btn.unavailable:focus-visible::after {
+      content: attr(data-unavailable-message);
+      position: absolute;
+      top: calc(100% + 8px);
+      left: 0;
+      z-index: 10;
+      width: max-content;
+      max-width: min(260px, calc(100vw - 32px));
+      padding: 7px 9px;
+      border: 1px solid #4a5060;
+      border-radius: 5px;
+      background: #252936;
+      color: #e6e9ef;
+      font-size: 12px;
+      font-weight: 400;
+      line-height: 1.35;
+      text-align: left;
+      white-space: normal;
+      pointer-events: none;
+    }
     .last8-toggle {
       display: flex;
       align-items: center;
@@ -1165,6 +1203,9 @@
       color: #4a5060;
     }
     [data-theme="light"] .time-btn.active { background: #dbeafe; border-color: #2563eb; color: #2563eb; }
+    [data-theme="light"] .time-btn.unavailable { border-color: #c9ced8; color: #777f8f; }
+    [data-theme="light"] .time-btn.unavailable:hover::after,
+    [data-theme="light"] .time-btn.unavailable:focus-visible::after { background: #ffffff; border-color: #c0c4cc; color: #2c3040; }
     [data-theme="light"] .last8-toggle { border-left-color: #c0c4cc; }
     [data-theme="light"] #last8Status { color: #5a6478; }
     [data-theme="light"] .view-btn { background: #f0f1f4; border-color: #c0c4cc; color: #4a5060; }
@@ -1391,12 +1432,13 @@
 </div>
 
 <div id="timeFilter" role="group" aria-label="Analytics date range">
-  <button class="time-btn" type="button" data-date-preset="1m" aria-pressed="false">Last 1 month</button>
-  <button class="time-btn" type="button" data-date-preset="3m" aria-pressed="false">3 mo</button>
-  <button class="time-btn active" type="button" data-date-preset="6m" aria-pressed="true">6 mo</button>
-  <button class="time-btn" type="button" data-date-preset="1y" aria-pressed="false">1 yr</button>
-  <button class="time-btn" type="button" data-date-preset="3y" aria-pressed="false">3 yr</button>
-  <button class="time-btn" type="button" data-date-preset="all" aria-pressed="false">all time</button>
+  <span id="dateRangeAvailabilityHelp" class="visually-hidden">Fetch a longer timeline to use this range.</span>
+  <button class="time-btn" type="button" data-date-preset="1m" data-unavailable-message="Fetch a longer timeline to use this range." aria-pressed="false">Last 1 month</button>
+  <button class="time-btn" type="button" data-date-preset="3m" data-unavailable-message="Fetch a longer timeline to use this range." aria-pressed="false">3 mo</button>
+  <button class="time-btn active" type="button" data-date-preset="6m" data-unavailable-message="Fetch a longer timeline to use this range." aria-pressed="true">6 mo</button>
+  <button class="time-btn" type="button" data-date-preset="1y" data-unavailable-message="Fetch a longer timeline to use this range." aria-pressed="false">1 yr</button>
+  <button class="time-btn" type="button" data-date-preset="3y" data-unavailable-message="Fetch a longer timeline to use this range." aria-pressed="false">3 yr</button>
+  <button class="time-btn" type="button" data-date-preset="all" data-unavailable-message="Fetch a longer timeline to use this range." aria-pressed="false">all time</button>
   <label id="last8ToggleWrap" class="last8-toggle">
     <span class="toggle-lbl">Last 8 matches</span>
     <span class="toggle-switch">

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -242,6 +242,7 @@ let selectedFetchTimeline = '6m'; // pre-fetch request scope; independent of ana
 let last8Matches = false;       // post-fetch analytics limit; never truncates cached history
 let matchTypeOverrides = {};    // match_id -> manual type for otherwise unconfirmed matches
 let lastFetchScope = null;
+let fetchCoverage = null;       // verified cumulative fetch intervals; null preserves pre-metadata behavior
 
 const FETCH_TIMELINE_PRESETS = Object.freeze({
   '1m':  { label: 'Last 1 month', months: 1 },
@@ -739,7 +740,9 @@ saveBtn.addEventListener('click', async () => {
       return;
     }
     // Clear cache and reset UI
-    await chrome.storage.local.remove(['matchCache', 'lastMatchList', 'stageOverrides']);
+    await chrome.storage.local.remove(['matchCache', 'lastMatchList', 'stageOverrides', 'fetchCoverage']);
+    fetchCoverage = null;
+    renderDateRangeFilter();
     allResults = [];
     stageOverrides = {};
     summaryBar.classList.remove('visible');
@@ -772,7 +775,7 @@ function hideOnboarding() {
 }
 
 // ── Restore persisted state on load ──────────────────────────────────────────
-chrome.storage.local.get(['memberNumber', 'name', 'lastMatchList', 'matchCache', 'deselectedMatches', 'stageOverrides', 'classificationData', 'selectedDivision', 'fetchTimeline', 'last8Matches', 'matchTypeOverrides'], async d => {
+chrome.storage.local.get(['memberNumber', 'name', 'lastMatchList', 'matchCache', 'deselectedMatches', 'stageOverrides', 'classificationData', 'selectedDivision', 'fetchTimeline', 'last8Matches', 'matchTypeOverrides', 'fetchCoverage'], async d => {
   // Try restoring from sync if local has no credentials (e.g. after reinstall)
   if (!d.memberNumber && !d.name) {
     await restoreFromSync();
@@ -792,6 +795,9 @@ chrome.storage.local.get(['memberNumber', 'name', 'lastMatchList', 'matchCache',
   fetchTimelineSelect.value = selectedFetchTimeline;
   last8Matches = d.last8Matches === true;
   matchTypeOverrides = normalizeMatchTypeOverrides(d.matchTypeOverrides);
+  fetchCoverage = normalizeFetchCoverage(d.fetchCoverage);
+  ensureAvailableDatePreset();
+  renderDateRangeFilter();
   renderLast8Control();
 
   // Lock inputs if we already have saved credentials
@@ -923,7 +929,9 @@ fetchBtn.addEventListener('click', async () => {
       'Your member number or name has changed. This will clear all cached match data and re-fetch everything.\n\nContinue?'
     );
     if (!ok) return;
-    await chrome.storage.local.remove(['matchCache', 'lastMatchList', 'stageOverrides']);
+    await chrome.storage.local.remove(['matchCache', 'lastMatchList', 'stageOverrides', 'fetchCoverage']);
+    fetchCoverage = null;
+    renderDateRangeFilter();
     allResults = [];
     stageOverrides = {};
     summaryBar.classList.remove('visible');
@@ -953,6 +961,9 @@ fetchBtn.addEventListener('click', async () => {
 
     const { results, log, fetchScope } = response.data;
     lastFetchScope = fetchScope || fetchTimeline;
+    fetchCoverage = normalizeFetchCoverage(response.data.fetchCoverage);
+    ensureAvailableDatePreset();
+    renderDateRangeFilter();
 
     if (log?.length) {
       debugLogEl.textContent = log.join('\n');
@@ -1031,6 +1042,55 @@ function subtractCalendarMonths(dateOnly, months) {
   return localDateOnly(new Date(targetYear, targetMonth, Math.min(day, lastDay)));
 }
 
+function addCalendarDays(dateOnly, days) {
+  const [year, month, day] = dateOnly.split('-').map(Number);
+  return localDateOnly(new Date(year, month - 1, day + days));
+}
+
+function normalizeFetchCoverage(value, today = localDateOnly()) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  if (value.allTime === true) return { allTime: true, intervals: [] };
+  if (!Array.isArray(value.intervals) || value.intervals.length === 0) return null;
+
+  const intervals = [];
+  for (const interval of value.intervals) {
+    const start = normalizeDateOnly(interval?.start);
+    const end = normalizeDateOnly(interval?.end);
+    if (!start || !end || start > end || end > today) return null;
+    intervals.push({ start, end });
+  }
+
+  intervals.sort((left, right) => left.start.localeCompare(right.start));
+  return {
+    allTime: false,
+    intervals: intervals.reduce((merged, interval) => {
+      const previous = merged.at(-1);
+      if (previous && interval.start <= addCalendarDays(previous.end, 1)) {
+        if (interval.end > previous.end) previous.end = interval.end;
+      } else {
+        merged.push({ ...interval });
+      }
+      return merged;
+    }, []),
+  };
+}
+
+function isDatePresetAvailable(presetKey, referenceDate = new Date()) {
+  const preset = DATE_RANGE_PRESETS[presetKey];
+  if (!preset) return false;
+  if (!fetchCoverage || fetchCoverage.allTime) return true;
+  if (preset.months == null) return false;
+  const end = localDateOnly(referenceDate);
+  const start = subtractCalendarMonths(end, preset.months);
+  return fetchCoverage.intervals.some(interval => interval.start <= start && interval.end >= end);
+}
+
+function ensureAvailableDatePreset(referenceDate = new Date()) {
+  if (isDatePresetAvailable(selectedDatePreset, referenceDate)) return;
+  const available = Object.keys(DATE_RANGE_PRESETS).filter(key => isDatePresetAvailable(key, referenceDate));
+  if (available.length > 0) selectedDatePreset = available.at(-1);
+}
+
 function activeDateBounds(referenceDate = new Date()) {
   const preset = DATE_RANGE_PRESETS[selectedDatePreset] || DATE_RANGE_PRESETS['6m'];
   if (preset.months == null) return null;
@@ -1066,15 +1126,21 @@ function renderLast8Control(totalCount = null, visibleCount = null) {
 
 function renderDateRangeFilter() {
   document.querySelectorAll('[data-date-preset]').forEach(button => {
-    const active = button.dataset.datePreset === selectedDatePreset;
+    const available = isDatePresetAvailable(button.dataset.datePreset);
+    const active = available && button.dataset.datePreset === selectedDatePreset;
     button.classList.toggle('active', active);
+    button.classList.toggle('unavailable', !available);
     button.setAttribute('aria-pressed', String(active));
+    button.setAttribute('aria-disabled', String(!available));
+    if (available) button.removeAttribute('aria-describedby');
+    else button.setAttribute('aria-describedby', 'dateRangeAvailabilityHelp');
+    button.title = available ? '' : 'Fetch a longer timeline to use this range.';
   });
 }
 
 document.querySelectorAll('[data-date-preset]').forEach(button => {
   button.addEventListener('click', () => {
-    if (!DATE_RANGE_PRESETS[button.dataset.datePreset]) return;
+    if (!DATE_RANGE_PRESETS[button.dataset.datePreset] || !isDatePresetAvailable(button.dataset.datePreset)) return;
     selectedDatePreset = button.dataset.datePreset;
     renderDateRangeFilter();
     renderAll();


### PR DESCRIPTION
## Summary

Persist verified cumulative fetch coverage, prevent unavailable analytics range selection with accessible guidance, and document the behavior.

## Files Changed

DESIGN.md, README.md, extension/background.js, extension/dashboard.html, extension/dashboard.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — node --check extension/dashboard.js; node --check extension/background.js; ./build.sh qa57; git diff --check

Resolves #57


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.292 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-terra spent 5m and 113,603 tokens on this as a headless worker.