### PR TITLE
GH#103: Preserve cached history across upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable user-facing changes are documented here. Update this file before pub
 
 ## Unreleased
 
+### Added
+
+- Added versioned local-data backup and validated restore controls for recovery
+  when an unpacked extension is loaded from a different folder or receives a
+  new identity.
+- Added explicit and periodic full history reconciliation for discovering older
+  delayed or backfilled PractiScore matches.
+
+### Changed
+
+- Routine PractiScore refreshes now scan newest history pages first and stop
+  after a conservative two-page overlap with trusted same-member sync metadata.
+- Compatible complete cache records now migrate non-destructively to the current
+  schema instead of being blanket-refetched.
+
+### Fixed
+
+- Upgrade guidance now preserves the loaded unpacked folder and uses Chrome's
+  Reload action, preventing accidental storage-namespace changes during normal
+  updates.
+- Incomplete pagination and corrupt sync metadata preserve existing history and
+  coverage while diagnostics explain the fallback and stop reason.
+
 ## v1.7.0 — 2026-09-07
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes are documented here. Update this file before pub
 
 ## Unreleased
 
+## v1.7.1 — 2026-09-08
+
 ### Added
 
 - Added versioned local-data backup and validated restore controls for recovery

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -87,12 +87,37 @@ Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter
 - Fetch timeline controls pre-fetch request scope; analytics presets independently filter cached data. Keep that distinction explicit in status and documentation.
 - The current visible select value is the next fetch scope. Changing it alone makes no request.
 - Preserve older cache and Match History entries when a narrower timeline is fetched. Explicit single-match refresh remains unrestricted.
-- Traverse every available Match History page and associate ID, name, and date within one source row or structured record. Deduplicate by match ID, never by date, so same-day matches remain distinct. An unsettled or incomplete extraction is non-destructive.
+- With valid same-owner sync metadata, scan Match History newest-first and stop
+  only after two consecutive settled pages contain no unknown IDs and every
+  valid date is at or before the stored high-water date. Any unknown ID resets
+  the overlap count, including a same-day addition. Missing/corrupt metadata,
+  malformed page dates, ten incremental runs, or fourteen days since the last
+  full scan require full pagination. Deduplicate by match ID, never by date, so
+  same-day matches remain distinct. An unsettled or incomplete extraction is
+  non-destructive and cannot advance sync metadata or erase coverage.
 - Store cache completeness with parser schema version, `complete|partial|unknown` state, expected and fetched stage counts, and failed stage identities. Legacy records are `unknown` and receive one lazy repair; only explicitly complete same-member records bypass score and stage requests.
 - Stage repair is sequential and bounded. Verify each selected stage, traverse result-table pages, retry failures, merge successful partial data by stable stage identity, and replace stages only after a complete authoritative fetch. Preserve stage overrides by stage number when names change.
 - Report extracted and in-range matches, complete cache reuse, partial and unknown repairs, new matches, expected and fetched stages, and failed stages as separate diagnostics.
+- Keep **Full history reconciliation**, **Back up data**, and **Restore backup**
+  as compact secondary controls below the primary fetch row. They wrap at narrow
+  widths, retain visible focus, and explain that backups are required before
+  changing an unpacked extension folder.
 - Use the dashboard-supplied inclusive date bounds as the authoritative fetch window so frontend and background scope cannot diverge across midnight.
 - Keep the label and select together as controls wrap at narrow widths, with visible focus and no page-level horizontal overflow.
+
+## Upgrade persistence and recovery
+
+- Preserve the manifest identity: do not add or change a fixed public key without
+  a separately verified one-time migration. In-place file replacement plus
+  Chrome's **Reload** is the supported unpacked-upgrade path.
+- Keep full history in `chrome.storage.local`; sync storage is reserved for compact credentials and theme preferences.
+- Backups are versioned JSON and include history, score cache, coverage,
+  selections, filters, and overrides. Validate format, size, field types, and
+  `cached_for` ownership before any restore write; require explicit confirmation
+  before replacing another member's local history.
+- Storage migrations are versioned and idempotent. Promote compatible complete
+  cache records to the current parser schema without refetching, preserve unknown
+  records for lazy repair, and never blanket-delete data during an upgrade.
 
 ## Last 8 analytics
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Chrome extension that pulls your USPSA match results from PractiScore and disp
 
 ![Hit Factor Charts — Analytics](/screenshots/bottom.png?raw=true "Hit Factor Charts — Full Analytics Suite")
 
-*Screenshots taken at v1.5.5. Current version is v1.7.0.*
+*Screenshots taken at v1.5.5. Current version is v1.7.1.*
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ A Chrome extension that pulls your USPSA match results from PractiScore and disp
 - **Export as CSV** — download all chart-visible data as a flat CSV (one row per stage) including CM numbers, USPSA %, HF, hit counts, adjusted %, and the selected reference division, class, HF, normalized HF, and benchmark method
 - **Light/dark theme** — defaults to light mode; toggle in the header; preference syncs across devices via Chrome storage
 - **Inter font** — bundled variable font for clean, consistent rendering at all weights
-- **Complete local caching** — match data is cached in browser storage with stage-completeness metadata; complete matches are reused, while legacy or partial records are repaired on the next fetch
+- **Durable local caching** — history and preferences stay in browser storage;
+  compatible schemas migrate in place, and a versioned backup can restore data
+  after an unpacked-folder identity change
+- **Incremental history refresh** — routine fetches scan newest PractiScore pages
+  first; periodic and explicit full reconciliations catch older delayed matches
 - **No external server** — everything runs locally in your browser using your existing PractiScore login session
 
 ---
@@ -95,6 +99,27 @@ In the top-right corner of the Extensions page, toggle on **Developer mode**.
 3. Click **Select Folder**
 
 The Hit Factor Charts icon will appear in your Chrome toolbar. Pin it for easy access via the puzzle-piece menu.
+
+### Updating without losing local history
+
+Chrome keys unpacked-extension storage to the extension identity. Reloading the
+same loaded directory preserves that identity and all local history. Removing
+the extension or loading the same files from a different path can create a
+different identity with an empty storage namespace.
+
+1. Open Hit Factor Charts and click **Back up data**.
+2. Replace the files *inside the directory currently loaded by Chrome*. Keep the
+   directory path unchanged.
+3. Open `chrome://extensions` and click **Reload** on Hit Factor Charts. Do not
+   remove the extension or load a newly named/versioned folder.
+4. Reopen the dashboard and confirm the cached history and preferences are present.
+
+If the folder or extension identity already changed, load the new copy, click
+**Restore backup**, and choose the JSON backup. Restore validates the format,
+size, cache ownership, and data types before writing. A backup for a different
+member requires explicit confirmation. Full match history remains in
+`chrome.storage.local`; only compact credentials and theme preferences use
+`chrome.storage.sync` because sync storage is too small for score history.
 
 ---
 
@@ -160,7 +185,27 @@ Analytics open on the most recent **6 mo** so trends stay readable. Use the butt
 
 The **Last 8 matches** switch applies after the active analytics date range, division, Scored/All view, and manually selected matches. Turn it on to use the most recent eight qualifying matches across every chart, summary, classifier analysis, and chart CSV export. If fewer than eight qualify, all available matches are used. The preference is remembered, while Match History and cached records remain complete.
 
-The **Fetch timeline** dropdown beside **Fetch Scores** is separate: it limits network requests before a fetch begins and remembers your last choice. A narrower fetch merges new results with older cached Match History instead of deleting it. When you later choose a broader timeline, every available history page is traversed and same-date matches remain separate. Matches explicitly recorded as complete for the same member are reused without score or stage requests. Legacy, unknown, or partial records are repaired non-destructively, preserving successful stages and stage filters if a retry remains incomplete. The status and progress log report extracted and in-range matches separately from complete cache reuse, repairs, expected stages, fetched stages, and failures. Changing the dropdown or Last 8 switch alone does not make a request, and refreshing one match remains unrestricted.
+The **Fetch timeline** dropdown beside **Fetch Scores** is separate: it limits
+score and stage requests and remembers your last choice. A narrower fetch merges
+new results with older cached Match History instead of deleting it. After one
+complete history scan establishes trusted sync metadata, routine refreshes scan
+newest PractiScore pages first and stop only after two settled pages contain no
+unknown IDs at or before the stored high-water date. Unknown or corrupt metadata
+falls back to full pagination. Same-date IDs remain distinct, and an incomplete
+page never deletes older rows or coverage.
+
+Click **Full history reconciliation** to scan every available history page while
+still reusing complete same-member score caches. The extension also performs a
+full reconciliation after ten incremental runs or fourteen days, whichever
+comes first, so older delayed or backfilled matches are eventually discovered.
+Matches explicitly recorded as complete for the same member are reused without
+score or stage requests. Compatible cache schemas migrate in place; unknown or
+partial records are repaired non-destructively, preserving successful stages
+and stage filters if a retry remains incomplete. The status and progress log
+report pages scanned, incremental/full mode, stop or fallback reason, newly
+discovered matches, cache reuse, repairs, and stage outcomes. Changing the
+dropdown or Last 8 switch alone does not make a request, and refreshing one
+match remains unrestricted.
 
 ### Exporting data
 
