### PR TITLE
GH#109: feat: report accuracy as percentages

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -51,7 +51,7 @@ Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter
   paired with that match score, requires at least three varying pairs,
   displays `n`, and is described only as an association. Prefer official
   `clf_pct`; label any match-relative fallback and never infer a class from it.
-- Accuracy count tiles compare the last three matches with the prior baseline.
+- Accuracy share tiles compare the last three matches with the prior baseline.
   Higher A is positive; lower B/C/D/M/NS is positive. Hit-zone tiles pair
   average shares with least-squares percentage-point trends using the same
   semantic directions.
@@ -70,7 +70,9 @@ Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter
 - **Time % (experimental)** is an opt-in, high-contrast teal dashed supplemental series on the same linear 0–100 scale. It uses only fastest valid combined-field raw stage time divided by shooter raw time, excludes classifiers, overrides, invalid or incomplete times, and unavailable benchmarks, and shows unavailable rather than a fabricated point. It never replaces Score Over Time or Adjusted %.
 - Hit Zone Breakdown stores and exports raw reported counts only. Source-column availability is part of each refreshed stage record; legacy records without it are unknown, and combined M+NS data must never be split into invented M and NS values.
 - The hit-zone denominator is the reported A/B/C/D/M/NS or combined M+NS total. Procedural penalties remain outside it and are disclosed in chart help and tooltips.
-- Hit-zone geometry transforms cumulative boundaries, never individual stored values: raw 0–50% maps linearly to 0–30% visual height, and raw 50–100% maps linearly to 30–100%. Raw ticks render at transformed positions, ordering is stable, and the cumulative endpoint remains 100%.
+- Accuracy Trend uses that same valid reported hit-zone total as each match's percentage denominator; missing or zero-denominator matches are unavailable, never zero accuracy.
+- Apply all chart filters before sorting Hit Zone Breakdown records and retaining the six most recent eligible matches in chronological display order.
+- Hit-zone geometry transforms cumulative boundaries, never individual stored values: raw 0–75% maps linearly to 0–45% visual height, and raw 75–100% maps linearly to 45–100%. Raw ticks render at transformed positions, ordering is stable, and the cumulative endpoint remains 100%. Keep this as a stacked bar chart: pie charts, 3D transforms, perspective, and area-based encodings would distort comparison.
 - Use distinct theme-safe colours and stable order for A, conditional positive B, C, D, separate M, separate NS, and combined M+NS. Tooltips and exports retain exact raw counts and percentages.
 
 ## Analytics date range

--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ Scored/All view, Last 8 setting, match checkboxes, and stage filters.
   varying pairs, reports `r` and `n`, and describes association rather than
   causation. Official USPSA percentages are preferred; any match-relative
   fallback is labelled.
-- **Accuracy Trend** — recent-vs-prior reported A/B/C/D/M/NS counts. Higher A
-  and lower B/C/D/M/NS are treated as improvement.
+- **Accuracy Trend** — recent-vs-prior reported A/B/C/D/M/NS percentage shares
+  of valid reported hits. Higher A and lower B/C/D/M/NS are treated as improvement.
 - **Hit Zone Breakdown** — average A/B/C/D/M/NS shares and their overall
   percentage-point trends. Procedurals remain outside the denominator.
 
@@ -178,9 +178,9 @@ show their own sample basis.
 
 The **Non-Classifier Stage Trend** averages your included non-classifier stage percentages for each match. Each percentage compares your hit factor with the top shooter on that stage at that match. It uses a linear 0–100% scale and is useful for tracking match-relative performance, but it is not an official USPSA classification percentage and does not use GM/M/A/B/C/D bands. Its 40%, 60%, 75%, 85%, and 95% lines are numeric percentage references only.
 
