### PR TITLE
GH#110: add persistent dashboard accents

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -32,6 +32,14 @@ Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter
   unavailable data, or metric basis through colour or an icon alone.
 - Verify layout changes in both themes at approximately 375px, 1920px, and
   2560px viewport widths.
+- Theme settings separate brightness from accent. Brightness offers System,
+  Light, and Dark; System follows the operating-system preference. Accent
+  presets are Blue (compatibility default), Dark green, Bright green, and
+  Purple. Persist both compact preferences in sync storage with a local backup.
+- Use shared CSS custom properties for accent, stronger accent, focus ring, and
+  accent surface. Selected settings require text and native radio state, never
+  color alone. Every preset must preserve contrast for text, controls, badges,
+  charts, and focus rings in either brightness mode.
 
 ## Chart language and axes
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ A Chrome extension that pulls your USPSA match results from PractiScore and disp
 - **Last 8 analytics** — focus every chart, summary, classifier view, and CSV export on your eight most recent qualifying matches without re-fetching or trimming Match History
 - **Export as image** — save any match or individual stage as a PNG card (floppy-disk button on each match row)
 - **Export as CSV** — download all chart-visible data as a flat CSV (one row per stage) including CM numbers, USPSA %, HF, hit counts, adjusted %, and the selected reference division, class, HF, normalized HF, and benchmark method
-- **Light/dark theme** — defaults to light mode; toggle in the header; preference syncs across devices via Chrome storage
+- **Theme settings** — choose system, light, or dark brightness independently
+  from blue, dark green, bright green, or purple accents; preferences sync
+  across devices via Chrome storage
 - **Inter font** — bundled variable font for clean, consistent rendering at all weights
 - **Durable local caching** — history and preferences stay in browser storage;
   compatible schemas migrate in place, and a versioned backup can restore data

--- a/extension/dashboard-charts.js
+++ b/extension/dashboard-charts.js
@@ -108,6 +108,7 @@ function GRID_COLOR() { return cssVar('--grid'); }
 function AXIS_COLOR() { return cssVar('--axis'); }
 function TEXT_COLOR() { return cssVar('--chart-text'); }
 function CHART_BG()   { return cssVar('--chart-bg'); }
