### PR TITLE
GH#121: fix: recover toolbar dashboard focus races

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -25,15 +25,42 @@ const storageMigrationPromise = migrateStorage().catch(error => {
 });
 
 // ── Open dashboard tab (or focus if already open) ─────────────────────────────
-chrome.action.onClicked.addListener(async () => {
+async function openDashboard() {
   const dashUrl = chrome.runtime.getURL('dashboard.html');
-  const existing = await chrome.tabs.query({ url: dashUrl });
-  if (existing.length > 0) {
-    await chrome.tabs.update(existing[0].id, { active: true });
-    await chrome.windows.update(existing[0].windowId, { focused: true });
-  } else {
-    chrome.tabs.create({ url: dashUrl });
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const existing = await chrome.tabs.query({ url: dashUrl });
+    if (!existing.length) {
+      await chrome.tabs.create({ url: dashUrl });
+      return;
+    }
+
+    const dashboard = existing[0];
+    try {
+      await chrome.tabs.update(dashboard.id, { active: true });
+    } catch (error) {
+      // A tab or window can close between query and focus. Re-query once so a
+      // stale result does not turn the toolbar action into a silent failure.
+      console.warn('[HFC] Dashboard focus race; retrying:', error);
+      continue;
+    }
+
+    try {
+      await chrome.windows.update(dashboard.windowId, { focused: true });
+    } catch (error) {
+      // The dashboard tab is already active. Do not create a duplicate when
+      // Chrome declines to focus its window (for example, a closing window).
+      console.warn('[HFC] Dashboard window could not be focused:', error);
+    }
+    return;
   }
+
+  // The second query found only stale dashboard state. Create one replacement.
+  await chrome.tabs.create({ url: dashUrl });
+}
+
+chrome.action.onClicked.addListener(() => {
+  return openDashboard().catch(error => console.error('[HFC] Unable to open dashboard:', error));
 });
 
 // ── Message handler ───────────────────────────────────────────────────────────

--- a/tests/background-storage.test.js
+++ b/tests/background-storage.test.js
@@ -32,26 +32,35 @@ function storageArea(initial = {}) {
   };
 }
 
-async function loadBackground(initialStorage = {}) {
+async function loadBackground(initialStorage = {}, chromeOverrides = {}) {
   const local = storageArea(initialStorage);
   const noopEvent = { addListener() {}, removeListener() {} };
-  const context = vm.createContext({
-    chrome: {
-      action: { onClicked: noopEvent },
-      runtime: {
-        getManifest: () => ({ version: 'test' }),
-        getURL: value => value,
-        onMessage: noopEvent,
-      },
-      scripting: { executeScript: async () => [{ result: null }] },
-      storage: { local },
-      tabs: {
-        create: async () => ({ id: 1 }),
-        get: async () => ({ url: 'https://practiscore.com/associate/step2' }),
-        onUpdated: noopEvent,
-        remove: async () => {},
-      },
+  let actionCallback = null;
+  const chrome = {
+    action: { onClicked: { addListener(callback) { actionCallback = callback; } } },
+    runtime: {
+      getManifest: () => ({ version: 'test' }),
+      getURL: value => value,
+      onMessage: noopEvent,
     },
+    scripting: { executeScript: async () => [{ result: null }] },
+    storage: { local },
+    tabs: {
+      create: async () => ({ id: 1 }),
+      get: async () => ({ url: 'https://practiscore.com/associate/step2' }),
+      onUpdated: noopEvent,
+      remove: async () => {},
+      query: async () => [],
+      update: async () => {},
+    },
+    windows: { update: async () => {} },
+  };
+  const { tabs: tabOverrides, windows: windowOverrides, ...otherOverrides } = chromeOverrides;
+  Object.assign(chrome, otherOverrides);
+  if (tabOverrides) Object.assign(chrome.tabs, tabOverrides);
+  if (windowOverrides) Object.assign(chrome.windows, windowOverrides);
+  const context = vm.createContext({
+    chrome,
     console,
     Date,
     Map,
@@ -68,7 +77,7 @@ async function loadBackground(initialStorage = {}) {
     normalizeHistorySync, createBackup, importBackup, fetchScores, isReusableMatchCache
   };`, context);
   await context.__hfcTest.storageMigrationPromise;
-  return { context, local, api: context.__hfcTest };
+  return { context, local, api: context.__hfcTest, actionCallback };
 }
 
 const firstId = '11111111-1111-4111-8111-111111111111';
@@ -103,6 +112,61 @@ function syncMetadata(overrides = {}) {
     ...overrides,
   };
 }
+
+test('toolbar action creates one dashboard tab when none exists', async () => {
+  const created = [];
+  const { actionCallback } = await loadBackground({}, {
+    tabs: { create: async details => { created.push(details); return { id: 1 }; } },
+  });
+
+  await actionCallback();
+  assert.deepEqual(JSON.parse(JSON.stringify(created)), [{ url: 'dashboard.html' }]);
+});
+
+test('toolbar action focuses an existing dashboard tab and its window', async () => {
+  const updates = [];
+  const { actionCallback } = await loadBackground({}, {
+    tabs: {
+      query: async () => [{ id: 9, windowId: 4 }],
+      update: async (...args) => updates.push(args),
+      create: async () => assert.fail('must not create a duplicate dashboard tab'),
+    },
+    windows: { update: async (...args) => updates.push(args) },
+  });
+
+  await actionCallback();
+  assert.deepEqual(JSON.parse(JSON.stringify(updates)), [[9, { active: true }], [4, { focused: true }]]);
+});
+
+test('toolbar action retries after a stale dashboard tab and creates one replacement', async () => {
+  let queryCount = 0;
+  const created = [];
+  const { actionCallback } = await loadBackground({}, {
+    tabs: {
+      query: async () => ++queryCount === 1 ? [{ id: 9, windowId: 4 }] : [],
+      update: async () => { throw new Error('No tab with id: 9'); },
+      create: async details => { created.push(details); return { id: 10 }; },
+    },
+  });
+
+  await actionCallback();
+  assert.equal(queryCount, 2);
+  assert.deepEqual(JSON.parse(JSON.stringify(created)), [{ url: 'dashboard.html' }]);
+});
+
+test('toolbar action does not duplicate an active dashboard when its window cannot focus', async () => {
+  let created = false;
+  const { actionCallback } = await loadBackground({}, {
+    tabs: {
+      query: async () => [{ id: 9, windowId: 4 }],
+      create: async () => { created = true; },
+    },
+    windows: { update: async () => { throw new Error('No window with id: 4'); } },
+  });
+
+  await actionCallback();
+  assert.equal(created, false);
+});
 
 test('compatible complete caches migrate without losing stages or preferences', async () => {
   const { local } = await loadBackground({


### PR DESCRIPTION
## Summary

Recovers the toolbar action when a queried dashboard tab closes during activation, while retaining and diagnosing existing-tab window-focus failures without creating duplicates. Adds VM coverage for create, cross-window focus, stale-tab recovery, and unavailable-window behavior.



## Files Changed

extension/background.js, tests/background-storage.test.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — node --test tests/background-storage.test.js tests/dashboard-analytics.test.js tests/dashboard-summaries.test.js tests/time-percentage.test.js; node --check extension/background.js; python3 -m json.tool extension/manifest.json; ./build.sh; git diff --check

Resolves #121


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.349 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-terra spent 3m and 96,200 tokens on this as a headless worker.