-The **Hit Zone Breakdown** uses the reported A/B/C/D/M/NS columns for included stages. B appears only when a positive B count is reported. Separate M and NS source columns remain separate; a combined source column is labelled **M+NS** and is never split. Older cached stages without column-availability metadata show blanks until that match is refreshed, so an unavailable field is not presented as an authoritative zero.
+The **Hit Zone Breakdown** uses the reported A/B/C/D/M/NS columns for included stages, after all active date, division, match-type, stage, Last 8, and match-selection filters. It then displays the six most recent eligible matches in chronological order. B appears only when a positive B count is reported. Separate M and NS source columns remain separate; a combined source column is labelled **M+NS** and is never split. Older cached stages without column-availability metadata show blanks until that match is refreshed, so an unavailable field is not presented as an authoritative zero.
 
-Hit-zone percentages use the **reported hit-zone total** as their denominator. Procedural penalties are disclosed but excluded. Raw counts and percentages remain unchanged in tooltips and exports; only the chart geometry is nonlinear. Cumulative raw boundaries from 0–50% occupy 0–30% of visual height, and boundaries from 50–100% occupy 30–100%, making smaller outcomes easier to distinguish while preserving order and the 100% endpoint.
+Accuracy Trend and hit-zone percentages use the **reported hit-zone total** as their denominator. A match with missing hit data or a zero denominator is unavailable rather than shown as 0%. Procedural penalties are disclosed but excluded. Raw counts and percentages remain unchanged in tooltips and exports; only the chart geometry is nonlinear. Cumulative raw boundaries from 0–75% occupy 0–45% of visual height, and boundaries from 75–100% occupy 45–100%, making smaller outcomes easier to distinguish while preserving order and the 100% endpoint. The chart deliberately remains a stacked bar chart: pie charts and 3D/perspective effects would distort comparisons.
 
 ### Filtering by date
 

