### PR TITLE
chore: release v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable user-facing changes are documented here. Update this file before pub
 
 ## Unreleased
 
+## v1.7.0 — 2026-09-07
+
+### Highlights
+
+- Every analytics chart now includes responsive insight tiles for its primary
+  values, recent comparisons, overall trends, and sample sizes.
+- Classifier insights now include best performance, same-match context, and
+  Pearson correlation when at least three varying paired matches are available.
+
+### Analytics semantics
+
+- Directional metrics now use explicit **Improving**, **Stable**, and
+  **Needs attention** labels, while non-directional metrics use neutral context
+  labels instead of implying progress.
+- Accuracy and hit-zone summaries preserve separate M/NS and combined M+NS
+  source data, exclude procedurals from hit-zone denominators, and leave missing
+  values unavailable instead of treating them as zero.
+- Insight grids now adapt from wide desktop columns to a single-column mobile
+  layout in both light and dark themes without horizontal page overflow.
+
+### Release documentation
+
+- Added the chart-summary metric, threshold, accessibility, and responsive
+  layout contracts to the README and design guide.
+
 ## v1.6.9 — 2026-09-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Chrome extension that pulls your USPSA match results from PractiScore and disp
 
 ![Hit Factor Charts — Analytics](/screenshots/bottom.png?raw=true "Hit Factor Charts — Full Analytics Suite")
 
-*Screenshots taken at v1.5.5. Current version is v1.6.4.*
+*Screenshots taken at v1.5.5. Current version is v1.7.0.*
 
 ---
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hit Factor Charts",
-  "version": "1.6.9",
+  "version": "1.7.0",
   "description": "Track your USPSA match performance: division %, adjusted field-strength scores, classifier trends, and placement over time.",
   "permissions": ["tabs", "scripting", "storage"],
   "host_permissions": ["https://practiscore.com/*", "https://s3.amazonaws.com/*", "https://api.github.com/*", "https://uspsa.org/*", "https://objects.githubusercontent.com/*"],


### PR DESCRIPTION
## Summary

- bump the extension from v1.6.9 to v1.7.0
- add user-facing release notes for the responsive chart insight tiles from #101
- synchronize the README's current-version label

## Verification

- `./build.sh` produced `dist/hitfactorcharts-v1.7.0.zip`
- all extension JavaScript files passed `node --check`
- the manifest and changelog release section were validated programmatically
- `git diff --check` passed
- changed Markdown adds no lint violations; the existing repository baseline remains unchanged

## Publication

Merging this PR triggers `.github/workflows/release.yml`, which creates the
`v1.7.0` GitHub release and uploads `HitFactorCharts.zip` from the merged source.

For #99.

<!-- aidevops:origin:interactive -->

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.333 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol
