### PR TITLE
GH#80: prevent silent header-only CSV exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes are documented here. Update this file before pub
 
 ## Unreleased
 
+### Fixed
+
+- Chart CSV export now shares the final chart dataset and explains empty filtered results instead of downloading a header-only file.
+
 ## v1.6.7 — 2026-08-27
 
 ### Added

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -71,6 +71,7 @@ Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter
 - Treat Last 8 as a post-fetch view preference. Toggling it makes no request and never mutates fetched results, Match History, `matchCache`, or `lastMatchList`.
 - When fewer than eight matches qualify, use all available matches. State the visible and qualifying counts near the switch.
 - Keep the controls wrapping at narrow widths without page-level overflow.
+- Chart CSV uses the same final analytics selection as rendering. When no data rows qualify, create no download and announce a concise status explanation for the current division/date, Scored/All view, unchecked-match, or Classifiers Only exclusion.
 
 ## Manual match type
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The **Fetch timeline** dropdown beside **Fetch Scores** is separate: it limits n
 
 **As image:** Click the floppy-disk icon on any match row to open the export menu. Choose **Full Match** for a match summary card or any individual stage for a per-stage card. Both download as PNG at 2× resolution. Stage cards preserve separate M/NS or an explicitly combined M+NS value and omit unavailable hit columns.
 
-**As CSV:** Click **⤓ CSV** in the chart section header to download all currently visible match data as a spreadsheet. One row per stage, includes match name, division, class, overall %, div %, placement, stage HF, time, reported hit counts (A/B/C/D/M/NS/M+NS/P), classifier number, and official USPSA %. Unavailable source columns remain blank; reported zeroes remain zero.
+**As CSV:** Click **⤓ CSV** in the chart section header to download the same final analytics dataset shown by the charts as a spreadsheet. One row per stage, includes match name, division, class, overall %, div %, placement, stage HF, time, reported hit counts (A/B/C/D/M/NS/M+NS/P), classifier number, and official USPSA %. Unavailable source columns remain blank; reported zeroes remain zero. When no rows qualify, no file is downloaded; the status message explains whether the active division/date range, Scored view, unchecked matches, or Classifiers Only mode excluded the data.
 
 ### Filtering matches
 

--- a/extension/dashboard-exports.js
+++ b/extension/dashboard-exports.js
@@ -343,16 +343,27 @@ function exportStageCard(match, stage) {
 // Exports chart-visible match data as a flat CSV (one row per stage).
 // Respects the active division, date-range preset, and Last 8 preference.
 // Includes USPSA clf_pct when available (official % vs national reference HF).
+function describeEmptyChartCSVExport(selection) {
+  const preset = DATE_RANGE_PRESETS[selectedDatePreset] || DATE_RANGE_PRESETS['6m'];
+  const context = `${selectedDiv ? divisionLabel(selectedDiv) : 'all divisions'} in ${preset.label}`;
+
+  if (!allResults.length) return `CSV export skipped: no matches are loaded for ${context}. Fetch scores, then try again.`;
+  if (!selection.chartableBase.length) return `CSV export skipped: no chartable USPSA matches qualify for ${context}. Match History can include other match types.`;
+  if (!selection.selectedRecords.length) return `CSV export skipped: all chartable matches are unchecked. Recheck a USPSA match in Match History, then try again.`;
+  if (!selection.viewRecords.length) {
+    return currentView === 'ranked'
+      ? `CSV export skipped: ${context} has no member-number-confirmed scores in Scored Matches. Switch to All Matches to include name-matched results.`
+      : `CSV export skipped: ${context} has no matches with a score or hit factor.`;
+  }
+  if (!selection.divisionRecords.length) return `CSV export skipped: no ${divisionLabel(selectedDiv)} matches qualify in the current view.`;
+  if (!selection.rangeRecords.length) return `CSV export skipped: no qualifying matches fall within ${preset.label}. Choose a broader date range or fetch more history.`;
+  return `CSV export skipped: no classifier stages qualify for ${context}. Turn off Classifiers Only or select matches with classifier stages.`;
+}
+
 function exportChartCSV() {
-  const uspsaBase = allResults.filter(r => isChartable(r) && !deselectedMatches.has(r.match_id));
-  const chartable = currentView === 'ranked'
-    ? uspsaBase.filter(r => r.found_by === 'member_number' && effectiveOverallPct(r) != null)
-    : uspsaBase.filter(r => effectiveOverallPct(r) != null || r.hf != null);
-  const sorted = chartable.filter(matchesSelectedDivision).sort((a, b) => {
-    const da = parseDate(a.date), db = parseDate(b.date);
-    return (da && db) ? da - db : 0;
-  });
-  const viewSorted = applyLast8Limit(filterByActiveDateRange(sorted));
+  // Capture one state snapshot so exported rows and filename cannot drift mid-click.
+  const selection = selectAnalyticsRecords();
+  const viewSorted = selection.records;
 
   // Flat format: one row per stage (match-level fields repeated).
   // In classifiersOnly mode, only classifier stages are included.
@@ -415,6 +426,11 @@ function exportChartCSV() {
         adj?.method || '',
       ]);
     }
