### PR TITLE
chore: release v1.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,18 @@ All notable user-facing changes are documented here. Update this file before pub
 
 ## Unreleased
 
+## v1.6.7 — 2026-08-27
+
+### Added
+
+- Percentage charts now include neutral reference guides at useful benchmarks without applying USPSA classification bands to non-classifier results.
+
 ### Fixed
 
-- Broader fetch timelines now traverse paginated Match History without collapsing same-date matches, repair legacy or partial stage caches, search paginated result tables, and preserve prior history and stages when extraction remains incomplete.
+- Broader fetch timelines now reuse complete cached matches while fetching missing history, reducing unnecessary PractiScore requests.
+- Expanded fetches now traverse paginated Match History without collapsing same-date matches, repair legacy or partial stage caches, search paginated result tables, and preserve prior history and stages when extraction remains incomplete.
+- Analytics range controls now disable periods outside the fetched coverage instead of implying that unavailable history has been loaded.
+- Charts now render at the correct high-DPI canvas size and remain sharp after resizing.
 
 ### Changed
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hit Factor Charts",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "description": "Track your USPSA match performance: division %, adjusted field-strength scores, classifier trends, and placement over time.",
   "permissions": ["tabs", "scripting", "storage"],
   "host_permissions": ["https://practiscore.com/*", "https://s3.amazonaws.com/*", "https://api.github.com/*", "https://uspsa.org/*", "https://objects.githubusercontent.com/*"],


### PR DESCRIPTION
## Summary

- bump the extension manifest to v1.6.7
- publish user-facing release notes for changes merged after v1.6.6
- keep internal dashboard module extraction out of the customer-facing notes

## Verification

- `node --check` passed for all extension JavaScript files
- manifest JSON parsed and reported version `1.6.7`
- v1.6.7 changelog extraction matched the release workflow pattern
- `./build.sh` produced `dist/hitfactorcharts-v1.6.7.zip`
- `git diff --check` passed

## Release

Merging this PR triggers `.github/workflows/release.yml`, which builds `HitFactorCharts.zip`, creates tag `v1.6.7`, and publishes the matching changelog section as the GitHub release notes.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.292 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol
