### PR TITLE
GH#99: feat: add chart insight tiles

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -11,6 +11,11 @@ Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter
 - Analytical canvases share a 380px displayed height, fill their section width, and redraw from their rendered dimensions after a browser resize.
 - Canvas backing stores scale to the current device pixel ratio while layout, drawing, and pointer hit testing remain in CSS-pixel coordinates. Hidden canvases retain their last valid backing size until visible measurement is possible.
 - Summary cards and controls wrap rather than forcing page-level horizontal scrolling.
+- Chart insight summaries use compact, repeated tiles beneath the related chart
+  or explanatory note. Score and classifier grids use four columns on wide
+  screens, placement and non-classifier grids use two, outcome grids auto-fit
+  their available metrics, and all grids stack before their content becomes
+  cramped.
 - At narrow widths, Match History rows wrap metadata and keep refresh, export, and delete actions visibly keyboard-accessible.
 - Wide layouts should use the available charting space; constrain individual text or control elements only when readability requires it.
 - Stage tables may scroll within their existing panel on narrow screens, but the page itself must not acquire unintended horizontal overflow.
@@ -20,11 +25,34 @@ Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter
 - Preserve visible keyboard focus and keyboard access for every control.
 - Do not rely on hover for required actions or information.
 - Keep motion restrained in this analytical interface; resizing and filtering should feel immediate rather than animated.
-- Verify layout changes in both themes at approximately 375px, 1920px, and 2560px viewport widths.
+- Insight status icons reinforce visible text and are decorative to assistive
+  technology. Never communicate Improving, Stable, Needs attention,
+  unavailable data, or metric basis through colour or an icon alone.
+- Verify layout changes in both themes at approximately 375px, 1920px, and
+  2560px viewport widths.
 
 ## Chart language and axes
 
-- Trend summaries must state their comparison and use percentage-point units. When labelled **Stable**, show the metric-specific threshold in visible supporting text.
+- Trend summaries must state their comparison and use percentage-point units.
+  When labelled **Stable**, show the metric-specific threshold in visible
+  supporting text.
+- Every insight tile identifies its metric, primary value, comparison basis,
+  and sample size. Directional tiles use **Improving**, **Stable**, or
+  **Needs attention**; non-directional values use explicit labels such as
+  **Field context**, **Overall view**, or **Association only** instead of
+  implying progress.
+- Overall percentage trends report the least-squares predicted first-to-last
+  change for the filtered view. Score, placement, non-classifier, accuracy,
+  hit-zone, and classifier insights use the same final dataset and
+  stage-inclusion rules as their charts.
+- Classifier correlation is Pearson `r` across per-match classifier averages
+  paired with that match score, requires at least three varying pairs,
+  displays `n`, and is described only as an association. Prefer official
+  `clf_pct`; label any match-relative fallback and never infer a class from it.
+- Accuracy count tiles compare the last three matches with the prior baseline.
+  Higher A is positive; lower B/C/D/M/NS is positive. Hit-zone tiles pair
+  average shares with least-squares percentage-point trends using the same
+  semantic directions.
 - Date ticks use measured text width and a minimum 10px gap. Keep the final date only when it does not collide with the preceding retained label.
 - Suppress labels for duplicate source dates while preserving distinct same-day data points and tooltips. If different years share the same month and day, include the year so useful dates remain distinguishable.
 - Axis labels must remain inside the canvas and readable in both themes at narrow, desktop, and wide widths.

--- a/README.md
+++ b/README.md
@@ -116,14 +116,37 @@ Choose a named USPSA division before fetching scores. The saved selection limits
 
 ### Reading the chart summaries
 
-Below the Score Over Time and Placement charts, plain-English summaries show:
+Compact insight tiles below every analytics chart show the value, comparison
+basis, sample size, and a visible status. Arrows and colour reinforce the words
+**Improving**, **Stable**, and **Needs attention**; they never carry meaning
+alone. Tiles stay synchronized with the selected division, date range,
+Scored/All view, Last 8 setting, match checkboxes, and stage filters.
 
-- **Score trend** — your last 3 matches averaged vs your prior baseline; **Stable** means the change is within ±1.0 percentage point
-- **Adjusted % context** — whether your adjusted average runs above or below your raw division average, and what that means about field strength
-- **Placement** — your average finishing percentile in your division, with recent-vs-prior changes measured in percentage points; **Stable** means within ±1.0 point
-- **Classifier trend** — your recent classifier average vs prior; **Stable** means within ±1.5 points, using the national HHF reference (the only stage-level metric that is directly comparable across different matches and courses)
+- **Score Over Time** — last 3 match average vs the prior baseline, adjusted
+  average vs paired raw results, and least-squares first-to-last trends for raw
+  and adjusted percentages. **Stable** means within ±1.0 percentage point.
+- **Placement Over Time** — average field beaten and last 3 vs the prior
+  baseline. A higher field-beaten percentage is better; **Stable** means within
+  ±1.0 point.
+- **Non-Classifier Stage Trend** — last 3 vs prior and the overall
+  match-relative trend. These are comparisons with each match's top shooter,
+  not USPSA classifications.
+- **Classifier vs Match Score** — recent classifier performance, best
+  classifier, match average when classifiers were present, and Pearson
+  correlation between paired per-match values. Correlation requires at least 3
+  varying pairs, reports `r` and `n`, and describes association rather than
+  causation. Official USPSA percentages are preferred; any match-relative
+  fallback is labelled.
+- **Accuracy Trend** — recent-vs-prior reported A/B/C/D/M/NS counts. Higher A
+  and lower B/C/D/M/NS are treated as improvement.
+- **Hit Zone Breakdown** — average A/B/C/D/M/NS shares and their overall
+  percentage-point trends. Procedurals remain outside the denominator.
 