+  }
+
+  if (rows.length === 1) {
+    setStatus(describeEmptyChartCSVExport(selection), 'error');
+    return;
   }
 
   const csv      = rows.map(r => r.map(v => `"${String(v).replace(/"/g, '""')}"`).join(',')).join('\n');

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -1327,7 +1327,7 @@
   <button id="fetchBtn"  class="ctrl-btn">Fetch Scores</button>
 </div>
 
-<div id="status">Enter your USPSA member number (recommended) and/or name, then click Fetch Scores.</div>
+<div id="status" role="status" aria-live="polite">Enter your USPSA member number (recommended) and/or name, then click Fetch Scores.</div>
 
 <div id="onboardingCard">
   <div class="onboarding-title">Welcome — let's load your match history</div>

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -1119,6 +1119,30 @@ function applyLast8Limit(records) {
   return last8Matches ? records.slice(-8) : records;
 }
 
+// Keep every chart surface and the CSV export on the same final filter pipeline.
+// Intermediate sets make empty-state explanations specific without mutating state.
+function selectAnalyticsRecords(referenceDate = new Date()) {
+  const chartableBase = allResults.filter(isChartable);
+  const selectedRecords = chartableBase.filter(r => !deselectedMatches.has(r.match_id));
+  const viewRecords = currentView === 'ranked'
+    ? selectedRecords.filter(r => r.found_by === 'member_number' && effectiveOverallPct(r) != null)
+    : selectedRecords.filter(r => effectiveOverallPct(r) != null || r.hf != null);
+  const divisionRecords = viewRecords.filter(matchesSelectedDivision).sort((a, b) => {
+    const da = parseDate(a.date), db = parseDate(b.date);
+    return (da && db) ? da - db : 0;
+  });
+  const rangeRecords = filterByActiveDateRange(divisionRecords, referenceDate);
+
+  return {
+    chartableBase,
+    selectedRecords,
+    viewRecords,
+    divisionRecords,
+    rangeRecords,
+    records: applyLast8Limit(rangeRecords),
+  };
+}
+
 function renderLast8Control(totalCount = null, visibleCount = null) {
   last8MatchesChk.checked = last8Matches;
   last8ToggleWrap.classList.toggle('active', last8Matches);
@@ -1190,24 +1214,9 @@ function renderAll() {
     return;
   }
 
-  // Level 2 filter: only chart USPSA/Hit Factor matches (excludes time-scored sports)
-  // Also exclude matches the user has manually deselected
-  const uspsaBase = allResults.filter(r =>
-    isChartable(r) &&
-    !deselectedMatches.has(r.match_id)
-  );
-
-  // 'ranked' = confirmed by member number, % score required
-  // 'all'    = any scored match (% or HF), including HF-only results
-  const chartable = currentView === 'ranked'
-    ? uspsaBase.filter(r => r.found_by === 'member_number' && effectiveOverallPct(r) != null)
-    : uspsaBase.filter(r => effectiveOverallPct(r) != null || r.hf != null);
-
-  const divs = [...new Set(chartable.map(r => normalizeDivision(r.division)).filter(Boolean))];
-  const sorted = chartable.filter(matchesSelectedDivision).sort((a, b) => {
-    const da = parseDate(a.date), db = parseDate(b.date);
-    return (da && db) ? da - db : 0;
-  });
+  const analyticsSelection = selectAnalyticsRecords();
+  const { viewRecords, divisionRecords: sorted, rangeRecords: rangeSorted, records: viewSorted } = analyticsSelection;
+  const divs = [...new Set(viewRecords.map(r => normalizeDivision(r.division)).filter(Boolean))];
   summaryBar.classList.add('visible');
   chartsEl.classList.add('visible');
   syncChartModeControls();
@@ -1239,8 +1248,6 @@ function renderAll() {
   }
 
   // Apply one shared range and optional recent-match limit to every analytics surface.
-  const rangeSorted = filterByActiveDateRange(sorted);
-  const viewSorted = applyLast8Limit(rangeSorted);
   renderLast8Control(rangeSorted.length, viewSorted.length);
 
   if (viewSorted.length === 0) {


### PR DESCRIPTION
## Summary

Shared chart rendering and CSV export selection, then stopped empty exports with an accessible explanation

## Files Changed

CHANGELOG.md, DESIGN.md, README.md, extension/dashboard-exports.js, extension/dashboard.html, extension/dashboard.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — node --check extension/dashboard.js; node --check extension/dashboard-exports.js; ./build.sh; git diff --check

Resolves #80


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.292 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-terra spent 3m and 98,373 tokens on this as a headless worker.