@@ -208,7 +253,8 @@ Use the **⚠ Clear All Data** button in the header to wipe all cached scores fr
 | Scores show 0% or wrong division | Your name in the Name field must match the result sheet exactly (e.g. `Doe, John`) |
 | Extension doesn't appear | Confirm Developer Mode is on and you loaded the `extension/` subfolder, not the repo root |
 | Match list is empty | Visit [practiscore.com/associate/step2](https://practiscore.com/associate/step2) while logged in to verify your history is accessible |
-| Charts show wrong colors | If upgrading from v1.4 or earlier, clear all data and re-fetch |
+| History appears empty after an update | The unpacked folder path may have changed. Load the intended copy and use **Restore backup**; for future updates, replace files in the loaded folder and click **Reload** |
+| An older delayed match is missing | Click **Full history reconciliation**; routine refreshes also trigger a periodic full scan |
 
 ---
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -2,9 +2,27 @@
 
 const PS_BASE = 'https://practiscore.com';
 const USPSA_BASE = 'https://uspsa.org';
-const CACHE_SCHEMA_VERSION = 1;
+const CACHE_SCHEMA_VERSION = 2;
+const STORAGE_SCHEMA_VERSION = 2;
+const HISTORY_SYNC_SCHEMA_VERSION = 1;
+const BACKUP_FORMAT_VERSION = 1;
 const MAX_HISTORY_PAGES = 100;
 const MAX_RESULTS_PAGES = 100;
+const HISTORY_OVERLAP_PAGES = 2;
+const FULL_HISTORY_SCAN_INTERVAL_MS = 14 * 24 * 60 * 60 * 1000;
+const FULL_HISTORY_SCAN_RUN_INTERVAL = 10;
+const MAX_BACKUP_BYTES = 8 * 1024 * 1024;
+const BACKUP_KEYS = Object.freeze([
+  'memberNumber', 'name', 'matchCache', 'lastMatchList', 'stageOverrides',
+  'fetchCoverage', 'deselectedMatches', 'classificationData', 'selectedDivision',
+  'fetchTimeline', 'last8Matches', 'matchTypeOverrides', 'matchHistorySync',
+  'storageMetadata', 'theme',
+]);
+
+const storageMigrationPromise = migrateStorage().catch(error => {
+  console.error('[HFC] Storage migration failed without changing cached data:', error);
+  return { migrated: false, error: error.message };
+});
 
 // ── Open dashboard tab (or focus if already open) ─────────────────────────────
 chrome.action.onClicked.addListener(async () => {
@@ -21,7 +39,7 @@ chrome.action.onClicked.addListener(async () => {
 // ── Message handler ───────────────────────────────────────────────────────────
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg.action === 'fetchScores') {
-    fetchScores(msg.memberNumber, msg.name, msg.fetchTimeline)
+    fetchScores(msg.memberNumber, msg.name, msg.fetchTimeline, { fullHistory: msg.fullHistory === true })
       .then(data  => sendResponse({ ok: true,  data }))
       .catch(err  => sendResponse({ ok: false, error: err.message }));
     return true;
@@ -44,9 +62,259 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       .catch(err  => sendResponse({ ok: false, error: err.message }));
     return true;
   }
+  if (msg.action === 'initializeStorage') {
+    storageMigrationPromise
+      .then(data => sendResponse({ ok: true, data }))
+      .catch(err => sendResponse({ ok: false, error: err.message }));
+    return true;
+  }
+  if (msg.action === 'exportBackup') {
+    createBackup()
+      .then(data => sendResponse({ ok: true, data }))
+      .catch(err => sendResponse({ ok: false, error: err.message }));
+    return true;
+  }
+  if (msg.action === 'importBackup') {
+    importBackup(msg.backup, { replaceExistingOwner: msg.replaceExistingOwner === true })
+      .then(data => sendResponse({ ok: true, data }))
+      .catch(err => sendResponse({ ok: false, error: err.message, code: err.code || null }));
+    return true;
+  }
 });
 
 // ── Cache helpers ─────────────────────────────────────────────────────────────
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizedOwner(memberNumber) {
+  return String(memberNumber || '').trim().toUpperCase() || null;
+}
+
+function ownerIdentity(memberNumber, name) {
+  const member = normalizedOwner(memberNumber);
+  if (member) return `member:${member}`;
+  const normalizedName = String(name || '').trim().toLowerCase().replace(/\s+/g, ' ');
+  return normalizedName ? `name:${normalizedName}` : null;
+}
+
+function isCompatibleCompleteCache(value) {
+  if (!isRecord(value) || !Array.isArray(value.stages)) return false;
+  const metadata = value.cache_completeness;
+  return isRecord(metadata) && metadata.state === 'complete' &&
+    Number.isInteger(metadata.expected_stage_count) &&
+    metadata.expected_stage_count === metadata.fetched_stage_count &&
+    Array.isArray(metadata.failed_stages) && metadata.failed_stages.length === 0 &&
+    value.stages.length === metadata.expected_stage_count;
+}
+
+async function migrateStorage() {
+  const stored = await chrome.storage.local.get(['memberNumber', 'matchCache', 'storageMetadata']);
+  const previousVersion = Number(stored.storageMetadata?.schemaVersion) || 0;
+  if (previousVersion >= STORAGE_SCHEMA_VERSION) {
+    return { migrated: false, from: previousVersion, to: STORAGE_SCHEMA_VERSION, cacheEntriesMigrated: 0 };
+  }
+
+  const matchCache = isRecord(stored.matchCache) ? { ...stored.matchCache } : {};
+  let cacheEntriesMigrated = 0;
+  for (const [matchId, cached] of Object.entries(matchCache)) {
+    if (!isCompatibleCompleteCache(cached)) continue;
+    const schemaVersion = Number(cached.cache_completeness?.schema_version) || 0;
+    if (schemaVersion >= CACHE_SCHEMA_VERSION) continue;
+    matchCache[matchId] = {
+      ...cached,
+      cache_completeness: { ...cached.cache_completeness, schema_version: CACHE_SCHEMA_VERSION },
+    };
+    cacheEntriesMigrated++;
+  }
+
+  const storageMetadata = {
+    schemaVersion: STORAGE_SCHEMA_VERSION,
+    migratedFrom: previousVersion,
+    migratedAt: Date.now(),
+    extensionVersion: chrome.runtime.getManifest().version,
+  };
+  await chrome.storage.local.set({
+    storageMetadata,
+    ...(cacheEntriesMigrated > 0 ? { matchCache } : {}),
+  });
+  console.log(`[HFC] Storage migration ${previousVersion} → ${STORAGE_SCHEMA_VERSION}; ${cacheEntriesMigrated} compatible cache record(s) preserved.`);
+  return { migrated: true, from: previousVersion, to: STORAGE_SCHEMA_VERSION, cacheEntriesMigrated };
+}
+
+function validateBackupData(backup) {
+  let byteLength;
+  try {
+    byteLength = new TextEncoder().encode(JSON.stringify(backup)).length;
+  } catch (_) {
+    throw new Error('Backup is not valid JSON data.');
+  }
+  if (byteLength > MAX_BACKUP_BYTES) throw new Error('Backup exceeds the 8 MB safety limit.');
+  if (!isRecord(backup) || backup.format !== 'hit-factor-charts-backup' || backup.version !== BACKUP_FORMAT_VERSION) {
+    throw new Error('Unsupported Hit Factor Charts backup format or version.');
+  }
+  if (!isRecord(backup.data)) throw new Error('Backup data is missing.');
+
+  const data = {};
+  for (const key of BACKUP_KEYS) {
+    if (Object.hasOwn(backup.data, key)) data[key] = backup.data[key];
+  }
+  if (typeof data.memberNumber !== 'undefined' && (typeof data.memberNumber !== 'string' || data.memberNumber.length > 64)) {
+    throw new Error('Backup member number is invalid.');
+  }
+  if (typeof data.name !== 'undefined' && (typeof data.name !== 'string' || data.name.length > 200)) {
+    throw new Error('Backup name is invalid.');
+  }
+  if (data.lastMatchList && (!Array.isArray(data.lastMatchList) || data.lastMatchList.length > 10000 ||
+      data.lastMatchList.some(match => !isRecord(match) || typeof match.match_id !== 'string' ||
+        typeof match.match_name !== 'string' || typeof match.date !== 'string'))) {
+    throw new Error('Backup match history is invalid.');
+  }
+  if (data.matchCache && (!isRecord(data.matchCache) || Object.keys(data.matchCache).length > 10000)) {
+    throw new Error('Backup match cache is invalid.');
+  }
+  if (Object.keys(data.matchCache || {}).some(key => !key || ['__proto__', 'prototype', 'constructor'].includes(key))) {
+    throw new Error('Backup match cache contains an invalid identifier.');
+  }
+  const expectedOwner = normalizedOwner(data.memberNumber);
+  for (const cached of Object.values(data.matchCache || {})) {
+    if (!isRecord(cached) || cached.cached_for !== expectedOwner) {
+      throw new Error('Backup cache ownership does not match its member number.');
+    }
+    if (typeof cached.stages !== 'undefined' &&
+        (!Array.isArray(cached.stages) || cached.stages.some(stage => !isRecord(stage)))) {
+      throw new Error('Backup cache contains invalid stage data.');
+    }
+    for (const stage of cached.stages || []) {
+      if ((stage.name !== undefined && stage.name !== null && typeof stage.name !== 'string') ||
+          (stage.classifier_code !== undefined && stage.classifier_code !== null && typeof stage.classifier_code !== 'string') ||
+          (stage.hit_columns !== undefined && !isRecord(stage.hit_columns)) ||
+          (stage.xdiv_benchmarks !== undefined && !isRecord(stage.xdiv_benchmarks))) {
+        throw new Error('Backup cache contains invalid stage fields.');
+      }
+    }
+    if (typeof cached.cache_completeness !== 'undefined') {
+      const completeness = cached.cache_completeness;
+      if (!isRecord(completeness) || !['complete', 'partial', 'unknown'].includes(completeness.state) ||
+          !Number.isInteger(completeness.schema_version) ||
+          (completeness.expected_stage_count !== null && !Number.isInteger(completeness.expected_stage_count)) ||
+          !Number.isInteger(completeness.fetched_stage_count) || !Array.isArray(completeness.failed_stages)) {
+        throw new Error('Backup cache completeness metadata is invalid.');
+      }
+    }
+  }
+  if (data.classificationData?.member_number && normalizedOwner(data.classificationData.member_number) !== expectedOwner) {
+    throw new Error('Backup classification ownership does not match its member number.');
+  }
+  if (data.matchHistorySync?.cachedFor !== undefined && data.matchHistorySync.cachedFor !== expectedOwner) {
+    throw new Error('Backup history-sync ownership does not match its member number.');
+  }
+  if (data.classificationData?.classifiers !== undefined &&
+      (!Array.isArray(data.classificationData.classifiers) ||
+        data.classificationData.classifiers.some(classifier => !isRecord(classifier) ||
+          (classifier.date !== undefined && classifier.date !== null && typeof classifier.date !== 'string') ||
+          (classifier.code !== undefined && classifier.code !== null && typeof classifier.code !== 'string') ||
+          (classifier.pct !== undefined && classifier.pct !== null && !Number.isFinite(classifier.pct)) ||
+          (classifier.hf !== undefined && classifier.hf !== null && !Number.isFinite(classifier.hf))))) {
+    throw new Error('Backup classification records are invalid.');
+  }
+  if (data.classificationData?.divisions !== undefined && !isRecord(data.classificationData.divisions)) {
+    throw new Error('Backup classification divisions are invalid.');
+  }
+  if (Object.values(data.classificationData?.divisions || {}).some(division => !isRecord(division) ||
+      (division.class_ !== undefined && division.class_ !== null && typeof division.class_ !== 'string') ||
+      (division.pct !== undefined && division.pct !== null && !Number.isFinite(division.pct)))) {
+    throw new Error('Backup classification division values are invalid.');
+  }
+  const objectKeys = ['stageOverrides', 'matchTypeOverrides', 'storageMetadata'];
+  const nullableObjectKeys = ['fetchCoverage', 'classificationData', 'matchHistorySync'];
+  if (objectKeys.some(key => typeof data[key] !== 'undefined' && !isRecord(data[key])) ||
+      nullableObjectKeys.some(key => data[key] !== null && typeof data[key] !== 'undefined' && !isRecord(data[key]))) {
+    throw new Error('Backup contains invalid structured preferences.');
+  }
+  if (Object.values(data.stageOverrides || {}).some(matchOverrides => !isRecord(matchOverrides) ||
+      Object.values(matchOverrides).some(override => !isRecord(override)))) {
+    throw new Error('Backup stage overrides are invalid.');
+  }
+  if (Object.values(data.matchTypeOverrides || {}).some(matchType => typeof matchType !== 'string')) {
+    throw new Error('Backup match type overrides are invalid.');
+  }
+  if (data.deselectedMatches && (!Array.isArray(data.deselectedMatches) || data.deselectedMatches.some(id => typeof id !== 'string'))) {
+    throw new Error('Backup match selections are invalid.');
+  }
+  if (typeof data.last8Matches !== 'undefined' && typeof data.last8Matches !== 'boolean') {
+    throw new Error('Backup Last 8 preference is invalid.');
+  }
+  if (typeof data.selectedDivision !== 'undefined' && data.selectedDivision !== null &&
+      !['co', 'lo', 'opn', 'prod', 'ltd', 'l10', 'pcc', 'rev', 'ss'].includes(data.selectedDivision)) {
+    throw new Error('Backup division preference is invalid.');
+  }
+  if (typeof data.fetchTimeline !== 'undefined' && !Object.hasOwn(FETCH_TIMELINES, data.fetchTimeline)) {
+    throw new Error('Backup fetch timeline is invalid.');
+  }
+  if (typeof data.theme !== 'undefined' && !['light', 'dark'].includes(data.theme)) {
+    throw new Error('Backup theme preference is invalid.');
+  }
+  const expectedIdentity = ownerIdentity(data.memberNumber, data.name);
+  if (!isRecord(backup.owner) || normalizedOwner(backup.owner.memberNumber) !== expectedOwner ||
+      String(backup.owner.name || '') !== String(data.name || '')) {
+    throw new Error('Backup owner metadata does not match its data.');
+  }
+  return { data, byteLength, expectedOwner, expectedIdentity };
+}
+
+async function createBackup() {
+  await storageMigrationPromise;
+  const data = await chrome.storage.local.get(BACKUP_KEYS);
+  const backup = {
+    format: 'hit-factor-charts-backup',
+    version: BACKUP_FORMAT_VERSION,
+    exportedAt: new Date().toISOString(),
+    extensionVersion: chrome.runtime.getManifest().version,
+    owner: { memberNumber: normalizedOwner(data.memberNumber), name: String(data.name || '') },
+    data,
+  };
+  validateBackupData(backup);
+  return backup;
+}
+
+async function importBackup(backup, { replaceExistingOwner = false } = {}) {
+  await storageMigrationPromise;
+  const validated = validateBackupData(backup);
+  const current = await chrome.storage.local.get(['memberNumber', 'name', 'lastMatchList', 'matchCache']);
+  const currentIdentity = ownerIdentity(current.memberNumber, current.name);
+  const hasCurrentHistory = (Array.isArray(current.lastMatchList) && current.lastMatchList.length > 0) ||
+    (isRecord(current.matchCache) && Object.keys(current.matchCache).length > 0);
+  if (hasCurrentHistory && currentIdentity !== validated.expectedIdentity && !replaceExistingOwner) {
+    const error = new Error('This backup belongs to a different member. Confirm replacement to continue.');
+    error.code = 'OWNER_CONFLICT';
+    throw error;
+  }
+
+  const previousManagedData = await chrome.storage.local.get(BACKUP_KEYS);
+  const omittedKeys = BACKUP_KEYS.filter(key => !Object.hasOwn(validated.data, key));
+  try {
+    await chrome.storage.local.set(validated.data);
+    if (omittedKeys.length) await chrome.storage.local.remove(omittedKeys);
+    await migrateStorage();
+  } catch (error) {
+    try {
+      await chrome.storage.local.set(previousManagedData);
+      const previouslyAbsentKeys = BACKUP_KEYS.filter(key => !Object.hasOwn(previousManagedData, key));
+      if (previouslyAbsentKeys.length) await chrome.storage.local.remove(previouslyAbsentKeys);
+    } catch (rollbackError) {
+      throw new Error(`Restore failed and local rollback could not complete: ${rollbackError.message}`);
+    }
+    throw error;
+  }
+  return {
+    importedKeys: Object.keys(validated.data).length,
+    matches: validated.data.lastMatchList?.length || 0,
+    cacheEntries: Object.keys(validated.data.matchCache || {}).length,
+    byteLength: validated.byteLength,
+  };
+}
+
 async function getCache() {
   const d = await chrome.storage.local.get('matchCache');
   return d.matchCache || {};
@@ -198,6 +466,70 @@ function mergeMatchLists(existing, incoming, { preserveMissing = true } = {}) {
     }
   }
   return merged;
+}
+
+function normalizeHistorySync(value, memberNumber) {
+  if (!isRecord(value) || value.schemaVersion !== HISTORY_SYNC_SCHEMA_VERSION) return null;
+  if (value.cachedFor !== normalizedOwner(memberNumber)) return null;
+  const highWaterDate = normalizeDateOnly(value.highWaterDate);
+  if (!highWaterDate || !Array.isArray(value.highWaterIds) || value.highWaterIds.length === 0 ||
+      value.highWaterIds.some(id => typeof id !== 'string') ||
+      !Array.isArray(value.knownIds) || value.knownIds.length === 0 || value.knownIds.length > 10000 ||
+      value.knownIds.some(id => typeof id !== 'string')) return null;
+  const lastFullScanAt = Number(value.lastFullScanAt);
+  const runsSinceFullScan = Number(value.runsSinceFullScan);
+  if (!Number.isFinite(lastFullScanAt) || lastFullScanAt <= 0 ||
+      !Number.isInteger(runsSinceFullScan) || runsSinceFullScan < 0) return null;
+  return {
+    schemaVersion: HISTORY_SYNC_SCHEMA_VERSION,
+    cachedFor: value.cachedFor,
+    highWaterDate,
+    highWaterIds: [...new Set(value.highWaterIds)],
+    knownIds: [...new Set(value.knownIds)],
+    lastFullScanAt,
+    lastSuccessfulScanAt: Number(value.lastSuccessfulScanAt) || lastFullScanAt,
+    runsSinceFullScan,
+  };
+}
+
+function buildHistorySync(matchList, discoveredMatches, memberNumber, previous, { fullScan }) {
+  const datedMatches = [...(matchList || []), ...(discoveredMatches || [])]
+    .map(match => ({ id: match?.match_id, date: normalizeDateOnly(match?.date) }))
+    .filter(match => match.id && match.date);
+  if (!datedMatches.length) return null;
+  const highWaterDate = datedMatches.reduce((latest, match) => match.date > latest ? match.date : latest, datedMatches[0].date);
+  const knownIds = fullScan
+    ? [...new Set((discoveredMatches || []).map(match => match?.match_id).filter(Boolean))]
+    : [...new Set([...(previous.knownIds || []), ...(discoveredMatches || []).map(match => match?.match_id).filter(Boolean)])];
+  const now = Date.now();
+  return {
+    schemaVersion: HISTORY_SYNC_SCHEMA_VERSION,
+    cachedFor: normalizedOwner(memberNumber),
+    highWaterDate,
+    highWaterIds: [...new Set(datedMatches.filter(match => match.date === highWaterDate).map(match => match.id))],
+    knownIds,
+    lastFullScanAt: fullScan ? now : previous.lastFullScanAt,
+    lastSuccessfulScanAt: now,
+    runsSinceFullScan: fullScan ? 0 : previous.runsSinceFullScan + 1,
+  };
+}
+
+function resolveHistoryDiscovery(previousMatchList, storedSync, memberNumber, forceFull = false, now = Date.now()) {
+  const sync = normalizeHistorySync(storedSync, memberNumber);
+  const knownIds = new Set([
+    ...(previousMatchList || []).map(match => match?.match_id).filter(Boolean),
+    ...(sync?.knownIds || []),
+  ]);
+  if (forceFull) return { mode: 'full', reason: 'explicit full history reconciliation', knownIds, sync: null, fallback: false };
+  if (!sync || knownIds.size === 0) {
+    return { mode: 'full', reason: 'missing or invalid sync metadata', knownIds, sync: null, fallback: true };
+  }
+  const periodicFullScanDue = now - sync.lastFullScanAt >= FULL_HISTORY_SCAN_INTERVAL_MS ||
+    sync.runsSinceFullScan >= FULL_HISTORY_SCAN_RUN_INTERVAL;
+  if (periodicFullScanDue) {
+    return { mode: 'full', reason: 'periodic backfill reconciliation due', knownIds, sync, fallback: true };
+  }
+  return { mode: 'incremental', reason: 'verified sync metadata available', knownIds, sync, fallback: false };
 }
 
 // ── Match type detection ──────────────────────────────────────────────────────
@@ -1203,13 +1535,17 @@ async function fetchUSPSAClassification(memberNumber, push) {
 }
 
 // ── Fetch all match scores ────────────────────────────────────────────────────
-async function fetchScores(memberNumber, name, requestedTimeline) {
+async function fetchScores(memberNumber, name, requestedTimeline, { fullHistory = false } = {}) {
   const log = [];
   const push = m => { log.push(m); console.log('[HFC]', m); };
   let tabId = null;
   const fetchScope = resolveFetchTimeline(requestedTimeline);
 
   try {
+    const migration = await storageMigrationPromise;
+    if (migration?.migrated) {
+      push(`Preserved ${migration.cacheEntriesMigrated} compatible cache record(s) during storage migration ${migration.from} → ${migration.to}.`);
+    }
     const bounds = fetchScope.value === 'all' ? '' : ` (${fetchScope.start} through ${fetchScope.end})`;
     push(`Loading match history — fetch timeline: ${fetchScope.label}${bounds}…`);
     const tab = await chrome.tabs.create({ url: `${PS_BASE}/associate/step2`, active: false });
@@ -1224,10 +1560,15 @@ async function fetchScores(memberNumber, name, requestedTimeline) {
       return { results: [], log, _not_logged_in_ps: true };
     }
 
-    const history = await collectMatchHistory(tabId, push);
+    const stored = await chrome.storage.local.get(['lastMatchList', 'matchCache', 'matchTypeOverrides', 'fetchCoverage', 'matchHistorySync']);
+    const previousMatchList = Array.isArray(stored.lastMatchList) ? stored.lastMatchList : [];
+    const discovery = resolveHistoryDiscovery(previousMatchList, stored.matchHistorySync, memberNumber, fullHistory);
+    push(`History discovery: ${discovery.mode}; ${discovery.reason}.`);
+    const history = await collectMatchHistory(tabId, push, discovery);
     const rawMatchList = history.matches;
     push(`Extracted ${rawMatchList.length} match(es) across ${history.pagesRead} history page(s).`);
-    if (!history.complete) push(`Match history extraction incomplete (${history.reason}); preserving cached history and coverage.`);
+    push(`History stop: ${history.reason}.`);
+    if (!history.complete) push('Match history extraction incomplete; preserving cached history, sync metadata, and coverage.');
     console.log('[HFC] matchList:', JSON.stringify(rawMatchList, null, 2));
 
     // Annotate every match with its detected type
@@ -1250,22 +1591,24 @@ async function fetchScores(memberNumber, name, requestedTimeline) {
     if (filtered.futureDateCount) push(`Skipping ${filtered.futureDateCount} future-dated match(es).`);
     if (filtered.beforeCutoffCount) push(`Skipping ${filtered.beforeCutoffCount} match(es) before ${fetchScope.start}.`);
 
-    const stored = await chrome.storage.local.get(['lastMatchList', 'matchCache', 'matchTypeOverrides', 'fetchCoverage']);
-    const previousMatchList = stored.lastMatchList || [];
     const cache = stored.matchCache || {};
     const matchTypeOverrides = normalizeMatchTypeOverrides(stored.matchTypeOverrides);
-    const preserveMissingHistory = fetchScope.value !== 'all' || !history.complete;
-    let mergedMatchList = mergeMatchLists(previousMatchList, matchList, { preserveMissing: preserveMissingHistory });
+    const preserveMissingHistory = !history.fullScanComplete;
+    let mergedMatchList = mergeMatchLists(previousMatchList, annotatedMatchList, { preserveMissing: preserveMissingHistory });
     const hasUsableMatchDate = annotatedMatchList.some(match => {
       const date = normalizeDateOnly(match.date);
       return date && date <= localDateOnly();
     });
-    const fetchCoverage = hasUsableMatchDate && history.complete
+    const fetchCoverage = hasUsableMatchDate && history.fullScanComplete
       ? mergeFetchCoverage(stored.fetchCoverage, fetchScope)
       : normalizeFetchCoverage(stored.fetchCoverage);
+    const matchHistorySync = history.complete && (history.fullScanComplete || history.verifiedOverlap)
+      ? buildHistorySync(mergedMatchList, rawMatchList, memberNumber, discovery.sync, { fullScan: history.fullScanComplete })
+      : null;
     await chrome.storage.local.set({
       lastMatchList: mergedMatchList,
       ...(fetchCoverage ? { fetchCoverage } : {}),
+      ...(matchHistorySync ? { matchHistorySync } : {}),
     });
     const mergedById = new Map(mergedMatchList.map(match => [match.match_id, match]));
     const workMatches = matchList.map(match => mergedById.get(match.match_id) || match);
@@ -1359,7 +1702,7 @@ async function fetchScores(memberNumber, name, requestedTimeline) {
     }
 
     // Re-save the merged list with any match types confirmed from results pages.
-    mergedMatchList = mergeMatchLists(previousMatchList, workMatches, { preserveMissing: preserveMissingHistory });
+    mergedMatchList = mergeMatchLists(mergedMatchList, workMatches, { preserveMissing: true });
     await chrome.storage.local.set({ lastMatchList: mergedMatchList });
 
     const n = results.filter(r => r.overall_pct != null).length;
@@ -1401,6 +1744,12 @@ async function fetchScores(memberNumber, name, requestedTimeline) {
       fetchedStages: fetchedStageCount,
       failedStages: failedStageCount,
       historyComplete: history.complete,
+      historyPagesScanned: history.pagesRead,
+      historyMode: discovery.mode,
+      historyStopReason: history.reason,
+      fullScanFallback: discovery.fallback,
+      fullScanComplete: history.fullScanComplete,
+      discoveredNewMatches: rawMatchList.filter(match => !discovery.knownIds.has(match.match_id)).length,
     };
     return { results: combinedResults, log, classificationData, _not_logged_in_uspsa, fetchScope, fetchCoverage, fetchDiagnostics };
 
@@ -1642,9 +1991,12 @@ function clickNextMatchHistoryPage() {
   return true;
 }
 
-async function collectMatchHistory(tabId, push) {
+async function collectMatchHistory(tabId, push, discovery = { mode: 'full', knownIds: new Set(), sync: null }) {
   const matches = new Map();
   const pageSignatures = new Set();
+  let settledOverlapPages = 0;
+  let incrementalStopDisabledReason = null;
+  let previousPageOldestDate = null;
 
   for (let pageNumber = 1; pageNumber <= MAX_HISTORY_PAGES; pageNumber++) {
     let page = null;
@@ -1654,17 +2006,70 @@ async function collectMatchHistory(tabId, push) {
       await sleep(400 + attempt * 150);
     }
     if (!page?._ready || !page.signature || pageSignatures.has(page.signature)) {
-      return { matches: [...matches.values()], complete: false, pagesRead: pageSignatures.size, reason: page?._debug || 'history page did not settle' };
+      return {
+        matches: [...matches.values()], complete: false, fullScanComplete: false,
+        verifiedOverlap: false, pagesRead: pageSignatures.size,
+        reason: page?._debug || 'history page did not settle',
+      };
     }
 
     pageSignatures.add(page.signature);
     for (const match of page.matches || []) matches.set(match.match_id, match);
-    if (!page.hasNextPage) return { matches: [...matches.values()], complete: true, pagesRead: pageNumber };
+
+    if (discovery.mode === 'incremental' && !incrementalStopDisabledReason) {
+      const pageMatches = page.matches || [];
+      const pageDates = pageMatches.map(match => normalizeDateOnly(match.date));
+      if (!pageMatches.length || pageDates.some(date => !date)) {
+        incrementalStopDisabledReason = 'malformed or empty history page required full pagination';
+        settledOverlapPages = 0;
+        push('Incremental boundary disabled: malformed or empty history data; continuing with a full scan.');
+      } else {
+        const newestPageDate = pageDates.reduce((latest, date) => date > latest ? date : latest, pageDates[0]);
+        const oldestPageDate = pageDates.reduce((earliest, date) => date < earliest ? date : earliest, pageDates[0]);
+        if (previousPageOldestDate && newestPageDate > previousPageOldestDate) {
+          incrementalStopDisabledReason = 'history pages were reordered; completed full pagination';
+          settledOverlapPages = 0;
+          push('Incremental boundary disabled: history page dates were not newest-first; continuing with a full scan.');
+        }
+        previousPageOldestDate = oldestPageDate;
+        const unknownIds = pageMatches.filter(match => !discovery.knownIds.has(match.match_id));
+        const atOrBeforeHighWater = pageDates.every(date => date <= discovery.sync.highWaterDate);
+        settledOverlapPages = !incrementalStopDisabledReason && unknownIds.length === 0 && atOrBeforeHighWater
+          ? settledOverlapPages + 1
+          : 0;
+        push(`  History page ${pageNumber}: ${unknownIds.length} unknown ID(s), overlap ${settledOverlapPages}/${HISTORY_OVERLAP_PAGES}.`);
+        if (settledOverlapPages >= HISTORY_OVERLAP_PAGES) {
+          return {
+            matches: [...matches.values()], complete: true, fullScanComplete: false,
+            verifiedOverlap: true, pagesRead: pageNumber,
+            reason: `verified overlap across ${HISTORY_OVERLAP_PAGES} settled page(s)`,
+          };
+        }
+      }
+    }
+
+    if (!page.hasNextPage) {
+      return {
+        matches: [...matches.values()], complete: true, fullScanComplete: true,
+        verifiedOverlap: false, pagesRead: pageNumber,
+        reason: incrementalStopDisabledReason || 'reached end of history',
+      };
+    }
 
     const advanced = await runInTab(tabId, clickNextMatchHistoryPage);
-    if (!advanced) return { matches: [...matches.values()], complete: false, pagesRead: pageNumber, reason: 'next history page could not be selected' };
+    if (!advanced) {
+      return {
+        matches: [...matches.values()], complete: false, fullScanComplete: false,
+        verifiedOverlap: false, pagesRead: pageNumber,
+        reason: 'next history page could not be selected',
+      };
+    }
   }
 
   push(`Match history pagination exceeded ${MAX_HISTORY_PAGES} pages.`);
-  return { matches: [...matches.values()], complete: false, pagesRead: MAX_HISTORY_PAGES, reason: 'history page limit exceeded' };
+  return {
+    matches: [...matches.values()], complete: false, fullScanComplete: false,
+    verifiedOverlap: false, pagesRead: MAX_HISTORY_PAGES,
+    reason: 'history page limit exceeded',
+  };
 }

--- a/extension/dashboard-history.js
+++ b/extension/dashboard-history.js
@@ -533,6 +533,7 @@ async function deleteMatch(match) {
     deselectedMatches: [...deselectedMatches],
     stageOverrides,
   });
+  await chrome.storage.local.remove('matchHistorySync');
 
   renderAll();
   renderMatchList();

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -143,6 +143,27 @@
     #cancelBtn { background: none; color: #8a9bb0; border-color: #2a2d3a; display: none; }
     #cancelBtn:hover { color: #e0e0e0; border-color: #555; }
 
+    .recovery-controls {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 8px;
+      padding: 0 24px 14px;
+      border-bottom: 1px solid #1e2130;
+    }
+    .recovery-controls .ctrl-btn {
+      min-height: 34px;
+      padding: 7px 12px;
+      background: none;
+      border-color: #2a2d3a;
+      color: #8a9bb0;
+      font-size: 12px;
+    }
+    .recovery-controls .ctrl-btn:hover { color: #4a9eff; border-color: #4a9eff; }
+    .recovery-controls .ctrl-btn:focus-visible { outline: 2px solid #4a9eff; outline-offset: 2px; }
+    .recovery-controls .ctrl-btn:disabled { opacity: 0.5; cursor: default; }
+    .recovery-help { color: #70798a; font-size: 12px; }
+
     /* ── Status ── */
     #status {
       padding: 10px 24px;
@@ -1171,6 +1192,8 @@
       header,
       .controls { padding-left: 16px; padding-right: 16px; }
       .controls input { flex-basis: 100%; max-width: none; }
+      .recovery-controls { padding-left: 16px; padding-right: 16px; }
+      .recovery-help { flex-basis: 100%; }
       #status { padding-left: 16px; padding-right: 16px; }
       .summary-bar { padding-left: 16px; padding-right: 16px; }
       #stats { gap: 10px; }
@@ -1224,6 +1247,10 @@
     [data-theme="light"] #themeToggle { color: #4a5060; border-color: #c0c4cc; }
     [data-theme="light"] #themeToggle:hover { color: #1a1d27; border-color: #2563eb; }
     [data-theme="light"] .controls { border-bottom-color: #e0e2e8; }
+    [data-theme="light"] .recovery-controls { border-bottom-color: #e0e2e8; }
+    [data-theme="light"] .recovery-controls .ctrl-btn { color: #5a6478; border-color: #d0d4dc; }
+    [data-theme="light"] .recovery-controls .ctrl-btn:hover { color: #2563eb; border-color: #2563eb; }
+    [data-theme="light"] .recovery-help { color: #6b7280; }
     [data-theme="light"] .controls input,
     [data-theme="light"] .controls select {
       background: #ffffff;
@@ -1397,6 +1424,14 @@
   <button id="fetchBtn"  class="ctrl-btn">Fetch Scores</button>
 </div>
 
+<div class="recovery-controls" aria-label="History maintenance and recovery">
+  <button id="fullHistoryBtn" class="ctrl-btn" type="button">Full history reconciliation</button>
+  <button id="exportBackupBtn" class="ctrl-btn" type="button">Back up data</button>
+  <button id="importBackupBtn" class="ctrl-btn" type="button">Restore backup</button>
+  <input id="importBackupInput" class="visually-hidden" type="file" accept="application/json,.json" tabindex="-1" aria-hidden="true">
+  <span class="recovery-help">Back up before moving the unpacked extension to another folder.</span>
+</div>
+
 <div id="status" role="status" aria-live="polite">Enter your USPSA member number (recommended) and/or name, then click Fetch Scores.</div>
 
 <div id="onboardingCard">
@@ -1446,20 +1481,20 @@
     <div class="update-step">
       <div class="update-step-num">1</div>
       <div class="update-step-text">
-        <a class="update-download-btn" id="updateDownloadBtn" href="#" target="_blank">⬇ Download update</a>
+        <a class="update-download-btn" id="updateDownloadBtn" href="#" target="_blank">⬇ Download update</a> and click <strong>Back up data</strong> above
       </div>
     </div>
     <div class="update-step">
       <div class="update-step-num">2</div>
-      <div class="update-step-text">Unzip the downloaded file — you'll get a folder called <strong>extension</strong></div>
+      <div class="update-step-text">Unzip the download, then replace the files inside the <strong>same extension folder Chrome already has loaded</strong></div>
     </div>
     <div class="update-step">
       <div class="update-step-num">3</div>
-      <div class="update-step-text">Go to <strong>chrome://extensions</strong> → enable <strong>Developer mode</strong> (top-right toggle) → click <strong>Load unpacked</strong> → select the <strong>extension</strong> folder</div>
+      <div class="update-step-text">Go to <strong>chrome://extensions</strong> and click <strong>Reload</strong> on Hit Factor Charts. Do not remove it or load a new versioned folder.</div>
     </div>
     <div class="update-step">
       <div class="update-step-num">4</div>
-      <div class="update-step-text">Close this tab and reopen Hit Factor Charts — you're on the latest version</div>
+      <div class="update-step-text">Reopen Hit Factor Charts. If the folder or extension identity changed, use <strong>Restore backup</strong>.</div>
     </div>
   </div>
   <div class="update-notes-wrap" id="updateNotesWrap" style="display:none">

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -46,6 +46,10 @@ const nameInput    = document.getElementById('nameInput');
 const divisionFilter = document.getElementById('divisionFilter');
 const fetchTimelineSelect = document.getElementById('fetchTimeline');
 const fetchBtn     = document.getElementById('fetchBtn');
+const fullHistoryBtn = document.getElementById('fullHistoryBtn');
+const exportBackupBtn = document.getElementById('exportBackupBtn');
+const importBackupBtn = document.getElementById('importBackupBtn');
+const importBackupInput = document.getElementById('importBackupInput');
 const editBtn      = document.getElementById('editBtn');
 const saveBtn      = document.getElementById('saveBtn');
 const cancelBtn    = document.getElementById('cancelBtn');
@@ -183,12 +187,15 @@ function applyTheme(theme) {
   if (btn) btn.textContent = theme === 'light' ? '\u263E' : '\u2606'; // moon / sun
 }
 
-// Restore saved theme (check sync first, then local)
-chrome.storage.sync.get(['theme'], syncData => {
-  const theme = syncData.theme || 'light';
+// Restore saved theme (check sync first, then restored local backup)
+Promise.all([
+  chrome.storage.sync.get(['theme']),
+  chrome.storage.local.get(['theme']),
+]).then(([syncData, localData]) => {
+  const theme = syncData.theme || localData.theme || 'light';
   applyTheme(theme);
-  // Also save to local for fast restore
   chrome.storage.local.set({ theme });
+  if (!syncData.theme && localData.theme) chrome.storage.sync.set({ theme });
 });
 
 document.getElementById('themeToggle').addEventListener('click', () => {
@@ -733,7 +740,7 @@ saveBtn.addEventListener('click', async () => {
       return;
     }
     // Clear cache and reset UI
-    await chrome.storage.local.remove(['matchCache', 'lastMatchList', 'stageOverrides', 'fetchCoverage']);
+    await chrome.storage.local.remove(['matchCache', 'lastMatchList', 'stageOverrides', 'fetchCoverage', 'matchHistorySync']);
     fetchCoverage = null;
     renderDateRangeFilter();
     allResults = [];
@@ -768,7 +775,13 @@ function hideOnboarding() {
 }
 
 // ── Restore persisted state on load ──────────────────────────────────────────
-chrome.storage.local.get(['memberNumber', 'name', 'lastMatchList', 'matchCache', 'deselectedMatches', 'stageOverrides', 'classificationData', 'selectedDivision', 'fetchTimeline', 'last8Matches', 'matchTypeOverrides', 'fetchCoverage'], async d => {
+async function initializeDashboard() {
+  try {
+    await chrome.runtime.sendMessage({ action: 'initializeStorage' });
+  } catch (error) {
+    console.warn('Storage migration could not be confirmed:', error);
+  }
+  const d = await chrome.storage.local.get(['memberNumber', 'name', 'lastMatchList', 'matchCache', 'deselectedMatches', 'stageOverrides', 'classificationData', 'selectedDivision', 'fetchTimeline', 'last8Matches', 'matchTypeOverrides', 'fetchCoverage']);
   // Try restoring from sync if local has no credentials (e.g. after reinstall)
   if (!d.memberNumber && !d.name) {
     await restoreFromSync();
@@ -820,6 +833,63 @@ chrome.storage.local.get(['memberNumber', 'name', 'lastMatchList', 'matchCache',
       renderMatchList();
       updateStatusCounts('Showing cached data:');
     }
+  }
+}
+
+initializeDashboard();
+
+// ── Versioned backup and recovery ────────────────────────────────────────────
+exportBackupBtn.addEventListener('click', async () => {
+  exportBackupBtn.disabled = true;
+  try {
+    const response = await chrome.runtime.sendMessage({ action: 'exportBackup' });
+    if (!response.ok) throw new Error(response.error || 'Backup failed.');
+    const blob = new Blob([JSON.stringify(response.data, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    const date = new Date().toISOString().slice(0, 10);
+    link.href = url;
+    link.download = `hit-factor-charts-backup-${date}.json`;
+    link.click();
+    URL.revokeObjectURL(url);
+    setStatus('Backup downloaded. Keep it before changing the unpacked extension folder.', 'success');
+  } catch (error) {
+    setStatus(`Backup error: ${error.message}`, 'error');
+  } finally {
+    exportBackupBtn.disabled = false;
+  }
+});
+
+importBackupBtn.addEventListener('click', () => importBackupInput.click());
+
+importBackupInput.addEventListener('change', async () => {
+  const file = importBackupInput.files?.[0];
+  importBackupInput.value = '';
+  if (!file) return;
+  if (file.size > 8 * 1024 * 1024) {
+    setStatus('Restore error: backup exceeds the 8 MB safety limit.', 'error');
+    return;
+  }
+
+  importBackupBtn.disabled = true;
+  try {
+    const backup = JSON.parse(await file.text());
+    let response = await chrome.runtime.sendMessage({ action: 'importBackup', backup });
+    if (!response.ok && response.code === 'OWNER_CONFLICT') {
+      const replace = confirm(
+        'This backup belongs to a different member than the cached history in this extension.\n\n' +
+        'Replace the current local history with the validated backup?'
+      );
+      if (!replace) return;
+      response = await chrome.runtime.sendMessage({ action: 'importBackup', backup, replaceExistingOwner: true });
+    }
+    if (!response.ok) throw new Error(response.error || 'Restore failed.');
+    setStatus(`Restored ${response.data.matches} match(es) and ${response.data.cacheEntries} cache record(s). Reloading…`, 'success');
+    setTimeout(() => location.reload(), 500);
+  } catch (error) {
+    setStatus(`Restore error: ${error.message}`, 'error');
+  } finally {
+    importBackupBtn.disabled = false;
   }
 });
 
@@ -892,8 +962,8 @@ fetchTimelineSelect.addEventListener('change', () => {
   chrome.storage.local.set({ fetchTimeline: selectedFetchTimeline });
 });
 
-// ── Fetch button ──────────────────────────────────────────────────────────────
-fetchBtn.addEventListener('click', async () => {
+// ── Fetch controls ────────────────────────────────────────────────────────────
+async function fetchScoresFromDashboard({ fullHistory = false } = {}) {
   const memberNumber = memberInput.value.trim().toUpperCase();
   const name         = nameInput.value.trim();
   selectedDiv = normalizeDivision(divisionFilter.value);
@@ -928,7 +998,7 @@ fetchBtn.addEventListener('click', async () => {
       'Your member number or name has changed. This will clear all cached match data and re-fetch everything.\n\nContinue?'
     );
     if (!ok) return;
-    await chrome.storage.local.remove(['matchCache', 'lastMatchList', 'stageOverrides', 'fetchCoverage']);
+    await chrome.storage.local.remove(['matchCache', 'lastMatchList', 'stageOverrides', 'fetchCoverage', 'matchHistorySync']);
     fetchCoverage = null;
     renderDateRangeFilter();
     allResults = [];
@@ -940,15 +1010,16 @@ fetchBtn.addEventListener('click', async () => {
 
   chrome.storage.local.set({ memberNumber, name, fetchTimeline: selectedFetchTimeline });
   lockInputs();
-  setStatus(`Opening PractiScore tab — fetch timeline: ${fetchTimeline.label}…`, '', true);
+  setStatus(`Opening PractiScore tab — ${fullHistory ? 'full history reconciliation' : `fetch timeline: ${fetchTimeline.label}`}…`, '', true);
   fetchBtn.disabled = true;
+  fullHistoryBtn.disabled = true;
   noDataEl.style.display   = 'none';
   debugLogEl.style.display = 'none';
   allResults = [];
 
   try {
     const response = await chrome.runtime.sendMessage({
-      action: 'fetchScores', memberNumber, name, fetchTimeline,
+      action: 'fetchScores', memberNumber, name, fetchTimeline, fullHistory,
     });
     if (!response.ok) throw new Error(response.error || 'Unknown error');
     if (response.data._not_logged_in_ps) {
@@ -1002,7 +1073,17 @@ fetchBtn.addEventListener('click', async () => {
     debugLogEl.style.display = 'block';
   } finally {
     fetchBtn.disabled = false;
+    fullHistoryBtn.disabled = false;
   }
+}
+
+fetchBtn.addEventListener('click', () => fetchScoresFromDashboard());
+fullHistoryBtn.addEventListener('click', () => {
+  const proceed = confirm(
+    'Scan every PractiScore Match History page?\n\n' +
+    'This preserves cached scores and preferences, but may take longer. Use it to find older delayed or backfilled matches.'
+  );
+  if (proceed) fetchScoresFromDashboard({ fullHistory: true });
 });
 
 // ── Analytics date-range presets ──────────────────────────────────────────────
@@ -1856,7 +1937,7 @@ function updateStatusCounts(verb) {
     ? ` · Fetch ${lastFetchScope.label}: ${lastFetchScope.inRangeCount ?? '?'} in range`
     : '';
   const detailNote = lastFetchDiagnostics
-    ? ` · Matches: ${lastFetchDiagnostics.extractedMatches} extracted, ${lastFetchDiagnostics.completeCacheReused} complete cached, ${lastFetchDiagnostics.partialRepairs} partial repaired, ${lastFetchDiagnostics.unknownRepairs} legacy repaired, ${lastFetchDiagnostics.newMatches} new · Stages: ${lastFetchDiagnostics.fetchedStages}/${lastFetchDiagnostics.expectedStages} fetched, ${lastFetchDiagnostics.failedStages} failed`
+    ? ` · History: ${lastFetchDiagnostics.historyPagesScanned} page(s), ${lastFetchDiagnostics.historyMode}, ${lastFetchDiagnostics.historyStopReason}${lastFetchDiagnostics.fullScanFallback ? ' (full-scan fallback)' : ''} · Matches: ${lastFetchDiagnostics.extractedMatches} extracted, ${lastFetchDiagnostics.discoveredNewMatches} newly discovered, ${lastFetchDiagnostics.completeCacheReused} complete cached, ${lastFetchDiagnostics.partialRepairs} partial repaired, ${lastFetchDiagnostics.unknownRepairs} legacy repaired, ${lastFetchDiagnostics.newMatches} detail fetches · Stages: ${lastFetchDiagnostics.fetchedStages}/${lastFetchDiagnostics.expectedStages} fetched, ${lastFetchDiagnostics.failedStages} failed`
     : '';
   setStatus(`${prefix}${divisionNote} ${uspsa} USPSA match(es) — ${scored} with scores${checkedNote}.${unconfirmedNote}${skippedNote}${fetchNote}${detailNote}`, 'success');
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hit Factor Charts",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Track your USPSA match performance: division %, adjusted field-strength scores, classifier trends, and placement over time.",
   "permissions": ["tabs", "scripting", "storage"],
   "host_permissions": ["https://practiscore.com/*", "https://s3.amazonaws.com/*", "https://api.github.com/*", "https://uspsa.org/*", "https://objects.githubusercontent.com/*"],

--- a/tests/background-storage.test.js
+++ b/tests/background-storage.test.js
@@ -1,0 +1,361 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const backgroundSource = fs.readFileSync(path.join(__dirname, '..', 'extension', 'background.js'), 'utf8');
+
+function storageArea(initial = {}) {
+  const data = structuredClone(initial);
+  return {
+    data,
+    failNextSet: false,
+    async get(keys) {
+      if (keys == null) return structuredClone(data);
+      const selected = {};
+      for (const key of Array.isArray(keys) ? keys : [keys]) {
+        if (Object.hasOwn(data, key)) selected[key] = structuredClone(data[key]);
+      }
+      return selected;
+    },
+    async set(values) {
+      if (this.failNextSet) {
+        this.failNextSet = false;
+        throw new Error('simulated storage failure');
+      }
+      Object.assign(data, structuredClone(values));
+    },
+    async remove(keys) {
+      for (const key of Array.isArray(keys) ? keys : [keys]) delete data[key];
+    },
+  };
+}
+
+async function loadBackground(initialStorage = {}) {
+  const local = storageArea(initialStorage);
+  const noopEvent = { addListener() {}, removeListener() {} };
+  const context = vm.createContext({
+    chrome: {
+      action: { onClicked: noopEvent },
+      runtime: {
+        getManifest: () => ({ version: 'test' }),
+        getURL: value => value,
+        onMessage: noopEvent,
+      },
+      scripting: { executeScript: async () => [{ result: null }] },
+      storage: { local },
+      tabs: {
+        create: async () => ({ id: 1 }),
+        get: async () => ({ url: 'https://practiscore.com/associate/step2' }),
+        onUpdated: noopEvent,
+        remove: async () => {},
+      },
+    },
+    console,
+    Date,
+    Map,
+    Object,
+    Promise,
+    Set,
+    TextEncoder,
+    clearTimeout,
+    setTimeout,
+    structuredClone,
+  });
+  vm.runInContext(`${backgroundSource}\n;globalThis.__hfcTest = {
+    storageMigrationPromise, resolveHistoryDiscovery, collectMatchHistory,
+    normalizeHistorySync, createBackup, importBackup, fetchScores
+  };`, context);
+  await context.__hfcTest.storageMigrationPromise;
+  return { context, local, api: context.__hfcTest };
+}
+
+const firstId = '11111111-1111-4111-8111-111111111111';
+const secondId = '22222222-2222-4222-8222-222222222222';
+const thirdId = '33333333-3333-4333-8333-333333333333';
+const delayedId = '44444444-4444-4444-8444-444444444444';
+
+function completeCache(schemaVersion = 1) {
+  return {
+    cached_for: 'A103',
+    stages: [{ num: 1, name: 'Stage 1' }],
+    cache_completeness: {
+      schema_version: schemaVersion,
+      state: 'complete',
+      expected_stage_count: 1,
+      fetched_stage_count: 1,
+      failed_stages: [],
+    },
+  };
+}
+
+function syncMetadata(overrides = {}) {
+  return {
+    schemaVersion: 1,
+    cachedFor: 'A103',
+    highWaterDate: '2026-09-07',
+    highWaterIds: [firstId],
+    knownIds: [firstId, secondId, thirdId],
+    lastFullScanAt: Date.now(),
+    lastSuccessfulScanAt: Date.now(),
+    runsSinceFullScan: 1,
+    ...overrides,
+  };
+}
+
+test('compatible complete caches migrate without losing stages or preferences', async () => {
+  const { local } = await loadBackground({
+    memberNumber: 'A103',
+    matchCache: { [firstId]: completeCache(1) },
+    stageOverrides: { [firstId]: { '01|Stage 1': { included: false } } },
+    storageMetadata: { schemaVersion: 1 },
+  });
+
+  assert.equal(local.data.storageMetadata.schemaVersion, 2);
+  assert.equal(local.data.matchCache[firstId].cache_completeness.schema_version, 2);
+  assert.deepEqual(local.data.matchCache[firstId].stages, [{ num: 1, name: 'Stage 1' }]);
+  assert.deepEqual(local.data.stageOverrides[firstId], { '01|Stage 1': { included: false } });
+});
+
+test('missing, corrupt, stale, and explicit metadata select full discovery', async () => {
+  const { api } = await loadBackground();
+  const list = [{ match_id: firstId }];
+
+  assert.equal(api.resolveHistoryDiscovery(list, null, 'A103').mode, 'full');
+  assert.equal(api.resolveHistoryDiscovery(list, syncMetadata({ cachedFor: 'B999' }), 'A103').mode, 'full');
+  assert.equal(api.resolveHistoryDiscovery(list, syncMetadata({ runsSinceFullScan: 10 }), 'A103').mode, 'full');
+  assert.equal(api.resolveHistoryDiscovery(list, syncMetadata(), 'A103', true).mode, 'full');
+  assert.equal(api.resolveHistoryDiscovery(list, syncMetadata(), 'A103').mode, 'incremental');
+});
+
+test('incremental discovery keeps same-day unknown IDs and stops after two known overlap pages', async () => {
+  const { context, api } = await loadBackground();
+  context.__pages = [
+    { signature: 'new', hasNextPage: true, _ready: true, matches: [{ match_id: delayedId, date: '2026-09-07' }] },
+    { signature: 'known-1', hasNextPage: true, _ready: true, matches: [{ match_id: firstId, date: '2026-09-07' }] },
+    { signature: 'known-2', hasNextPage: true, _ready: true, matches: [{ match_id: secondId, date: '2026-09-06' }] },
+    { signature: 'unread', hasNextPage: false, _ready: true, matches: [{ match_id: thirdId, date: '2026-09-05' }] },
+  ];
+  vm.runInContext('let __pageIndex = 0; runInTab = async (_tab, fn) => fn === extractMatchList ? __pages[Math.min(__pageIndex, __pages.length - 1)] : (++__pageIndex, true); sleep = async () => {};', context);
+  const discovery = api.resolveHistoryDiscovery(
+    [{ match_id: firstId }, { match_id: secondId }, { match_id: thirdId }],
+    syncMetadata(),
+    'A103'
+  );
+  const history = await api.collectMatchHistory(1, () => {}, discovery);
+
+  assert.equal(history.pagesRead, 3);
+  assert.equal(history.verifiedOverlap, true);
+  assert.equal(history.fullScanComplete, false);
+  assert.deepEqual([...history.matches].map(match => match.match_id), [delayedId, firstId, secondId]);
+});
+
+test('malformed dates disable incremental stopping and complete full pagination', async () => {
+  const { context, api } = await loadBackground();
+  context.__pages = [
+    { signature: 'bad-date', hasNextPage: true, _ready: true, matches: [{ match_id: firstId, date: 'unknown' }] },
+    { signature: 'last', hasNextPage: false, _ready: true, matches: [{ match_id: secondId, date: '2026-09-06' }] },
+  ];
+  vm.runInContext('let __pageIndex = 0; runInTab = async (_tab, fn) => fn === extractMatchList ? __pages[Math.min(__pageIndex, __pages.length - 1)] : (++__pageIndex, true); sleep = async () => {};', context);
+  const discovery = api.resolveHistoryDiscovery([{ match_id: firstId }, { match_id: secondId }], syncMetadata(), 'A103');
+  const history = await api.collectMatchHistory(1, () => {}, discovery);
+
+  assert.equal(history.pagesRead, 2);
+  assert.equal(history.fullScanComplete, true);
+  assert.match(history.reason, /malformed/);
+});
+
+test('an unsettled next page reports incomplete discovery without inventing completion', async () => {
+  const { context, api } = await loadBackground();
+  context.__pages = [
+    { signature: 'first', hasNextPage: true, _ready: true, matches: [{ match_id: firstId, date: '2026-09-07' }] },
+    { signature: 'first', hasNextPage: true, _ready: true, matches: [{ match_id: firstId, date: '2026-09-07' }] },
+  ];
+  vm.runInContext('let __pageIndex = 0; runInTab = async (_tab, fn) => fn === extractMatchList ? __pages[Math.min(__pageIndex, __pages.length - 1)] : (++__pageIndex, true); sleep = async () => {};', context);
+  const discovery = api.resolveHistoryDiscovery([{ match_id: firstId }], syncMetadata(), 'A103');
+  const history = await api.collectMatchHistory(1, () => {}, discovery);
+
+  assert.equal(history.complete, false);
+  assert.equal(history.fullScanComplete, false);
+  assert.equal(history.pagesRead, 1);
+  assert.deepEqual([...history.matches].map(match => match.match_id), [firstId]);
+});
+
+test('bounded full reconciliation persists all discovered IDs and authoritatively removes stale history', async () => {
+  const { context, local, api } = await loadBackground({
+    memberNumber: 'A103',
+    lastMatchList: [{ match_id: thirdId, match_name: 'Stale IDPA Match', date: '2019-01-01' }],
+  });
+  context.__history = {
+    matches: [
+      { match_id: firstId, match_name: 'Recent IDPA Match', date: '2026-09-01' },
+      { match_id: delayedId, match_name: 'Older IDPA Backfill', date: '2020-01-01' },
+    ],
+    complete: true,
+    fullScanComplete: true,
+    verifiedOverlap: false,
+    pagesRead: 4,
+    reason: 'reached end of history',
+  };
+  vm.runInContext('waitForTabLoad = async () => {}; sleep = async () => {}; collectMatchHistory = async () => __history;', context);
+
+  const response = await api.fetchScores('A103', 'Test Shooter', {
+    value: '6m', label: '6 mo', start: '2026-03-07', end: '2026-09-07',
+  }, { fullHistory: true });
+  const persistedIds = local.data.lastMatchList.map(match => match.match_id);
+
+  assert.deepEqual(persistedIds, [firstId, delayedId]);
+  assert.deepEqual([...local.data.matchHistorySync.knownIds], persistedIds);
+  assert.equal(response.fetchDiagnostics.inRangeMatches, 1);
+  assert.equal(response.fetchDiagnostics.newMatches, 0);
+  assert.equal(response.results.length, 2);
+});
+
+test('incremental reconciliation persists an out-of-range unknown ID and preserves prior history', async () => {
+  const { context, local, api } = await loadBackground({
+    memberNumber: 'A103',
+    lastMatchList: [{ match_id: secondId, match_name: 'Existing IDPA Match', date: '2025-01-01', match_type: 'IDPA' }],
+    matchHistorySync: syncMetadata({ knownIds: [secondId], highWaterDate: '2025-01-01', highWaterIds: [secondId] }),
+  });
+  context.__history = {
+    matches: [
+      { match_id: firstId, match_name: 'Recent IDPA Match', date: '2026-09-01' },
+      { match_id: delayedId, match_name: 'Older IDPA Backfill', date: '2020-01-01' },
+    ],
+    complete: true,
+    fullScanComplete: false,
+    verifiedOverlap: true,
+    pagesRead: 2,
+    reason: 'verified overlap across 2 settled page(s)',
+  };
+  vm.runInContext('waitForTabLoad = async () => {}; sleep = async () => {}; collectMatchHistory = async () => __history;', context);
+
+  await api.fetchScores('A103', 'Test Shooter', {
+    value: '6m', label: '6 mo', start: '2026-03-07', end: '2026-09-07',
+  });
+  const persistedIds = local.data.lastMatchList.map(match => match.match_id);
+
+  assert.deepEqual(persistedIds, [firstId, delayedId, secondId]);
+  assert.ok(local.data.matchHistorySync.knownIds.every(id => persistedIds.includes(id)));
+});
+
+test('backup round trip validates ownership and restores all managed history keys', async () => {
+  const source = await loadBackground({
+    memberNumber: 'A103',
+    name: 'Test Shooter',
+    matchCache: { [firstId]: completeCache(1) },
+    lastMatchList: [{ match_id: firstId, match_name: 'Test Match', date: '2026-09-07' }],
+    selectedDivision: 'co',
+    fetchTimeline: '6m',
+    last8Matches: true,
+  });
+  const backup = await source.api.createBackup();
+  const target = await loadBackground();
+  const result = await target.api.importBackup(backup);
+
+  assert.equal(result.matches, 1);
+  assert.equal(target.local.data.memberNumber, 'A103');
+  assert.equal(target.local.data.matchCache[firstId].cached_for, 'A103');
+  assert.equal(target.local.data.last8Matches, true);
+
+  backup.data.matchCache[firstId].cached_for = 'B999';
+  await assert.rejects(target.api.importBackup(backup), /ownership/);
+});
+
+test('restore rejects malformed nested cache data before changing storage', async () => {
+  const source = await loadBackground({
+    memberNumber: 'A103',
+    matchCache: { [firstId]: completeCache(1) },
+    lastMatchList: [{ match_id: firstId, match_name: 'Imported', date: '2026-09-07' }],
+  });
+  const backup = await source.api.createBackup();
+  backup.data.matchCache[firstId].stages = 'invalid';
+  const target = await loadBackground({ name: 'Untouched' });
+
+  await assert.rejects(target.api.importBackup(backup), /stage data/);
+  assert.equal(target.local.data.name, 'Untouched');
+  assert.equal(target.local.data.matchCache, undefined);
+});
+
+test('restore rejects malformed classifier and stage fields before changing storage', async () => {
+  const source = await loadBackground({
+    memberNumber: 'A103',
+    matchCache: { [firstId]: completeCache(1) },
+    lastMatchList: [{ match_id: firstId, match_name: 'Imported', date: '2026-09-07' }],
+    classificationData: { member_number: 'A103', classifiers: [], divisions: {} },
+  });
+  const backup = await source.api.createBackup();
+  const target = await loadBackground({ name: 'Untouched' });
+
+  backup.data.classificationData.classifiers = [null];
+  await assert.rejects(target.api.importBackup(backup), /classification records/);
+  backup.data.classificationData.classifiers = [];
+  backup.data.matchCache[firstId].stages[0].name = {};
+  await assert.rejects(target.api.importBackup(backup), /stage fields/);
+  backup.data.matchCache[firstId].stages[0].name = 'Stage 1';
+  backup.data.classificationData.divisions = { CarryOptics: { class_: 42, pct: '75' } };
+  await assert.rejects(target.api.importBackup(backup), /division values/);
+  assert.equal(target.local.data.name, 'Untouched');
+});
+
+test('restore requires confirmation before replacing another owner history', async () => {
+  const source = await loadBackground({
+    memberNumber: 'A103',
+    matchCache: { [firstId]: completeCache(1) },
+    lastMatchList: [{ match_id: firstId, match_name: 'Imported', date: '2026-09-07' }],
+  });
+  const backup = await source.api.createBackup();
+  const target = await loadBackground({
+    memberNumber: 'B999',
+    matchCache: { [secondId]: { ...completeCache(2), cached_for: 'B999' } },
+    lastMatchList: [{ match_id: secondId, match_name: 'Existing', date: '2026-09-01' }],
+    matchHistorySync: { cachedFor: 'B999' },
+  });
+
+  await assert.rejects(target.api.importBackup(backup), error => error.code === 'OWNER_CONFLICT');
+  await target.api.importBackup(backup, { replaceExistingOwner: true });
+  assert.equal(target.local.data.memberNumber, 'A103');
+  assert.equal(target.local.data.matchCache[secondId], undefined);
+  assert.equal(target.local.data.lastMatchList[0].match_id, firstId);
+});
+
+test('name-only restore detects owner conflicts and removes omitted managed keys', async () => {
+  const source = await loadBackground({
+    name: 'Shooter One',
+    matchCache: { [firstId]: { ...completeCache(1), cached_for: null } },
+    lastMatchList: [{ match_id: firstId, match_name: 'Imported', date: '2026-09-07' }],
+  });
+  const backup = await source.api.createBackup();
+  const target = await loadBackground({
+    name: 'Shooter Two',
+    matchCache: { [secondId]: { ...completeCache(2), cached_for: null } },
+    lastMatchList: [{ match_id: secondId, match_name: 'Existing', date: '2026-09-01' }],
+    deselectedMatches: [secondId],
+  });
+
+  await assert.rejects(target.api.importBackup(backup), error => error.code === 'OWNER_CONFLICT');
+  await target.api.importBackup(backup, { replaceExistingOwner: true });
+  assert.equal(target.local.data.name, 'Shooter One');
+  assert.equal(target.local.data.deselectedMatches, undefined);
+});
+
+test('failed restore write leaves the previous managed state unchanged', async () => {
+  const source = await loadBackground({
+    memberNumber: 'A103',
+    matchCache: { [firstId]: completeCache(1) },
+    lastMatchList: [{ match_id: firstId, match_name: 'Imported', date: '2026-09-07' }],
+  });
+  const backup = await source.api.createBackup();
+  const target = await loadBackground({
+    memberNumber: 'A103',
+    matchCache: { [secondId]: completeCache(2) },
+    lastMatchList: [{ match_id: secondId, match_name: 'Existing', date: '2026-09-01' }],
+    deselectedMatches: [secondId],
+  });
+  const before = structuredClone(target.local.data);
+  target.local.failNextSet = true;
+
+  await assert.rejects(target.api.importBackup(backup), /simulated storage failure/);
+  assert.deepEqual(target.local.data, before);
+});


### PR DESCRIPTION
## Summary

- preserve compatible cached scores, match history, preferences, and overrides through versioned storage migration
- add validated backup export and rollback-safe restore with owner-conflict protection
- make PractiScore history refresh incremental, with overlap detection and periodic or explicit full reconciliation
- persist all discovered history independently from the selected score-detail timeline, including older delayed or backfilled matches
- add recovery controls, diagnostics, documentation, and focused regression coverage

## Testing

- `node --test tests/background-storage.test.js` — 13/13 passing
- `node --check extension/background.js`
- `node --check extension/dashboard.js`
- `node --check extension/dashboard-history.js`
- `git diff --check`
- independent closeout review found no remaining actionable defects in the corrected persistence flow

## Runtime Testing

The background service-worker storage migration, backup/restore, reconciliation, and bounded-detail-fetch paths were exercised through the repository's Node VM Chrome API harness. The stable unpacked-extension directory was synchronized for final interactive Chrome smoke testing.

## Decisions

- preserve the existing unpacked-extension identity rather than introducing a manifest key
- keep complete discovered history in local storage while limiting score and stage requests to the selected timeline
- treat only completed full pagination as authoritative for removing stale history

Resolves #103

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.343 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 20h 38m and 1,308,052 tokens on this with the user in an interactive session.