-Summaries appear automatically once enough data is loaded. Classifier trend requires at least 6 classifier stages.
+Recent-vs-prior trends require at least 4 results. Least-squares trends require
+at least 3. Classifier recent trends require at least 6 stages and use a
+±1.5-point Stable threshold. Insufficient metrics remain visibly unavailable
+rather than appearing as zero. Combined M+NS values always remain combined and
+show their own sample basis.
 
 The **Non-Classifier Stage Trend** averages your included non-classifier stage percentages for each match. Each percentage compares your hit factor with the top shooter on that stage at that match. It uses a linear 0–100% scale and is useful for tracking match-relative performance, but it is not an official USPSA classification percentage and does not use GM/M/A/B/C/D bands. Its 40%, 60%, 75%, 85%, and 95% lines are numeric percentage references only.
 

--- a/extension/dashboard-summaries.js
+++ b/extension/dashboard-summaries.js
@@ -1,18 +1,162 @@
 // dashboard-summaries.js — dashboard analytics summary helpers
 
-// ── Chart summaries ───────────────────────────────────────────────────────────
-// Simple helper: mean of a numeric array (returns 0 on empty).
+const SUMMARY_IDS = [
+  'chartTimeSummary',
+  'chartPlaceSummary',
+  'chartNonClfSummary',
+  'chartClfSummary',
+  'chartAccuracySummary',
+  'chartHitZoneSummary',
+];
+
 function _avg(arr) {
-  return arr.length ? arr.reduce((s, v) => s + v, 0) / arr.length : 0;
+  return arr.length ? arr.reduce((sum, value) => sum + value, 0) / arr.length : null;
 }
 