+function ACCENT_COLOR() { return cssVar('--accent'); }
 
 // USPSA classification bands (% thresholds)
 const CLASS_BANDS = [
@@ -538,7 +539,7 @@ function drawLineChart(canvas, points, opts = {}) {
   clearCanvas(ctx, canvas);
 
   const {
-    yLabel = '', yMin, yMax, invertY = false, color = '#4a9eff', trend = false,
+    yLabel = '', yMin, yMax, invertY = false, color = ACCENT_COLOR(), trend = false,
     showPercentageReferenceGuides = false,
   } = opts;
 

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -80,7 +80,45 @@
       margin-left: auto;
       flex-shrink: 0;
     }
-    #themeToggle:hover { color: #ccc; border-color: #4a9eff; }
+    #themeToggle:hover { color: #ccc; border-color: var(--accent); }
+    #themeToggle:focus-visible,
+    .theme-settings input:focus-visible + label {
+      outline: 2px solid var(--focus-ring);
+      outline-offset: 2px;
+    }
+    .theme-settings {
+      position: absolute;
+      right: 24px;
+      top: 64px;
+      z-index: 2;
+      width: min(320px, calc(100vw - 32px));
+      padding: 14px;
+      border: 1px solid var(--accent);
+      border-radius: 8px;
+      background: var(--menu-bg);
+      color: var(--menu-text);
+      box-shadow: 0 6px 20px rgba(0,0,0,0.25);
+    }
+    .theme-settings[hidden] { display: none; }
+    .theme-settings fieldset { border: 0; margin: 0 0 12px; padding: 0; }
+    .theme-settings legend { font-weight: 700; margin-bottom: 6px; }
+    .theme-options { display: grid; grid-template-columns: repeat(3, 1fr); gap: 6px; }
+    .theme-options--accents { grid-template-columns: repeat(2, 1fr); }
+    .theme-settings input { position: absolute; opacity: 0; }
+    .theme-settings label {
+      display: block;
+      border: 1px solid var(--menu-border);
+      border-radius: 5px;
+      cursor: pointer;
+      padding: 7px 8px;
+      text-align: center;
+    }
+    .theme-settings input:checked + label {
+      background: var(--accent-soft);
+      border-color: var(--accent);
+      color: var(--accent-strong);
+      font-weight: 700;
+    }
 
     /* ── Controls ── */
     .controls {
@@ -1243,7 +1281,17 @@
       --grid:       #1e2130;
       --axis:       #2a2d3a;
       --chart-text: #8a9bb0;
+      --accent: #4a9eff;
+      --accent-strong: #8cc4ff;
+      --accent-soft: #213a5e;
+      --focus-ring: #8cc4ff;
+      --menu-bg: #1a1d27;
+      --menu-text: #e0e0e0;
+      --menu-border: #4a5060;
     }
+    [data-accent="dark-green"] { --accent: #2eaf65; --accent-strong: #77d79b; --accent-soft: #163d27; --focus-ring: #9be6b6; }
+    [data-accent="bright-green"] { --accent: #4caf50; --accent-strong: #a5e7a8; --accent-soft: #1d4720; --focus-ring: #b8f0ba; }
+    [data-accent="purple"] { --accent: #9b59d0; --accent-strong: #d7a9f3; --accent-soft: #40235a; --focus-ring: #e5c2fa; }
 
     /* ── Light theme overrides ── */
     [data-theme="light"] {
@@ -1251,6 +1299,9 @@
       --grid:       #e0e2e8;
       --axis:       #c8ccd8;
       --chart-text: #5a6478;
+      --menu-bg: #ffffff;
+      --menu-text: #2c3040;
+      --menu-border: #c0c4cc;
     }
     [data-theme="light"],
     [data-theme="light"] body {
@@ -1260,22 +1311,22 @@
     [data-theme="light"] .page { background: #f5f6f8; }
      [data-theme="light"] header {
        background: #ffffff;
-       border-bottom-color: #2563eb;
+      border-bottom-color: var(--accent);
      }
     [data-theme="light"] header h1 { color: #1a1d27; }
     [data-theme="light"] #headerVersion {
       background: #e8f1ff;
-      border-color: #2563eb;
+      border-color: var(--accent);
       color: #174ea6;
     }
     [data-theme="light"] #headerVersion:hover,
     [data-theme="light"] #headerVersion:focus-visible {
       background: #dbeafe;
       color: #123b82;
-      outline-color: #2563eb;
+      outline-color: var(--focus-ring);
     }
     [data-theme="light"] #themeToggle { color: #4a5060; border-color: #c0c4cc; }
-    [data-theme="light"] #themeToggle:hover { color: #1a1d27; border-color: #2563eb; }
+    [data-theme="light"] #themeToggle:hover { color: #1a1d27; border-color: var(--accent); }
     [data-theme="light"] .controls { border-bottom-color: #e0e2e8; }
     [data-theme="light"] .recovery-controls { border-bottom-color: #e0e2e8; }
     [data-theme="light"] .recovery-controls .ctrl-btn { color: #5a6478; border-color: #d0d4dc; }
@@ -1424,7 +1475,26 @@
 <header>
   <h1>Hit Factor Charts</h1>
   <a id="headerVersion" href="https://github.com/johnwaldo/hitfactorcharts/releases" target="_blank" rel="noopener noreferrer"></a>
-  <button id="themeToggle" title="Toggle light/dark mode">&#9788;</button>
+  <button id="themeToggle" type="button" aria-expanded="false" aria-controls="themeSettings" title="Theme settings">Theme</button>
+  <div id="themeSettings" class="theme-settings" hidden>
+    <fieldset>
+      <legend>Brightness</legend>
+      <div class="theme-options">
+        <input id="themeSystem" name="themeMode" type="radio" value="system" checked><label for="themeSystem">System</label>
+        <input id="themeLight" name="themeMode" type="radio" value="light"><label for="themeLight">Light</label>
+        <input id="themeDark" name="themeMode" type="radio" value="dark"><label for="themeDark">Dark</label>
+      </div>
+    </fieldset>
+    <fieldset>
+      <legend>Accent</legend>
+      <div class="theme-options theme-options--accents">
+        <input id="accentBlue" name="accent" type="radio" value="blue" checked><label for="accentBlue">Blue</label>
+        <input id="accentDarkGreen" name="accent" type="radio" value="dark-green"><label for="accentDarkGreen">Dark green</label>
+        <input id="accentBrightGreen" name="accent" type="radio" value="bright-green"><label for="accentBrightGreen">Bright green</label>
+        <input id="accentPurple" name="accent" type="radio" value="purple"><label for="accentPurple">Purple</label>
+      </div>
+    </fieldset>
+  </div>
 </header>
 
 <div class="controls">

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -191,15 +191,13 @@ const selectedThemeMode = () => document.querySelector('input[name="themeMode"]:
   selectedAccent = () => document.querySelector('input[name="accent"]:checked').value;
 function applyThemeSettings(mode, accent) {
   document.documentElement.setAttribute('data-theme', mode === 'system' ? (systemTheme.matches ? 'dark' : 'light') : mode); document.documentElement.setAttribute('data-accent', accent);
-  document.querySelector(`input[name="themeMode"][value="${mode}"]`).checked = true;
-  document.querySelector(`input[name="accent"][value="${accent}"]`).checked = true; renderAll();
+  document.querySelector(`input[name="themeMode"][value="${mode}"]`).checked = true; document.querySelector(`input[name="accent"][value="${accent}"]`).checked = true; renderAll();
 }
 function persistThemeSettings(mode, accent) {
   const values = { theme: mode, themeMode: mode, accent }; chrome.storage.local.set(values); chrome.storage.sync.set(values);
 }
 Promise.all([chrome.storage.sync.get(['themeMode', 'theme', 'accent']), chrome.storage.local.get(['themeMode', 'theme', 'accent'])]).then(([syncData, localData]) => {
-  const mode = [syncData.themeMode, syncData.theme, localData.themeMode, localData.theme].find(value => validThemeModes.has(value)) || 'system';
-  const accent = [syncData.accent, localData.accent].find(value => validAccents.has(value)) || 'blue';
+  const mode = [syncData.themeMode, syncData.theme, localData.themeMode, localData.theme].find(value => validThemeModes.has(value)) || 'system', accent = [syncData.accent, localData.accent].find(value => validAccents.has(value)) || 'blue';
   applyThemeSettings(mode, accent); persistThemeSettings(mode, accent);
 });
 themeToggle.addEventListener('click', () => {

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -183,32 +183,64 @@ function showUpdateBanner(latestVersion, zipUrl, releasePageUrl, releaseNotes) {
 
 checkForUpdate();
 
-// ── Theme toggle ──────────────────────────────────────────────────────────────
-function applyTheme(theme) {
-  document.documentElement.setAttribute('data-theme', theme);
-  const btn = document.getElementById('themeToggle');
-  if (btn) btn.textContent = theme === 'light' ? '\u263E' : '\u2606'; // moon / sun
+// ── Theme settings ────────────────────────────────────────────────────────────
+const systemTheme = window.matchMedia('(prefers-color-scheme: dark)');
+const themeToggle = document.getElementById('themeToggle');
+const themeSettings = document.getElementById('themeSettings');
+const validThemeModes = new Set(['system', 'light', 'dark']);
+const validAccents = new Set(['blue', 'dark-green', 'bright-green', 'purple']);
+
+function resolvedTheme(mode) {
+  return mode === 'system' ? (systemTheme.matches ? 'dark' : 'light') : mode;
 }
 
-// Restore saved theme (check sync first, then restored local backup)
+function applyThemeSettings(mode, accent) {
+  document.documentElement.setAttribute('data-theme', resolvedTheme(mode));
+  document.documentElement.setAttribute('data-accent', accent);
+  document.querySelector(`input[name="themeMode"][value="${mode}"]`).checked = true;
+  document.querySelector(`input[name="accent"][value="${accent}"]`).checked = true;
+  renderAll();
+}
+
+function persistThemeSettings(mode, accent) {
+  const values = { theme: mode, themeMode: mode, accent };
+  chrome.storage.local.set(values);
+  chrome.storage.sync.set(values);
+}
+
 Promise.all([
-  chrome.storage.sync.get(['theme']),
-  chrome.storage.local.get(['theme']),
+  chrome.storage.sync.get(['themeMode', 'theme', 'accent']),
+  chrome.storage.local.get(['themeMode', 'theme', 'accent']),
 ]).then(([syncData, localData]) => {
-  const theme = syncData.theme || localData.theme || 'light';
-  applyTheme(theme);
-  chrome.storage.local.set({ theme });
-  if (!syncData.theme && localData.theme) chrome.storage.sync.set({ theme });
+  // Legacy light/dark `theme` values are the selected brightness mode.
+  const mode = [syncData.themeMode, syncData.theme, localData.themeMode, localData.theme]
+    .find(value => validThemeModes.has(value)) || 'system';
+  const accent = [syncData.accent, localData.accent].find(value => validAccents.has(value)) || 'blue';
+  applyThemeSettings(mode, accent);
+  persistThemeSettings(mode, accent);
 });
 
-document.getElementById('themeToggle').addEventListener('click', () => {
-  const current = document.documentElement.getAttribute('data-theme') || 'light';
-  const next = current === 'dark' ? 'light' : 'dark';
-  applyTheme(next);
-  chrome.storage.local.set({ theme: next });
-  chrome.storage.sync.set({ theme: next });
-  // Redraw charts with new theme colors
-  renderAll();
+themeToggle.addEventListener('click', () => {
+  const open = themeSettings.hidden;
+  themeSettings.hidden = !open;
+  themeToggle.setAttribute('aria-expanded', String(open));
+  if (open) themeSettings.querySelector('input:checked').focus();
+});
+
+document.querySelectorAll('input[name="themeMode"], input[name="accent"]').forEach(input => {
+  input.addEventListener('change', () => {
+    const mode = document.querySelector('input[name="themeMode"]:checked').value;
+    const accent = document.querySelector('input[name="accent"]:checked').value;
+    applyThemeSettings(mode, accent);
+    persistThemeSettings(mode, accent);
+  });
+});
+
+systemTheme.addEventListener('change', () => {
+  const mode = document.querySelector('input[name="themeMode"]:checked').value;
+  if (mode === 'system') {
+    applyThemeSettings(mode, document.querySelector('input[name="accent"]:checked').value);
+  }
 });
 
 // ── Credential sync backup ────────────────────────────────────────────────────

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -183,8 +183,7 @@ function showUpdateBanner(latestVersion, zipUrl, releasePageUrl, releaseNotes) {
 
 checkForUpdate();
 
-const systemTheme = window.matchMedia('(prefers-color-scheme: dark)');
-const themeToggle = document.getElementById('themeToggle'), themeSettings = document.getElementById('themeSettings');
+const systemTheme = window.matchMedia('(prefers-color-scheme: dark)'), themeToggle = document.getElementById('themeToggle'), themeSettings = document.getElementById('themeSettings');
 const validThemeModes = new Set(['system', 'light', 'dark']),
   validAccents = new Set(['blue', 'dark-green', 'bright-green', 'purple']);
 const selectedThemeMode = () => document.querySelector('input[name="themeMode"]:checked').value,
@@ -195,8 +194,7 @@ function applyThemeSettings(mode, accent) {
 }
 function persistThemeSettings(mode, accent) {
   const values = { theme: mode, themeMode: mode, accent }; chrome.storage.local.set(values); chrome.storage.sync.set(values);
-}
-Promise.all([chrome.storage.sync.get(['themeMode', 'theme', 'accent']), chrome.storage.local.get(['themeMode', 'theme', 'accent'])]).then(([syncData, localData]) => {
+} Promise.all([chrome.storage.sync.get(['themeMode', 'theme', 'accent']), chrome.storage.local.get(['themeMode', 'theme', 'accent'])]).then(([syncData, localData]) => {
   const mode = [syncData.themeMode, syncData.theme, localData.themeMode, localData.theme].find(value => validThemeModes.has(value)) || 'system', accent = [syncData.accent, localData.accent].find(value => validAccents.has(value)) || 'blue';
   applyThemeSettings(mode, accent); persistThemeSettings(mode, accent);
 });

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -183,64 +183,36 @@ function showUpdateBanner(latestVersion, zipUrl, releasePageUrl, releaseNotes) {
 
 checkForUpdate();
 
-// ── Theme settings ────────────────────────────────────────────────────────────
 const systemTheme = window.matchMedia('(prefers-color-scheme: dark)');
-const themeToggle = document.getElementById('themeToggle');
-const themeSettings = document.getElementById('themeSettings');
-const validThemeModes = new Set(['system', 'light', 'dark']);
-const validAccents = new Set(['blue', 'dark-green', 'bright-green', 'purple']);
-
-function resolvedTheme(mode) {
-  return mode === 'system' ? (systemTheme.matches ? 'dark' : 'light') : mode;
-}
-
+const themeToggle = document.getElementById('themeToggle'), themeSettings = document.getElementById('themeSettings');
+const validThemeModes = new Set(['system', 'light', 'dark']),
+  validAccents = new Set(['blue', 'dark-green', 'bright-green', 'purple']);
+const selectedThemeMode = () => document.querySelector('input[name="themeMode"]:checked').value,
+  selectedAccent = () => document.querySelector('input[name="accent"]:checked').value;
 function applyThemeSettings(mode, accent) {
-  document.documentElement.setAttribute('data-theme', resolvedTheme(mode));
-  document.documentElement.setAttribute('data-accent', accent);
+  document.documentElement.setAttribute('data-theme', mode === 'system' ? (systemTheme.matches ? 'dark' : 'light') : mode); document.documentElement.setAttribute('data-accent', accent);
   document.querySelector(`input[name="themeMode"][value="${mode}"]`).checked = true;
-  document.querySelector(`input[name="accent"][value="${accent}"]`).checked = true;
-  renderAll();
+  document.querySelector(`input[name="accent"][value="${accent}"]`).checked = true; renderAll();
 }
-
 function persistThemeSettings(mode, accent) {
-  const values = { theme: mode, themeMode: mode, accent };
-  chrome.storage.local.set(values);
-  chrome.storage.sync.set(values);
+  const values = { theme: mode, themeMode: mode, accent }; chrome.storage.local.set(values); chrome.storage.sync.set(values);
 }
-
-Promise.all([
-  chrome.storage.sync.get(['themeMode', 'theme', 'accent']),
-  chrome.storage.local.get(['themeMode', 'theme', 'accent']),
-]).then(([syncData, localData]) => {
-  // Legacy light/dark `theme` values are the selected brightness mode.
-  const mode = [syncData.themeMode, syncData.theme, localData.themeMode, localData.theme]
-    .find(value => validThemeModes.has(value)) || 'system';
+Promise.all([chrome.storage.sync.get(['themeMode', 'theme', 'accent']), chrome.storage.local.get(['themeMode', 'theme', 'accent'])]).then(([syncData, localData]) => {
+  const mode = [syncData.themeMode, syncData.theme, localData.themeMode, localData.theme].find(value => validThemeModes.has(value)) || 'system';
   const accent = [syncData.accent, localData.accent].find(value => validAccents.has(value)) || 'blue';
-  applyThemeSettings(mode, accent);
-  persistThemeSettings(mode, accent);
+  applyThemeSettings(mode, accent); persistThemeSettings(mode, accent);
 });
-
 themeToggle.addEventListener('click', () => {
   const open = themeSettings.hidden;
-  themeSettings.hidden = !open;
-  themeToggle.setAttribute('aria-expanded', String(open));
+  themeSettings.hidden = !open; themeToggle.setAttribute('aria-expanded', String(open));
   if (open) themeSettings.querySelector('input:checked').focus();
 });
-
-document.querySelectorAll('input[name="themeMode"], input[name="accent"]').forEach(input => {
-  input.addEventListener('change', () => {
-    const mode = document.querySelector('input[name="themeMode"]:checked').value;
-    const accent = document.querySelector('input[name="accent"]:checked').value;
-    applyThemeSettings(mode, accent);
-    persistThemeSettings(mode, accent);
-  });
-});
-
+document.querySelectorAll('input[name="themeMode"], input[name="accent"]').forEach(input => input.addEventListener('change', () => {
+  const mode = selectedThemeMode(), accent = selectedAccent();
+  applyThemeSettings(mode, accent); persistThemeSettings(mode, accent);
+}));
 systemTheme.addEventListener('change', () => {
-  const mode = document.querySelector('input[name="themeMode"]:checked').value;
-  if (mode === 'system') {
-    applyThemeSettings(mode, document.querySelector('input[name="accent"]:checked').value);
-  }
+  if (selectedThemeMode() === 'system') applyThemeSettings('system', selectedAccent());
 });
 
 // ── Credential sync backup ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds an accessible dashboard theme menu with independent system/light/dark brightness and persistent blue, dark green, bright green, and purple accents. Charts read the shared accent token and redraw when settings change.

## Verification

- `node --check extension/dashboard.js`
- `node --check extension/dashboard-charts.js`
- `node --test tests/background-storage.test.js tests/dashboard-summaries.test.js tests/time-percentage.test.js`
- `git diff --check`

Resolves #110

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.346 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra
