### PR TITLE
chore: release v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable user-facing changes are documented here. Update this file before pub
 
 ## Unreleased
 
+## v1.8.0 — 2026-09-09
+
+### Added
+
+- Added familiar D, C, B, A, M, and GM equivalent badges to match finish and
+  Adjusted % summaries while keeping them explicitly separate from official
+  USPSA classifier classifications.
+- Added an opt-in experimental Time % series that compares valid raw stage times
+  with the fastest combined-field times without applying division or power-factor
+  weighting.
+- Added persistent light/dark brightness and blue, dark green, bright green, or
+  purple accent controls that synchronize through Chrome storage.
+- Added the installed extension version to the dashboard header so the active
+  build can be confirmed without opening Chrome's extension settings.
+
+### Changed
+
+- Accuracy insights now report A, C, D, miss, no-shoot, and procedural outcomes
+  as percentages with explicit denominators, while retaining raw counts where
+  useful for context.
+- PractiScore onboarding now explains CAPTCHA and Cloudflare verification after
+  sign-in, including accessible recovery guidance when a fetch is interrupted.
+
+### Fixed
+
+- Dashboard size safeguards now account for the expanded theme and analytics
+  controls without weakening the existing bundle guard.
+
 ## v1.7.1 — 2026-09-08
 
 ### Added

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hit Factor Charts",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "Track your USPSA match performance: division %, adjusted field-strength scores, classifier trends, and placement over time.",
   "permissions": ["tabs", "scripting", "storage"],
   "host_permissions": ["https://practiscore.com/*", "https://s3.amazonaws.com/*", "https://api.github.com/*", "https://uspsa.org/*", "https://objects.githubusercontent.com/*"],


### PR DESCRIPTION
## Summary

- Bump the Chrome extension manifest from v1.7.1 to v1.8.0.
- Publish dated release notes for the user-facing work merged through #108, #109, #110, #111, #112, and #119 (issue #98).
- Keep the Unreleased section ready for subsequent changes.

## Verification

- `node --test tests/background-storage.test.js tests/dashboard-analytics.test.js tests/dashboard-summaries.test.js tests/time-percentage.test.js` — 21/21 passed.
- `node --check` passed for all six extension JavaScript files.
- `python3 -m json.tool extension/manifest.json` passed.
- `git diff --check` passed.
- `./build.sh` produced `dist/hitfactorcharts-v1.8.0.zip`.
- `unzip -t dist/hitfactorcharts-v1.8.0.zip` reported no errors.
- Repository pre-commit and pre-push hooks passed without bypasses.

## Runtime Testing

The underlying user-facing features were runtime-verified in their source PRs. This release-only change updates version metadata and release notes; focused tests and the packaged artifact were verified locally.

## Release behavior

After merge, `.github/workflows/release.yml` reads version `1.8.0`, builds `HitFactorCharts.zip`, extracts the `v1.8.0` changelog section, and creates the `v1.8.0` GitHub release and tag.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.349 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-sol spent 46m and 348,099 tokens on this with the user in an interactive session.