### PR TITLE
GH#98: add PractiScore verification guidance

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -27,6 +27,12 @@ Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter
 - Preserve visible keyboard focus and keyboard access for every control.
 - Do not rely on hover for required actions or information.
 - Keep motion restrained in this analytical interface; resizing and filtering should feel immediate rather than animated.
+- Place the PractiScore human-verification notice directly after onboarding
+  step 3 and before optional USPSA.org guidance. Keep it visually distinct but
+  subordinate to the numbered steps, readable in both themes, and full-width
+  on narrow screens. It must tell users to keep the PractiScore tab open and
+  complete any repeated CAPTCHA or Cloudflare checks without adding a modal,
+  animation, or new application state.
 - Insight status icons reinforce visible text and are decorative to assistive
   technology. Never communicate Improving, Stable, Needs attention,
   unavailable data, or metric basis through colour or an icon alone.

--- a/README.md
+++ b/README.md
@@ -136,7 +136,14 @@ member requires explicit confirmation. Full match history remains in
 
 3. **Enter your member number and/or name** — type your USPSA member number (e.g. `A12345`) and/or your name as it appears on result sheets (e.g. `Smith, Jane`). At least one is required; providing both improves match accuracy.
 
-4. **Choose your division and a Fetch timeline, then click Fetch Scores** — a division is required. The timeline defaults to **6 mo** and offers **Last 1 month**, **3 mo**, **6 mo**, and **1 yr**. It limits which PractiScore matches receive score and stage requests. The extension opens each in-range match's results page, selects your division, and records your score. Progress is shown in the status bar.
+4. **Choose your division and a Fetch timeline, then click Fetch Scores** — a
+   division is required. The timeline defaults to **6 mo** and offers **Last 1
+   month**, **3 mo**, **6 mo**, and **1 yr**. It limits which PractiScore matches
+   receive score and stage requests. The extension opens each in-range match's
+   results page, selects your division, and records your score. Keep the
+   PractiScore tab open and complete any CAPTCHA or Cloudflare verification that
+   appears there; longer history pulls may ask more than once. Progress is shown
+   in the status bar.
 
 5. **Explore your data** — the summary bar shows matches found, average %, best %, field-strength adjusted average, and your USPSA classification. The **Scored Matches / All Matches** toggle below the cards switches between member-number lookup results and all name-matched results.
 

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -999,6 +999,17 @@
       color: #778;
       line-height: 1.5;
     }
+    .onboarding-verification-note {
+      margin: 14px 0 2px 40px;
+      padding: 10px 12px;
+      border-left: 3px solid #f59e0b;
+      border-radius: 5px;
+      background: rgba(245,158,11,0.08);
+      color: #b8c0cf;
+      font-size: 14px;
+      line-height: 1.5;
+    }
+    .onboarding-verification-note strong { color: #fbbf24; }
     .onboarding-link-btn {
       display: inline-flex;
       align-items: center;
@@ -1273,6 +1284,7 @@
       .refresh-btn,
       .export-btn,
       .delete-btn { opacity: 1; }
+      .onboarding-verification-note { margin-left: 0; }
     }
 
     /* ── CSS variables: chart primitives (read by CHART_BG/GRID_COLOR etc. in JS) ── */
@@ -1465,6 +1477,12 @@
     [data-theme="light"] .onboarding-step-desc { color: #5a6478; }
     [data-theme="light"] .onboarding-step-num { background: #2563eb; }
     [data-theme="light"] .onboarding-step-title { color: #1a1d27; }
+    [data-theme="light"] .onboarding-verification-note {
+      background: #fffbeb;
+      border-left-color: #d97706;
+      color: #78350f;
+    }
+    [data-theme="light"] .onboarding-verification-note strong { color: #92400e; }
     [data-theme="light"] .match-type-badge { background: #e0e2e8; color: #5a6478; }
     [data-theme="light"] .match-type-badge.uspsa { background: #dbeafe; color: #1d4ed8; }
   </style>
@@ -1567,6 +1585,10 @@
       </div>
     </div>
 
+  </div>
+  <div class="onboarding-verification-note" role="note">
+    <strong>Watch the PractiScore tab for verification.</strong>
+    Keep it open while scores are loading. If a CAPTCHA or Cloudflare check appears, open the tab and complete it so the fetch can continue. Longer history pulls may ask more than once.
   </div>
   <hr class="onboarding-divider">
   <div class="onboarding-optional">


### PR DESCRIPTION
## Summary

- Add a visible, non-blocking onboarding note after step 3.
- Tell users to keep PractiScore open and complete CAPTCHA or Cloudflare verification, including repeated prompts during longer fetches.
- Keep README instructions and the design contract aligned with the interface.

## Runtime Testing

- Rendered the dashboard at 1280×900 in light mode and 375×812 in dark mode.
- Confirmed the notice remains inside the onboarding card with no horizontal overflow.
- Measured text contrast at 8.75:1 in light mode and 8.58:1 in dark mode; emphasized text measured 6.84:1 and 9.40:1.
- Static HTTP rendering reports the expected missing `chrome.runtime` error outside an extension context; no application JavaScript changed.

## Verification

```text
node --check extension/dashboard.js
node --test tests/background-storage.test.js tests/dashboard-analytics.test.js tests/dashboard-summaries.test.js tests/time-percentage.test.js
git diff --check
```

All 21 tests pass. Pre-commit and pre-push hooks pass.

Resolves #98

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.347 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 1d 6h and 2,779,634 tokens on this with the user in an interactive session.
