### PR TITLE
chore: release v1.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes are documented here. Update this file before pub
 
 ## Unreleased
 
+## v1.6.8 — 2026-08-27
+
 ### Fixed
 
 - Match, non-classifier stage, and Adjusted % displays and PNG cards now remain neutral instead of inferring USPSA classes. Captured GM hit factors appear separately as an explicit benchmark comparison.

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hit Factor Charts",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "description": "Track your USPSA match performance: division %, adjusted field-strength scores, classifier trends, and placement over time.",
   "permissions": ["tabs", "scripting", "storage"],
   "host_permissions": ["https://practiscore.com/*", "https://s3.amazonaws.com/*", "https://api.github.com/*", "https://uspsa.org/*", "https://objects.githubusercontent.com/*"],


### PR DESCRIPTION
## Summary

- bump the extension manifest to v1.6.8
- publish release notes for the neutral match-relative percentage fix
- publish release notes for actionable CSV export empty states

## Verification

- `node --check` passed for all extension JavaScript files
- manifest JSON parsed and reported version `1.6.8`
- v1.6.8 changelog extraction matched the release workflow pattern
- `./build.sh` produced `dist/hitfactorcharts-v1.6.8.zip`
- `git diff --check` passed
- pre-commit and pre-push quality hooks passed

## Release

Merging this PR triggers `.github/workflows/release.yml`, which builds `HitFactorCharts.zip`, creates tag `v1.6.8`, and publishes the v1.6.8 changelog section as the GitHub release notes.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.292 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol
