### PR TITLE
GH#89: refine Hit Zone scale and labels

### DIFF
--- a/extension/dashboard-charts.js
+++ b/extension/dashboard-charts.js
@@ -634,10 +634,10 @@ function drawMessage(canvas, msg) {
 
 // ── Stacked bar chart — hit zone breakdown ────────────────────────────────────
 // Raw shares are stored on each bar. Only cumulative display boundaries are
-// transformed: 0–50% raw maps to 0–30% visual; 50–100% maps to 30–100%.
+// transformed: 0–75% raw maps to 0–45% visual; 75–100% maps to 45–100%.
 function hitZoneVisualPct(rawPct) {
   const bounded = Math.max(0, Math.min(100, rawPct));
-  return bounded <= 50 ? bounded * 0.6 : 30 + (bounded - 50) * 1.4;
+  return bounded <= 75 ? bounded * 0.6 : 45 + (bounded - 75) * 2.2;
 }
 
 function drawStackedBarChart(canvas, bars) {
@@ -681,6 +681,22 @@ function drawStackedBarChart(canvas, bars) {
       const yTop = area.y0 + area.h - (upperVisual / 100) * area.h;
       ctx.fillStyle = COLORS[seg];
       ctx.fillRect(cx - barW / 2, yTop, barW, yBottom - yTop);
+
+      if (seg === 'a' && bar.aPct != null) {
+        const label = `${bar.aPct.toFixed(2)}%`;
+        const labelHeight = 10;
+        ctx.save();
+        ctx.font = `600 ${labelHeight}px Inter, system-ui, sans-serif`;
+        const fits = barW >= ctx.measureText(label).width + 4 && yBottom - yTop >= labelHeight + 4;
+        if (fits) {
+          // Dark green is readable on the bright A segment in either dashboard theme.
+          ctx.fillStyle = '#092916';
+          ctx.textAlign = 'center';
+          ctx.textBaseline = 'middle';
+          ctx.fillText(label, cx, yTop + (yBottom - yTop) / 2);
+        }
+        ctx.restore();
+      }
     });
 
     hitMap.push({ cx, cy: area.y0 + area.h / 2, bar });

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -1512,7 +1512,7 @@
       <h3>Hit Zone Breakdown</h3>
       <span class="chart-subtitle">Reported hit-zone distribution per match · nonlinear visual scale</span>
     </div>
-    <div class="chart-scale-note">Raw 0–50% maps to 0–30% of visual height; raw 50–100% maps to 30–100%. Tooltips show exact raw counts and percentages. Procedural penalties are excluded from the reported hit-zone total.</div>
+    <div class="chart-scale-note">Raw 0–75% maps to 0–45% of visual height; raw 75–100% maps to 45–100%. Legible A segments show their exact percentage. Tooltips show exact raw counts and percentages. Procedural penalties are excluded from the reported hit-zone total.</div>
     <canvas id="chartHitZone" height="380"></canvas>
   </div>
 </div>


### PR DESCRIPTION
## Summary

- Updates the Hit Zone nonlinear display scale: raw 0–75% maps to visual 0–45%, then raw 75–100% maps to visual 45–100%.
- Shows a two-decimal A-hit percentage only when the A segment is present and large enough to remain legible.
- Updates the visible scale disclosure; tooltips retain raw source values.

## Verification

- `node --check extension/dashboard.js`
- `node --check extension/dashboard-charts.js`
- `git diff --check`
- Executed the transform endpoint contract and a canvas rendering harness for available, missing, and zero-A data.

## Runtime Testing

Self-assessed. Playwriter cannot access extension pages in the existing browser session; no browser state or credentials were modified.

Resolves #89

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.298 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-terra spent 47m and 312,352 tokens on this with the user in an interactive session.