-// Trend label HTML for a percentage-point delta, with an inclusive ±threshold for "stable".
-function _trendLabel(delta, threshold = 1.0) {
-  if (delta >  threshold) return `<span class="s-up">↑ improving</span>`;
-  if (delta < -threshold) return `<span class="s-down">↓ declining</span>`;
-  const unit = threshold === 1 ? 'percentage point' : 'percentage points';
-  return `<span class="s-flat">→ stable</span> ` +
-    `<span class="s-note">(within ±${threshold.toFixed(1)} ${unit} of baseline)</span>`;
+function _finiteValues(values) {
+  return values.filter(Number.isFinite);
+}
+
+function _recentComparison(values, recentSize = 3) {
+  const finite = _finiteValues(values);
+  if (finite.length <= recentSize) return null;
+  const recent = finite.slice(-recentSize);
+  const prior = finite.slice(0, -recentSize);
+  return {
+    recentAvg: _avg(recent),
+    priorAvg: _avg(prior),
+    delta: _avg(recent) - _avg(prior),
+    recentCount: recent.length,
+    priorCount: prior.length,
+  };
+}
+
+function _overallTrend(values) {
+  const samples = values
+    .map((value, index) => ({ x: index, y: value }))
+    .filter(sample => Number.isFinite(sample.y));
+  const regression = leastSquaresRegression(samples);
+  if (!regression) return null;
+  return {
+    delta: regression.end.y - regression.start.y,
+    count: samples.length,
+  };
+}
+
+function _pearsonCorrelation(pairs) {
+  const finite = pairs.filter(pair => Number.isFinite(pair.x) && Number.isFinite(pair.y));
+  if (finite.length < 3) return null;
+  const meanX = _avg(finite.map(pair => pair.x));
+  const meanY = _avg(finite.map(pair => pair.y));
+  const numerator = finite.reduce((sum, pair) => sum + (pair.x - meanX) * (pair.y - meanY), 0);
+  const spreadX = finite.reduce((sum, pair) => sum + Math.pow(pair.x - meanX, 2), 0);
+  const spreadY = finite.reduce((sum, pair) => sum + Math.pow(pair.y - meanY, 2), 0);
+  const denominator = Math.sqrt(spreadX * spreadY);
+  if (!denominator) return null;
+  return { r: numerator / denominator, count: finite.length };
+}
+
+function _signed(value, digits = 1) {
+  return `${value >= 0 ? '+' : ''}${value.toFixed(digits)}`;
+}
+
+function _trendStatus(delta, threshold = 1.0, lowerIsBetter = false) {
+  const improvement = lowerIsBetter ? -delta : delta;
+  if (improvement > threshold) return { tone: 'positive', icon: '↑', label: 'Improving' };
+  if (improvement < -threshold) return { tone: 'negative', icon: '↓', label: 'Needs attention' };
+  return { tone: 'neutral', icon: '→', label: 'Stable' };
+}
+
+function _contextStatus(label, icon = '•') {
+  return { tone: 'context', icon, label };
+}
+
+function _insightTile({ label, value, comparison, meta, status }) {
+  const safeStatus = status || _contextStatus('Context');
+  return `
+    <article class="insight-tile insight-tile--${safeStatus.tone}" role="listitem">
+      <div class="insight-tile__label">${escHtml(label)}</div>
+      <div class="insight-tile__value">${escHtml(value)}</div>
+      <div class="insight-tile__status">
+        <span class="insight-tile__icon" aria-hidden="true">${escHtml(safeStatus.icon)}</span>
+        <span>${escHtml(safeStatus.label)}</span>
+      </div>
+      <div class="insight-tile__comparison">${escHtml(comparison)}</div>
+      <div class="insight-tile__meta">${escHtml(meta)}</div>
+    </article>`;
+}
+
+function _unavailableTile(label, reason) {
+  return _insightTile({
+    label,
+    value: '—',
+    comparison: reason,
+    meta: 'Missing values are not treated as zero.',
+    status: _contextStatus('Not enough data', '…'),
+  });
+}
+
+function _renderSummary(id, tiles) {
+  const element = document.getElementById(id);
+  if (!element) return;
+  element.innerHTML = tiles.join('');
+  element.style.display = tiles.length ? '' : 'none';
+}
+
+function clearChartSummaries() {
+  for (const id of SUMMARY_IDS) {
+    const element = document.getElementById(id);
+    if (!element) continue;
+    element.innerHTML = '';
+    element.style.display = 'none';
+  }
+}
+
+function _comparisonTile(label, comparison, unit, threshold = 1.0, lowerIsBetter = false) {
+  if (!comparison) return _unavailableTile(label, 'At least 4 results are required.');
+  const status = _trendStatus(comparison.delta, threshold, lowerIsBetter);
+  const thresholdNote = status.label === 'Stable'
+    ? ` · stable within ±${threshold.toFixed(1)} ${unit === '%' ? 'pp' : 'hits'}`
+    : '';
+  return _insightTile({
+    label,
+    value: `${comparison.recentAvg.toFixed(1)}${unit}`,
+    comparison: `${_signed(comparison.delta)}${unit === '%' ? ' pp' : ''} vs prior ${comparison.priorAvg.toFixed(1)}${unit}`,
+    meta: `Recent ${comparison.recentCount} vs prior ${comparison.priorCount}${thresholdNote}`,
+    status,
+  });
+}
+
+function _overallTrendTile(label, values, threshold = 1.0, lowerIsBetter = false) {
+  const trend = _overallTrend(values);
+  if (!trend) return _unavailableTile(label, 'At least 3 comparable results are required.');
+  const status = _trendStatus(trend.delta, threshold, lowerIsBetter);
+  const thresholdNote = status.label === 'Stable' ? ` · stable within ±${threshold.toFixed(1)} pp` : '';
+  return _insightTile({
+    label,
+    value: `${_signed(trend.delta)} pp`,
+    comparison: 'Predicted first-to-last change',
+    meta: `Least-squares trend · n=${trend.count}${thresholdNote}`,
+    status,
+  });
+}
+
+function _adjustedPairs(sorted) {
+  const pairs = [];
+  for (const record of sorted) {
+    if (!record.stages?.length || !record.division) continue;
+    const adjustedStages = getMetricStages(record)
+      .map(stage => computeAdjustedPct(stage, record.division))
+      .filter(Boolean);
+    const raw = effectiveDivPct(record) ?? effectiveOverallPct(record);
+    if (!adjustedStages.length || !Number.isFinite(raw)) continue;
+    pairs.push({
+      adjusted: _avg(adjustedStages.map(stage => stage.adjPct)),
+      raw,
+      references: adjustedStages.map(({ refClass, refDiv }) => ({ refClass, refDiv })),
+    });
+  }
+  return pairs;
 }
 
 function dominantEliteReference(pairs) {
@@ -38,132 +182,211 @@ function dominantEliteReference(pairs) {
   return ['GM', 'M'].includes(refClass) ? { refClass, refDiv } : null;
 }
 
-function generateSummaries(viewSorted) {
+function _scoreTiles(sorted) {
+  const rawValues = sorted
+    .map(record => effectiveDivPct(record) ?? effectiveOverallPct(record))
+    .filter(Number.isFinite);
+  const adjustedPairs = _adjustedPairs(sorted);
+  const adjustedValues = adjustedPairs.map(pair => pair.adjusted);
+  const recentRaw = _recentComparison(rawValues);
+  const tiles = [
+    _comparisonTile('Recent match score', recentRaw, '%'),
+  ];
+
+  if (adjustedPairs.length >= 3) {
+    const adjustedAverage = _avg(adjustedValues);
+    const rawAverage = _avg(adjustedPairs.map(pair => pair.raw));
+    const difference = adjustedAverage - rawAverage;
+    const eliteReference = dominantEliteReference(adjustedPairs);
+    const context = difference > 1.5
+      ? 'Stronger overall fields than the division draw'
+      : difference < -1.5
+      ? 'Strong division draw relative to the match field'
+      : eliteReference
+      ? `Similar field strength · mostly ${eliteReference.refClass} ${divisionLabel(eliteReference.refDiv)}`
+      : 'Division and overall field strength are similar';
+    tiles.push(_insightTile({
+      label: 'Adjusted average',
+      value: `${adjustedAverage.toFixed(1)}%`,
+      comparison: `${_signed(difference)} pp vs paired raw ${rawAverage.toFixed(1)}%`,
+      meta: `${context} · n=${adjustedPairs.length}`,
+      status: _contextStatus('Field context', '◆'),
+    }));
+  } else {
+    tiles.push(_unavailableTile('Adjusted average', 'At least 3 paired matches are required.'));
+  }
+
+  tiles.push(_overallTrendTile('Overall match trend', rawValues));
+  tiles.push(_overallTrendTile('Overall adjusted trend', adjustedValues));
+  return tiles;
+}
+
+function _placementTiles(sorted) {
+  const fieldBeaten = sorted
+    .filter(record => record.div_place != null && record.div_total > 0)
+    .map(record => (1 - record.div_place / record.div_total) * 100);
+  const average = _avg(fieldBeaten);
+  const averageTile = average == null
+    ? _unavailableTile('Average field beaten', 'Placement data is unavailable.')
+    : _insightTile({
+      label: 'Average field beaten',
+      value: `${average.toFixed(1)}%`,
+      comparison: 'Share of division finished behind you',
+      meta: `Current filtered view · n=${fieldBeaten.length}`,
+      status: _contextStatus('Overall view', '◎'),
+    });
+  return [averageTile, _comparisonTile('Recent placement', _recentComparison(fieldBeaten), '%')];
+}
+
+function _nonClassifierTiles(points) {
+  const values = points.map(point => point.y);
+  return [
+    _comparisonTile('Recent stage performance', _recentComparison(values), '%'),
+    _overallTrendTile('Overall stage trend', values),
+  ];
+}
+
+function _classifierData(sorted) {
+  const officialScores = [];
+  const fallbackScores = [];
+  const officialPairs = [];
+  const mixedPairs = [];
+  const matchScores = [];
+
+  for (const record of sorted) {
+    const classifiers = getMetricStages(record).filter(stage => isClassifierStage(stage));
+    if (!classifiers.length) continue;
+    const official = classifiers.map(stage => stage.clf_pct).filter(Number.isFinite);
+    const fallback = classifiers.map(stage => stage.clf_pct ?? stage.pct).filter(Number.isFinite);
+    officialScores.push(...official);
+    fallbackScores.push(...fallback);
+
+    const matchScore = effectiveOverallPct(record);
+    if (!Number.isFinite(matchScore)) continue;
+    matchScores.push(matchScore);
+    if (official.length) officialPairs.push({ x: _avg(official), y: matchScore });
+    if (fallback.length) mixedPairs.push({ x: _avg(official.length ? official : fallback), y: matchScore });
+  }
+
+  const useOfficial = officialScores.length > 0;
+  const scores = useOfficial ? officialScores : fallbackScores;
+  const useOfficialPairs = officialPairs.length >= 3;
+  return {
+    scores,
+    basis: useOfficial ? 'Official USPSA national HHF' : 'Match-relative classifier fallback',
+    pairs: useOfficialPairs ? officialPairs : mixedPairs,
+    pairBasis: useOfficialPairs ? 'Official classifier % only' : 'Mixed basis, explicitly labelled',
+    matchScores,
+  };
+}
+
+function _correlationDescription(r) {
+  const magnitude = Math.abs(r);
+  if (magnitude >= 0.7) return 'Strong association';
+  if (magnitude >= 0.4) return 'Moderate association';
+  if (magnitude >= 0.2) return 'Weak association';
+  return 'Little association';
+}
+
+function _classifierTiles(sorted) {
+  const data = _classifierData(sorted);
+  const recentSize = Math.min(5, Math.floor(data.scores.length / 2));
+  const recent = recentSize >= 1 && data.scores.length >= 6
+    ? _recentComparison(data.scores, recentSize)
+    : null;
+  const averageMatchScore = _avg(data.matchScores);
+  const correlation = _pearsonCorrelation(data.pairs);
+
+  return [
+    recent
+      ? _comparisonTile('Recent classifiers', recent, '%', 1.5)
+      : _unavailableTile('Recent classifiers', 'At least 6 classifier stages are required.'),
+    data.scores.length
+      ? _insightTile({
+        label: 'Best classifier',
+        value: `${Math.max(...data.scores).toFixed(1)}%`,
+        comparison: data.basis,
+        meta: `Best of ${data.scores.length} stages`,
+        status: _contextStatus('Best result', '★'),
+      })
+      : _unavailableTile('Best classifier', 'Classifier scores are unavailable.'),
+    averageMatchScore == null
+      ? _unavailableTile('Classifier-match score', 'No paired match scores are available.')
+      : _insightTile({
+        label: 'Classifier-match score',
+        value: `${averageMatchScore.toFixed(1)}%`,
+        comparison: 'Average match score when a classifier was present',
+        meta: `Current filtered view · n=${data.matchScores.length}`,
+        status: _contextStatus('Match context', '◎'),
+      }),
+    correlation
+      ? _insightTile({
+        label: 'Classifier correlation',
+        value: `r ${correlation.r.toFixed(2)}`,
+        comparison: `${_correlationDescription(correlation.r)} · association only`,
+        meta: `${data.pairBasis} · n=${correlation.count}`,
+        status: _contextStatus('Context, not causation', '↔'),
+      })
+      : _unavailableTile('Classifier correlation', 'At least 3 paired matches with variation are required.'),
+  ];
+}
+
+function _outcomeTiles(points, mode) {
+  const definitions = [
+    ['a', 'A hits', false],
+    ['b', 'B hits', true],
+    ['c', 'C hits', true],
+    ['d', 'D hits', true],
+    ['m', 'Misses', true],
+    ['ns', 'No-shoots', true],
+    ['m_ns', 'Combined M+NS', true],
+  ];
+  const tiles = [];
+
+  for (const [key, label, lowerIsBetter] of definitions) {
+    const property = mode === 'share' ? `${key}Pct` : key;
+    const values = points.map(point => point[property]).filter(Number.isFinite);
+    if (!values.length || (key === 'b' && !values.some(value => value > 0))) continue;
+
+    if (mode === 'share') {
+      const average = _avg(values);
+      const trend = _overallTrend(values);
+      const status = trend ? _trendStatus(trend.delta, 1.0, lowerIsBetter) : null;
+      const thresholdNote = status?.label === 'Stable' ? ' · stable within ±1.0 pp' : '';
+      tiles.push(_insightTile({
+        label,
+        value: `${average.toFixed(1)}%`,
+        comparison: trend ? `${_signed(trend.delta)} pp predicted change` : 'Trend needs at least 3 matches',
+        meta: `Average share · n=${values.length}${thresholdNote}`,
+        status: status || _contextStatus('Not enough trend data', '…'),
+      }));
+      continue;
+    }
+
+    const comparison = _recentComparison(values);
+    tiles.push(comparison
+      ? _comparisonTile(label, comparison, '', 0.5, lowerIsBetter)
+      : _unavailableTile(label, 'At least 4 matches with this reported column are required.'));
+  }
+  return tiles;
+}
+
+function generateSummaries(viewSorted, analysis = {}) {
+  clearChartSummaries();
   const sorted = [...viewSorted].sort((a, b) => {
     const da = parseDate(a.date), db = parseDate(b.date);
     return (da && db) ? da - db : 0;
   });
 
-  // ── 1. Score over time: last 3 matches vs prior baseline ──────────────────
-  const scoredMatches = sorted.filter(r => effectiveDivPct(r) != null || effectiveOverallPct(r) != null);
-  const scoreEl = document.getElementById('chartTimeSummary');
-  if (scoreEl) {
-    if (scoredMatches.length >= 4) {
-      const recent     = scoredMatches.slice(-3);
-      const prior      = scoredMatches.slice(0, -3);
-      const recentAvg  = _avg(recent.map(r => effectiveDivPct(r) ?? effectiveOverallPct(r)).filter(v => v != null));
-      const priorAvg   = _avg(prior.map(r => effectiveDivPct(r) ?? effectiveOverallPct(r)).filter(v => v != null));
-      const delta      = recentAvg - priorAvg;
-      const sign       = delta >= 0 ? '+' : '';
-      scoreEl.innerHTML =
-        `Last 3 matches: <span class="s-val">${recentAvg.toFixed(1)}%</span> ` +
-        `vs prior baseline <span class="s-val">${priorAvg.toFixed(1)}%</span> ` +
-        `— ${sign}${delta.toFixed(1)} pp ${_trendLabel(delta)}`;
-      scoreEl.style.display = '';
-    } else {
-      scoreEl.style.display = 'none';
-    }
+  if (analysis.mode === 'classifiersOnly') {
+    _renderSummary('chartTimeSummary', _classifierTiles(sorted));
+    return;
   }
 
-  // ── 2. Adjusted % vs raw division % ───────────────────────────────────────
-  const adjEl = document.getElementById('chartAdjSummary');
-  if (adjEl) {
-    const pairs = [];
-    for (const r of sorted) {
-      if (!r.stages?.length || !r.division) continue;
-      const adjs = getMetricStages(r).map(s => computeAdjustedPct(s, r.division)).filter(Boolean);
-      if (!adjs.length) continue;
-      const rawPct = effectiveDivPct(r) ?? effectiveOverallPct(r);
-      if (rawPct == null) continue;
-      pairs.push({
-        adj: _avg(adjs.map(a => a.adjPct)),
-        raw: rawPct,
-        references: adjs.map(({ refClass, refDiv }) => ({ refClass, refDiv })),
-      });
-    }
-    if (pairs.length >= 3) {
-      const meanAdj = _avg(pairs.map(p => p.adj));
-      const meanRaw = _avg(pairs.map(p => p.raw));
-      const diff    = meanAdj - meanRaw;
-      const sign    = diff >= 0 ? '+' : '';
-      const eliteReference = dominantEliteReference(pairs);
-      const context = diff > 1.5
-        ? `You're regularly competing against stronger fields than your division draw alone suggests.`
-        : diff < -1.5
-        ? `Your division tends to draw competitive shooters relative to the overall match field.`
-        : eliteReference
-        ? `Your raw division % was already measured against predominantly ${escHtml(eliteReference.refClass)}-class competition in ${escHtml(divisionLabel(eliteReference.refDiv))}, so little field-strength adjustment was needed.`
-        : `Your division's field strength closely mirrors the overall match field.`;
-      adjEl.innerHTML =
-        `Adjusted avg <span class="s-val">${meanAdj.toFixed(1)}%</span> ` +
-        `vs raw division avg <span class="s-val">${meanRaw.toFixed(1)}%</span> ` +
-        `(${sign}${diff.toFixed(1)}%) — ${context}`;
-      adjEl.style.display = '';
-    } else {
-      adjEl.style.display = 'none';
-    }
-  }
-
-  // ── 3. Placement: average percentile + trend ───────────────────────────────
-  const placeEl = document.getElementById('chartPlaceSummary');
-  if (placeEl) {
-    const placeData = sorted.filter(r => r.div_place != null && r.div_total > 0);
-    if (placeData.length >= 3) {
-      const pcts      = placeData.map(r => r.div_place / r.div_total);
-      const meanPct   = _avg(pcts);
-      const topPct    = Math.round(meanPct * 100);
-      let trendStr    = '';
-      if (placeData.length >= 4) {
-        // Lower percentile ratio = higher in the field = better
-        const recentPct = _avg(pcts.slice(-3)) * 100;
-        const priorPct  = _avg(pcts.slice(0, -3)) * 100;
-        const delta     = priorPct - recentPct; // positive = moved up = improving
-        const sign      = delta >= 0 ? '+' : '';
-        trendStr        = ` Recent: top <span class="s-val">${recentPct.toFixed(1)}%</span> ` +
-          `vs prior top <span class="s-val">${priorPct.toFixed(1)}%</span> ` +
-          `— ${sign}${delta.toFixed(1)} pp ${_trendLabel(delta)}.`;
-      }
-      placeEl.innerHTML =
-        `Finishing in the top <span class="s-val">${topPct}%</span> of your division on average.${trendStr}`;
-      placeEl.style.display = '';
-    } else {
-      placeEl.style.display = 'none';
-    }
-  }
-
-  // ── 4. Classifier trend: clf_pct only (national HHF — directly comparable) ─
-  const clfEl = document.getElementById('chartClfSummary');
-  if (clfEl) {
-    const clfStages = [];
-    for (const r of sorted) {
-      if (!r.stages) continue;
-      for (const s of getMetricStages(r)) {
-        if (s.clf_pct != null) clfStages.push(s.clf_pct);
-      }
-    }
-    if (clfStages.length >= 6) {
-      const N         = Math.min(5, Math.floor(clfStages.length / 2));
-      const recent    = clfStages.slice(-N);
-      const prior     = clfStages.slice(0, -N);
-      const recentAvg = _avg(recent);
-      const priorAvg  = _avg(prior);
-      const delta     = recentAvg - priorAvg;
-      const sign      = delta >= 0 ? '+' : '';
-      clfEl.innerHTML =
-        `Last ${N} classifiers: <span class="s-val">${recentAvg.toFixed(1)}%</span> ` +
-        `vs prior <span class="s-val">${priorAvg.toFixed(1)}%</span> ` +
-        `— ${sign}${delta.toFixed(1)} pp ${_trendLabel(delta, 1.5)} ` +
-        `<span class="s-note">(national HHF reference — directly comparable across matches)</span>`;
-      clfEl.style.display = '';
-    } else if (clfStages.length >= 2) {
-      const clfAvg = _avg(clfStages);
-      clfEl.innerHTML =
-        `Classifier avg: <span class="s-val">${clfAvg.toFixed(1)}%</span> ` +
-        `across ${clfStages.length} stage${clfStages.length > 1 ? 's' : ''}. ` +
-        `<span class="s-note">(${6 - clfStages.length} more needed for trend)</span>`;
-      clfEl.style.display = '';
-    } else {
-      clfEl.style.display = 'none';
-    }
-  }
+  _renderSummary('chartTimeSummary', _scoreTiles(sorted));
+  _renderSummary('chartPlaceSummary', _placementTiles(sorted));
+  _renderSummary('chartNonClfSummary', _nonClassifierTiles(analysis.nonClfPoints || []));
+  _renderSummary('chartClfSummary', _classifierTiles(sorted));
+  _renderSummary('chartAccuracySummary', _outcomeTiles(analysis.accuracyPoints || [], 'count'));
+  _renderSummary('chartHitZoneSummary', _outcomeTiles(analysis.hitZoneBars || [], 'share'));
 }

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -410,21 +410,82 @@
 
     canvas { display: block; width: 100% !important; height: 380px; }
 
-    /* ── Chart data summaries ── */
+    /* ── Chart insight tiles ── */
     .chart-summary {
-      margin-top: 10px;
-      padding: 9px 14px;
-      font-size: 14px;
-      color: #777;
-      line-height: 1.7;
-      border-top: 1px solid #252838;
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 10px;
+      margin-top: 16px;
     }
-    .chart-summary--adj { border-top-style: dashed; border-top-color: #1e2130; }
-    .chart-summary .s-val  { color: #e0e0e0; font-weight: 600; }
-    .chart-summary .s-up   { color: #4caf50; font-weight: 600; }
-    .chart-summary .s-down { color: #ff6b6b; font-weight: 600; }
-    .chart-summary .s-flat { color: #888;    font-weight: 500; }
-    .chart-summary .s-note { font-size: 12px; color: #aab3c2; }
+    .chart-summary--wide { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+    .chart-summary--outcomes { grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); }
+    .insight-tile {
+      min-width: 0;
+      padding: 13px 14px 12px;
+      background: #171a24;
+      border: 1px solid #2a2d3a;
+      border-left: 3px solid #596274;
+      border-radius: 8px;
+    }
+    .insight-tile--positive { border-left-color: #4caf50; }
+    .insight-tile--negative { border-left-color: #ff6b6b; }
+    .insight-tile--context { border-left-color: #4a9eff; }
+    .insight-tile__label {
+      color: #aab3c2;
+      font-size: 11px;
+      font-weight: 700;
+      line-height: 1.3;
+      text-transform: uppercase;
+      letter-spacing: 0.55px;
+    }
+    .insight-tile__value {
+      margin-top: 7px;
+      color: #f0f2f6;
+      font-size: 24px;
+      font-weight: 750;
+      line-height: 1.1;
+      font-feature-settings: 'tnum' 1;
+      overflow-wrap: anywhere;
+    }
+    .insight-tile__status {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+      margin-top: 8px;
+      color: #aab3c2;
+      font-size: 12px;
+      font-weight: 700;
+      line-height: 1.3;
+    }
+    .insight-tile--positive .insight-tile__status { color: #6fd47a; }
+    .insight-tile--negative .insight-tile__status { color: #ff8585; }
+    .insight-tile--context .insight-tile__status { color: #78b6ff; }
+    .insight-tile__icon {
+      display: inline-grid;
+      width: 17px;
+      height: 17px;
+      place-items: center;
+      border: 1px solid currentColor;
+      border-radius: 50%;
+      font-size: 11px;
+      line-height: 1;
+      flex: 0 0 auto;
+    }
+    .insight-tile__comparison {
+      margin-top: 7px;
+      color: #d0d5df;
+      font-size: 12px;
+      line-height: 1.4;
+      font-feature-settings: 'tnum' 1;
+      overflow-wrap: anywhere;
+    }
+    .insight-tile__meta {
+      margin-top: 4px;
+      color: #8993a5;
+      font-size: 11px;
+      line-height: 1.4;
+      overflow-wrap: anywhere;
+    }
     .chart-subtitle {
       font-size: 12px;
       color: #aab3c2;
@@ -1117,6 +1178,9 @@
       .last8-toggle { margin-left: 0; padding-left: 0; border-left: 0; }
       .chart-section { padding: 20px 16px; }
       .chart-section-header { align-items: flex-start; flex-wrap: wrap; gap: 8px; }
+      .chart-summary,
+      .chart-summary--wide,
+      .chart-summary--outcomes { grid-template-columns: 1fr; }
       #matchHistory { margin-left: 16px; margin-right: 16px; }
       .match-row { flex-wrap: wrap; gap: 6px; padding: 10px 12px; }
       .match-info { flex: 1 1 calc(100% - 55px); }
@@ -1216,10 +1280,18 @@
     [data-theme="light"] .chart-note { background: #f0f2f7; border-left-color: #c0c4cc; color: #5a6478; }
     [data-theme="light"] .chart-note strong { color: #2c3040; }
     [data-theme="light"] .chart-note em { color: #4a5060; }
-    [data-theme="light"] .chart-summary { color: #5a6478; border-top-color: #d8dce6; }
-    [data-theme="light"] .chart-summary--adj { border-top-color: #e0e2e8; }
-    [data-theme="light"] .chart-summary .s-val { color: #1a1d27; }
-    [data-theme="light"] .chart-summary .s-note { color: #4f596b; }
+    [data-theme="light"] .insight-tile { background: #ffffff; border-color: #d0d4dc; border-left-color: #687386; }
+    [data-theme="light"] .insight-tile--positive { border-left-color: #16803d; }
+    [data-theme="light"] .insight-tile--negative { border-left-color: #c9362b; }
+    [data-theme="light"] .insight-tile--context { border-left-color: #2563eb; }
+    [data-theme="light"] .insight-tile__label { color: #4f596b; }
+    [data-theme="light"] .insight-tile__value { color: #171a24; }
+    [data-theme="light"] .insight-tile__status { color: #4f596b; }
+    [data-theme="light"] .insight-tile--positive .insight-tile__status { color: #16733a; }
+    [data-theme="light"] .insight-tile--negative .insight-tile__status { color: #b42318; }
+    [data-theme="light"] .insight-tile--context .insight-tile__status { color: #1d4ed8; }
+    [data-theme="light"] .insight-tile__comparison { color: #374151; }
+    [data-theme="light"] .insight-tile__meta { color: #5a6478; }
     [data-theme="light"] .chart-subtitle { color: #4f596b; }
     [data-theme="light"] .chart-scale-note { color: #5a6478; }
     [data-theme="light"] #exportCsvBtn { color: #8a9bb0; border-color: #d0d4dc; }
@@ -1474,8 +1546,7 @@
        Adjusted % is the more meaningful progress indicator because it compares you with the strongest normalized stage result at that match, regardless of division. Neither match metric is an official USPSA classification percentage; use Classifiers Only for nationally normalized classifier context.
        The numeric 40%, 60%, 75%, 85%, and 95% lines are neutral percentage references, not inferred USPSA classifications.
     </div>
-    <div class="chart-summary" id="chartTimeSummary" style="display:none"></div>
-    <div class="chart-summary chart-summary--adj" id="chartAdjSummary" style="display:none"></div>
+    <div class="chart-summary chart-summary--wide" id="chartTimeSummary" role="list" aria-label="Score insights" style="display:none"></div>
   </div>
   <div class="chart-section" id="chartPlaceSection">
     <div class="chart-section-header">
@@ -1483,7 +1554,7 @@
       <span id="chartPlaceSubtitle" style="font-size:12px;color:#666;text-transform:uppercase;letter-spacing:0.5px"></span>
     </div>
     <canvas id="chartPlace" height="380"></canvas>
-    <div class="chart-summary" id="chartPlaceSummary" style="display:none"></div>
+    <div class="chart-summary" id="chartPlaceSummary" role="list" aria-label="Placement insights" style="display:none"></div>
   </div>
   <div class="chart-section" id="chartNonClfSection" style="display:none">
     <div class="chart-section-header">
@@ -1491,6 +1562,7 @@
       <span class="chart-subtitle">Average stage % compared with each match's top shooter — neutral numeric guides, not USPSA classifications</span>
     </div>
     <canvas id="chartNonClf" height="380"></canvas>
+    <div class="chart-summary" id="chartNonClfSummary" role="list" aria-label="Non-classifier stage insights" style="display:none"></div>
   </div>
   <div class="chart-section" id="chartClfOverlaySection" style="display:none">
     <div class="chart-section-header">
@@ -1498,7 +1570,7 @@
       <span style="font-size:12px;color:#666;text-transform:uppercase;letter-spacing:0.5px">Numeric guides compare percentage references; they are not class bands</span>
     </div>
     <canvas id="chartClfOverlay" height="380"></canvas>
-    <div class="chart-summary" id="chartClfSummary" style="display:none"></div>
+    <div class="chart-summary chart-summary--wide" id="chartClfSummary" role="list" aria-label="Classifier and match score insights" style="display:none"></div>
   </div>
   <div class="chart-section" id="chartAccuracySection" style="display:none">
     <div class="chart-section-header">
@@ -1506,6 +1578,7 @@
       <span style="font-size:12px;color:#666;text-transform:uppercase;letter-spacing:0.5px">Reported C, D, M, and NS counts per match · nonlinear scale · combined M+NS is not split</span>
     </div>
     <canvas id="chartAccuracy" height="380"></canvas>
+    <div class="chart-summary chart-summary--outcomes" id="chartAccuracySummary" role="list" aria-label="Accuracy outcome insights" style="display:none"></div>
   </div>
   <div class="chart-section" id="chartHitZoneSection" style="display:none">
     <div class="chart-section-header">
@@ -1514,6 +1587,7 @@
     </div>
     <div class="chart-scale-note">Raw 0–75% maps to 0–45% of visual height; raw 75–100% maps to 45–100%. Legible A segments show their exact percentage. Dotted lines are per-series least-squares progressions; the green line here tracks raw A%. Tooltips show exact raw counts and percentages. Procedural penalties are excluded from the reported hit-zone total.</div>
     <canvas id="chartHitZone" height="380"></canvas>
+    <div class="chart-summary chart-summary--outcomes" id="chartHitZoneSummary" role="list" aria-label="Hit zone insights" style="display:none"></div>
   </div>
 </div>
 

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -1190,8 +1190,7 @@ function setPlacementVisible(visible) {
 function resetSecondaryAnalysis() {
   ['chartNonClfSection', 'chartClfOverlaySection', 'chartAccuracySection', 'chartHitZoneSection']
     .forEach(id => { document.getElementById(id).style.display = 'none'; });
-  ['chartTimeSummary', 'chartAdjSummary', 'chartPlaceSummary', 'chartClfSummary']
-    .forEach(id => { document.getElementById(id).style.display = 'none'; });
+  clearChartSummaries();
   document.getElementById('chartPlaceSubtitle').textContent = '';
 }
 
@@ -1467,6 +1466,7 @@ function renderAll() {
       showClassBands: allClassifierScoresOfficial,
     });
     setPlacementVisible(false);
+    generateSummaries(viewSorted, { mode: 'classifiersOnly' });
     return;
   }
 
@@ -1707,11 +1707,11 @@ function renderAll() {
   const accuracyPoints  = [];
   for (const r of viewSorted) {
     if (!r.stages?.length) continue;
-    const totals = { c: 0, d: 0, m: 0, ns: 0 };
-    const available = { c: false, d: false, m: false, ns: false };
+    const totals = { a: 0, b: 0, c: 0, d: 0, m: 0, ns: 0, m_ns: 0 };
+    const available = { a: false, b: false, c: false, d: false, m: false, ns: false, m_ns: false };
     let hasCombinedMNs = false, stagesWithHits = 0;
     for (const s of getMetricStages(r)) {
-      for (const key of ['c', 'd']) {
+      for (const key of ['a', 'b', 'c', 'd']) {
         const value = reportedStageHit(s, key);
         if (value == null) continue;
         available[key] = true;
@@ -1723,7 +1723,12 @@ function renderAll() {
         if (stageM != null) { available.m = true; totals.m += stageM; }
         if (stageNS != null) { available.ns = true; totals.ns += stageNS; }
       } else {
-        if (reportedStageHit(s, 'm_ns') != null) hasCombinedMNs = true;
+        const stageCombined = reportedStageHit(s, 'm_ns');
+        if (stageCombined != null) {
+          hasCombinedMNs = true;
+          available.m_ns = true;
+          totals.m_ns += stageCombined;
+        }
       }
       stagesWithHits++;
     }
@@ -1732,11 +1737,14 @@ function renderAll() {
       date: r.date,
       label: r.match_name,
       division: r.division,
+      a: available.a ? totals.a : null,
+      b: available.b ? totals.b : null,
       c: available.c ? totals.c : null,
       d: available.d ? totals.d : null,
       m: hasCombinedMNs ? null : (available.m ? totals.m : null),
       ns: hasCombinedMNs ? null : (available.ns ? totals.ns : null),
-      m_ns: hasCombinedMNs,
+      m_ns: available.m_ns ? totals.m_ns : null,
+      hasCombinedMNs,
     });
   }
   accuracyPoints.sort((a, b) => (a.date || '').localeCompare(b.date || ''));
@@ -1818,7 +1826,7 @@ function renderAll() {
     hitZoneSection.style.display = 'none';
   }
 
-  generateSummaries(viewSorted);
+  generateSummaries(viewSorted, { nonClfPoints, accuracyPoints, hitZoneBars });
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Replace prose chart summaries with responsive, accessible metric tiles across score, placement, stage, classifier, accuracy, and hit-zone analytics. Add explicit trend, sample-size, missing-data, and correlation semantics, plus user and design documentation.

## Files Changed

DESIGN.md, README.md, extension/dashboard-summaries.js, extension/dashboard.html, extension/dashboard.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Passed node syntax checks for dashboard scripts, synthetic summary assertions including combined M+NS and missing-data cases, git diff --check, extension build, WCAG contrast calculations, and Playwright visual/accessibility review at 375px, 1920px, and 2560px in both themes. Changed Markdown lines are lint-clean; repository-wide Markdown lint still reports fewer pre-existing violations than origin/main.

Resolves #99


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.333 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 1h 13m and 631,305 tokens on this with the user in an interactive session.