--- a/extension/dashboard-summaries.js
+++ b/extension/dashboard-summaries.js
@@ -378,7 +378,7 @@ function _outcomeTiles(points, mode) {
     const values = points.map(point => point[property]).filter(Number.isFinite);
     if (!values.length || (key === 'b' && !values.some(value => value > 0))) continue;
 
-    if (mode === 'share') {
+    if (mode === 'share' || mode === 'percentage') {
       const average = _avg(values);
       const trend = _overallTrend(values);
       const status = trend ? _trendStatus(trend.delta, 1.0, lowerIsBetter) : null;
@@ -387,7 +387,7 @@ function _outcomeTiles(points, mode) {
         label,
         value: `${average.toFixed(1)}%`,
         comparison: trend ? `${_signed(trend.delta)} pp predicted change` : 'Trend needs at least 3 matches',
-        meta: `Average share · n=${values.length}${thresholdNote}`,
+        meta: `Average reported hit-zone share · n=${values.length}${thresholdNote}`,
         status: status || _contextStatus('Not enough trend data', '…'),
       }));
       continue;
@@ -417,6 +417,6 @@ function generateSummaries(viewSorted, analysis = {}) {
   _renderSummary('chartPlaceSummary', _placementTiles(sorted));
   _renderSummary('chartNonClfSummary', _nonClassifierTiles(analysis.nonClfPoints || []));
   _renderSummary('chartClfSummary', _classifierTiles(sorted));
-  _renderSummary('chartAccuracySummary', _outcomeTiles(analysis.accuracyPoints || [], 'count'));
+  _renderSummary('chartAccuracySummary', _outcomeTiles(analysis.accuracyPoints || [], 'percentage'));
   _renderSummary('chartHitZoneSummary', _outcomeTiles(analysis.hitZoneBars || [], 'share'));
 }

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -1652,7 +1652,7 @@
   <div class="chart-section" id="chartAccuracySection" style="display:none">
     <div class="chart-section-header">
       <h3>Accuracy Trend</h3>
-      <span style="font-size:12px;color:#666;text-transform:uppercase;letter-spacing:0.5px">Reported C, D, M, and NS counts per match · nonlinear scale · combined M+NS is not split</span>
+      <span style="font-size:12px;color:#666;text-transform:uppercase;letter-spacing:0.5px">Reported C, D, M, and NS share of valid hit-zone totals · combined M+NS is not split</span>
     </div>
     <canvas id="chartAccuracy" height="380"></canvas>
     <div class="chart-summary chart-summary--outcomes" id="chartAccuracySummary" role="list" aria-label="Accuracy outcome insights" style="display:none"></div>
@@ -1660,7 +1660,7 @@
   <div class="chart-section" id="chartHitZoneSection" style="display:none">
     <div class="chart-section-header">
       <h3>Hit Zone Breakdown</h3>
-      <span class="chart-subtitle">Reported hit-zone distribution per match · nonlinear visual scale</span>
+      <span class="chart-subtitle">Six most recent eligible matches · reported hit-zone distribution · nonlinear visual scale</span>
     </div>
     <div class="chart-scale-note">Raw 0–75% maps to 0–45% of visual height; raw 75–100% maps to 45–100%. Legible A segments show their exact percentage. Dotted lines are per-series least-squares progressions; the green line here tracks raw A%. Tooltips show exact raw counts and percentages. Procedural penalties are excluded from the reported hit-zone total.</div>
     <canvas id="chartHitZone" height="380"></canvas>

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -1,6 +1,5 @@
 // dashboard.js
 
-// ── Global state (declared first to avoid TDZ in event handlers below) ────────
 let allResults = [];
 
 // ── Size canvases to their visible CSS-pixel dimensions ───────────────────────
@@ -37,13 +36,11 @@ function scheduleDashboardResize() {
 window.addEventListener('resize', scheduleDashboardResize);
 document.addEventListener('DOMContentLoaded', sizeCanvases);
 
-// ── Version display ───────────────────────────────────────────────────────────
 const headerVersion = document.getElementById('headerVersion');
 const installedVersion = chrome.runtime.getManifest().version;
 headerVersion.textContent = 'Installed v' + installedVersion;
 headerVersion.setAttribute('aria-label', 'Installed extension version ' + installedVersion + '. View GitHub Releases.');
 
-// ── DOM refs ──────────────────────────────────────────────────────────────────
 const memberInput  = document.getElementById('memberInput');
 const nameInput    = document.getElementById('nameInput');
 const divisionFilter = document.getElementById('divisionFilter');
@@ -1823,8 +1820,8 @@ function renderAll() {
   }
 
   // ── Accuracy trend ────────────────────────────────────────────────────────
-  // Plots reported C, D, M, and NS counts per match. Combined M+NS values are
-  // deliberately not split into separate series.
+  // Plots reported C, D, M, and NS shares of valid scored hits per match.
+  // Combined M+NS values are deliberately not split into separate series.
   const accuracySection = document.getElementById('chartAccuracySection');
   const accuracyPoints  = [];
   for (const r of viewSorted) {
@@ -1854,18 +1851,21 @@ function renderAll() {
       }
       stagesWithHits++;
     }
-    if (!stagesWithHits) continue;
+    const hitKeys = ['a', 'b', 'c', 'd', 'm', 'ns', 'm_ns'];
+    const total = hitKeys.reduce((sum, key) => sum + (available[key] ? totals[key] : 0), 0);
+    if (!stagesWithHits || !total) continue;
     accuracyPoints.push({
       date: r.date,
       label: r.match_name,
       division: r.division,
-      a: available.a ? totals.a : null,
-      b: available.b ? totals.b : null,
-      c: available.c ? totals.c : null,
-      d: available.d ? totals.d : null,
-      m: hasCombinedMNs ? null : (available.m ? totals.m : null),
-      ns: hasCombinedMNs ? null : (available.ns ? totals.ns : null),
-      m_ns: available.m_ns ? totals.m_ns : null,
+      a: available.a ? (totals.a / total) * 100 : null,
+      b: available.b ? (totals.b / total) * 100 : null,
+      c: available.c ? (totals.c / total) * 100 : null,
+      d: available.d ? (totals.d / total) * 100 : null,
+      m: hasCombinedMNs ? null : (available.m ? (totals.m / total) * 100 : null),
+      ns: hasCombinedMNs ? null : (available.ns ? (totals.ns / total) * 100 : null),
+      m_ns: available.m_ns ? (totals.m_ns / total) * 100 : null,
+      total,
       hasCombinedMNs,
     });
   }
@@ -1883,7 +1883,7 @@ function renderAll() {
     const accDates  = accuracyPoints.map(p => p.date);
     if (accSeries.length) {
       drawMultiSeriesChart(document.getElementById('chartAccuracy'), accSeries, accDates, {
-        yLabel: 'Reported hits (nonlinear)', yMin: 0, yMax: null, invertY: false, trend: true, valueUnit: 'hits', yScale: 'sqrt',
+        yLabel: 'Reported hit share', yMin: 0, yMax: 100, invertY: false, trend: true, valueUnit: '%',
         showClassBands: false,
       });
     } else {
@@ -1940,18 +1940,18 @@ function renderAll() {
     });
   }
   hitZoneBars.sort((a, b) => (a.date || '').localeCompare(b.date || ''));
+  const recentHitZoneBars = hitZoneBars.slice(-6);
 
-  if (hitZoneBars.length >= 2) {
+  if (recentHitZoneBars.length >= 2) {
     hitZoneSection.style.display = '';
-    drawStackedBarChart(document.getElementById('chartHitZone'), hitZoneBars);
+    drawStackedBarChart(document.getElementById('chartHitZone'), recentHitZoneBars);
   } else {
     hitZoneSection.style.display = 'none';
   }
 
-  generateSummaries(viewSorted, { nonClfPoints, accuracyPoints, hitZoneBars });
+  generateSummaries(viewSorted, { nonClfPoints, accuracyPoints, hitZoneBars: recentHitZoneBars });
 }
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
 function setStatus(msg, type = '', loading = false) {
   statusEl.className = type;
   statusEl.innerHTML = loading ? `<div class="spinner"></div>${msg}` : msg;

--- a/tests/dashboard-analytics.test.js
+++ b/tests/dashboard-analytics.test.js
@@ -1,0 +1,23 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+function hitShares(hits) {
+  const total = Object.values(hits).reduce((sum, value) => sum + value, 0);
+  return total ? Object.fromEntries(Object.entries(hits).map(([key, value]) => [key, value / total * 100])) : null;
+}
+
+function latestEligible(records) {
+  return records.filter(record => record.total > 0).sort((a, b) => a.date.localeCompare(b.date)).slice(-6);
+}
+
+test('accuracy shares use valid reported-hit denominators and reject zero totals', () => {
+  assert.deepEqual(hitShares({ a: 8, c: 1, m: 1 }), { a: 80, c: 10, m: 10 });
+  assert.equal(hitShares({ a: 0, c: 0, m: 0 }), null);
+});
+
+test('Hit Zone retains the six newest eligible records after filtering', () => {
+  const records = Array.from({ length: 8 }, (_, index) => ({ date: `2026-01-0${index + 1}`, total: index === 1 ? 0 : 10 }));
+  assert.deepEqual(latestEligible(records).map(record => record.date), [
+    '2026-01-03', '2026-01-04', '2026-01-05', '2026-01-06', '2026-01-07', '2026-01-08',
+  ]);
+});


### PR DESCRIPTION
## Summary

Accuracy Trend now uses valid reported-hit percentages, and Hit Zone applies chart filters before showing the six most recent matches.

## Files Changed

DESIGN.md, README.md, extension/dashboard-summaries.js, extension/dashboard.html, extension/dashboard.js, tests/dashboard-analytics.test.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — node --check extension/dashboard.js; node --check extension/dashboard-charts.js; node --check extension/dashboard-summaries.js; node --test tests/*.test.js; git diff --check

Resolves #109


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.346 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 7m and 100,325 tokens on this as a headless worker.
