### PR TITLE
GH#75: add dashboard size guard

### DIFF
--- a/.github/workflows/dashboard-size.yml
+++ b/.github/workflows/dashboard-size.yml
@@ -1,0 +1,28 @@
+name: Dashboard size guard
+
+on:
+  pull_request:
+    paths:
+      - 'extension/dashboard.js'
+      - '.github/workflows/dashboard-size.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  dashboard-size:
+    name: Enforce dashboard.js line limit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check dashboard.js line count
+        run: |
+          line_count=$(wc -l < extension/dashboard.js)
+          limit=2000
+          printf 'extension/dashboard.js has %s lines; limit is %s lines.\n' "$line_count" "$limit"
+
+          if [ "$line_count" -ge "$limit" ]; then
+            echo "::error file=extension/dashboard.js::dashboard.js has ${line_count} lines and must stay below ${limit}. Extract a cohesive module before merging."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Added a pull-request workflow that enforces the dashboard.js 2,000-line limit.

## Files Changed

.github/workflows/dashboard-size.yml

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — Ruby YAML parsing passed; current 1,861-line dashboard count passed the below-2,000 condition; controlled 2,000 condition returned non-zero; git diff --check passed.

Resolves #75


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.292 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-terra spent 2m and 63,111 tokens on this as a headless worker.