### PR TITLE
GH#128: add Accuracy Trend scale

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -73,6 +73,11 @@ Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter
   Higher A is positive; lower B/C/D/M/NS is positive. Hit-zone tiles pair
   average shares with least-squares percentage-point trends using the same
   semantic directions.
+- Accuracy Trend uses a disclosed piecewise-linear geometry only: raw 0%, 5%,
+  10%, 20%, 40%, 50%, and 100% map to 0%, 30%, 45%, 62%, 84%, 90%, and 100%
+  of visual height. Its raw ticks are 0%, 1%, 2%, 5%, 10%, 20%, 40%, 50%, and
+  100%; tooltips, summaries, exports, trend inputs, denominators, and stored
+  records remain raw percentages. No other chart receives this warp.
 - Date ticks use measured text width and a minimum 10px gap. Keep the final date only when it does not collide with the preceding retained label.
 - Suppress labels for duplicate source dates while preserving distinct same-day data points and tooltips. If different years share the same month and day, include the year so useful dates remain distinguishable.
 - Axis labels must remain inside the canvas and readable in both themes at narrow, desktop, and wide widths.

--- a/README.md
+++ b/README.md
@@ -188,7 +188,10 @@ Scored/All view, Last 8 setting, match checkboxes, and stage filters.
   causation. Official USPSA percentages are preferred; any match-relative
   fallback is labelled.
 - **Accuracy Trend** — recent-vs-prior reported A/B/C/D/M/NS percentage shares
-  of valid reported hits. Higher A and lower B/C/D/M/NS are treated as improvement.
+  of valid reported hits. Its disclosed nonlinear geometry expands 0–5%, gives
+  values below 40% most of the chart height, and compresses values above 50%; all
+  labels, tooltips, summaries, and exports retain exact raw percentages. Higher A
+  and lower B/C/D/M/NS are treated as improvement.
 - **Hit Zone Breakdown** — average A/B/C/D/M/NS shares and their overall
   percentage-point trends. Procedurals remain outside the denominator.
 
@@ -202,7 +205,7 @@ The **Non-Classifier Stage Trend** averages your included non-classifier stage p
 
 The **Hit Zone Breakdown** uses the reported A/B/C/D/M/NS columns for included stages, after all active date, division, match-type, stage, Last 8, and match-selection filters. It then displays the six most recent eligible matches in chronological order. B appears only when a positive B count is reported. Separate M and NS source columns remain separate; a combined source column is labelled **M+NS** and is never split. Older cached stages without column-availability metadata show blanks until that match is refreshed, so an unavailable field is not presented as an authoritative zero.
 
-Accuracy Trend and hit-zone percentages use the **reported hit-zone total** as their denominator. A match with missing hit data or a zero denominator is unavailable rather than shown as 0%. Procedural penalties are disclosed but excluded. Raw counts and percentages remain unchanged in tooltips and exports; only the chart geometry is nonlinear. Cumulative raw boundaries from 0–75% occupy 0–45% of visual height, and boundaries from 75–100% occupy 45–100%, making smaller outcomes easier to distinguish while preserving order and the 100% endpoint. The chart deliberately remains a stacked bar chart: pie charts and 3D/perspective effects would distort comparisons.
+Accuracy Trend and hit-zone percentages use the **reported hit-zone total** as their denominator. A match with missing hit data or a zero denominator is unavailable rather than shown as 0%. Procedural penalties are disclosed but excluded. Raw counts and percentages remain unchanged in tooltips and exports. Accuracy Trend maps raw 0%, 5%, 10%, 20%, 40%, 50%, and 100% to 0%, 30%, 45%, 62%, 84%, 90%, and 100% of visual height; the Hit Zone chart separately maps cumulative raw boundaries from 0–75% to 0–45% of visual height and 75–100% to 45–100%. The chart deliberately remains a stacked bar chart: pie charts and 3D/perspective effects would distort comparisons.
 
 ### Filtering by date
 

--- a/extension/dashboard-charts.js
+++ b/extension/dashboard-charts.js
@@ -9,6 +9,15 @@ const FONT       = '11px Inter, system-ui, sans-serif';
 // Neutral reference percentages for match-performance charts. These are numeric
 // guides only; official classifier charts retain their separate class semantics.
 const USPSA_PERCENTAGE_REFERENCE_GUIDES = [40, 60, 75, 85, 95];
+// Accuracy Trend expands low-frequency reported outcomes without changing their
+// raw percentages. Values are expressed bottom-to-top as chart-height fractions.
+const ACCURACY_TREND_WARP_POINTS = Object.freeze([
+  { real: 0, visual: 0 }, { real: 5, visual: 0.30 },
+  { real: 10, visual: 0.45 }, { real: 20, visual: 0.62 },
+  { real: 40, visual: 0.84 }, { real: 50, visual: 0.90 },
+  { real: 100, visual: 1 },
+]);
+const ACCURACY_TREND_TICKS = Object.freeze([0, 1, 2, 5, 10, 20, 40, 50, 100]);
 
 function chartYAxisTicks(rawMin, rawMax, showPercentageReferenceGuides = false) {
   if (!showPercentageReferenceGuides) {
@@ -162,6 +171,14 @@ function warpPct(v, pts) {
   return 1;
 }
 
+function isValidWarpMap(pts, rawMin, rawMax) {
+  if (!Array.isArray(pts) || pts.length < 2) return false;
+  if (pts[0].real !== rawMin || pts[0].visual !== 0) return false;
+  if (pts[pts.length - 1].real !== rawMax || pts[pts.length - 1].visual !== 1) return false;
+  return pts.every((point, index) => Number.isFinite(point.real) && Number.isFinite(point.visual)
+    && (index === 0 || (point.real > pts[index - 1].real && point.visual > pts[index - 1].visual)));
+}
+
 function fmtPct(pct) {
   if (pct == null) return '—';
   return `<span style="color:#8a9bb0">${pct.toFixed(1)}%</span>`;
@@ -266,6 +283,7 @@ function drawMultiSeriesChart(canvas, seriesArr, allDates, opts = {}) {
   const {
     yLabel = '', yMin, yMax, invertY = false, trend = false, valueUnit = '%', yScale = 'linear',
     showClassBands = false, showPercentageReferenceGuides = false,
+    warpPoints = null, yTickValues = null,
     preserveDuplicateDates = false,
   } = opts;
 
@@ -279,7 +297,8 @@ function drawMultiSeriesChart(canvas, seriesArr, allDates, opts = {}) {
 
   // Build warp map for class-band-weighted Y-axis when showClassBands is active.
   // Falls back to null (linear scale) when fewer than two bands are visible.
-  const warpMap = showClassBands ? buildWarpMap(rawMin, rawMax) : null;
+  const classWarpMap = showClassBands ? buildWarpMap(rawMin, rawMax) : null;
+  const warpMap = isValidWarpMap(warpPoints, rawMin, rawMax) ? warpPoints : classWarpMap;
 
   const dateToCanvasX = (date, pointIndex = null) => {
     const idx = preserveDuplicateDates && pointIndex != null ? pointIndex : allDates.indexOf(date);
@@ -329,7 +348,8 @@ function drawMultiSeriesChart(canvas, seriesArr, allDates, opts = {}) {
     ctx,
     area,
     toY,
-    chartYAxisTicks(rawMin, rawMax, showPercentageReferenceGuides)
+    Array.isArray(yTickValues) ? yTickValues.filter(value => value >= rawMin && value <= rawMax)
+      : chartYAxisTicks(rawMin, rawMax, showPercentageReferenceGuides)
   );
 
   // Axes
@@ -852,4 +872,13 @@ function drawStackedBarChart(canvas, bars) {
     });
     canvas.addEventListener('mouseleave', () => { tooltipEl.style.display = 'none'; });
   }
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = {
+    ACCURACY_TREND_TICKS,
+    ACCURACY_TREND_WARP_POINTS,
+    isValidWarpMap,
+    warpPct,
+  };
 }

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -1787,6 +1787,7 @@
       <h3>Accuracy Trend</h3>
       <span style="font-size:12px;color:#666;text-transform:uppercase;letter-spacing:0.5px">Reported C, D, M, and NS share of valid hit-zone totals · combined M+NS is not split</span>
     </div>
+    <div class="chart-scale-note">Nonlinear visual scale: 0–5% is expanded, values below 40% receive most of the chart height, and values above 50% are compressed. Tick labels, tooltips, summaries, and exports retain exact raw percentages.</div>
     <canvas id="chartAccuracy" height="380"></canvas>
     <div class="chart-summary chart-summary--outcomes" id="chartAccuracySummary" role="list" aria-label="Accuracy outcome insights" style="display:none"></div>
   </div>

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -1877,7 +1877,7 @@ function renderAll() {
     if (accSeries.length) {
       drawMultiSeriesChart(document.getElementById('chartAccuracy'), accSeries, accDates, {
         yLabel: 'Reported hit share', yMin: 0, yMax: 100, invertY: false, trend: true, valueUnit: '%',
-        showClassBands: false,
+        showClassBands: false, warpPoints: ACCURACY_TREND_WARP_POINTS, yTickValues: ACCURACY_TREND_TICKS,
       });
     } else {
       drawMessage(document.getElementById('chartAccuracy'), 'M/NS are combined in the available source data.\nSeparate M and NS values are not estimated.');

--- a/tests/dashboard-analytics.test.js
+++ b/tests/dashboard-analytics.test.js
@@ -16,6 +16,12 @@ test('accuracy shares use valid reported-hit denominators and reject zero totals
   assert.equal(hitShares({ a: 0, c: 0, m: 0 }), null);
 });
 
+test('Accuracy Trend selects its geometry-only custom scale', () => {
+  const script = fs.readFileSync('extension/dashboard.js', 'utf8');
+  assert.match(script, /chartAccuracy[\s\S]*?warpPoints: ACCURACY_TREND_WARP_POINTS/);
+  assert.match(script, /chartAccuracy[\s\S]*?yTickValues: ACCURACY_TREND_TICKS/);
+});
+
 test('Hit Zone retains the six newest eligible records after filtering', () => {
   const records = Array.from({ length: 8 }, (_, index) => ({ date: `2026-01-0${index + 1}`, total: index === 1 ? 0 : 10 }));
   assert.deepEqual(latestEligible(records).map(record => record.date), [

--- a/tests/dashboard-charts.test.js
+++ b/tests/dashboard-charts.test.js
@@ -1,0 +1,35 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  ACCURACY_TREND_TICKS,
+  ACCURACY_TREND_WARP_POINTS,
+  isValidWarpMap,
+  warpPct,
+} = require('../extension/dashboard-charts.js');
+
+test('Accuracy Trend warp maps documented anchors exactly', () => {
+  const expected = [[0, 0], [5, 0.30], [10, 0.45], [20, 0.62], [40, 0.84], [50, 0.90], [100, 1]];
+  assert.deepEqual(ACCURACY_TREND_WARP_POINTS.map(point => [point.real, point.visual]), expected);
+  expected.forEach(([raw, visual]) => assert.equal(warpPct(raw, ACCURACY_TREND_WARP_POINTS), visual));
+  assert.deepEqual(ACCURACY_TREND_TICKS, [0, 1, 2, 5, 10, 20, 40, 50, 100]);
+});
+
+test('Accuracy Trend warp interpolates monotonically and preserves endpoints', () => {
+  assert.equal(warpPct(2.5, ACCURACY_TREND_WARP_POINTS), 0.15);
+  assert.equal(warpPct(30, ACCURACY_TREND_WARP_POINTS), 0.73);
+  let prior = -1;
+  for (let raw = 0; raw <= 100; raw++) {
+    const visual = warpPct(raw, ACCURACY_TREND_WARP_POINTS);
+    assert.ok(visual >= prior, `${raw}% must not move down the visual scale`);
+    prior = visual;
+  }
+  assert.equal(warpPct(0, ACCURACY_TREND_WARP_POINTS), 0);
+  assert.equal(warpPct(100, ACCURACY_TREND_WARP_POINTS), 1);
+});
+
+test('custom warps require complete strictly increasing raw and visual anchors', () => {
+  assert.equal(isValidWarpMap(ACCURACY_TREND_WARP_POINTS, 0, 100), true);
+  assert.equal(isValidWarpMap([{ real: 0, visual: 0 }, { real: 100, visual: 0.5 }], 0, 100), false);
+  assert.equal(isValidWarpMap([{ real: 0, visual: 0 }, { real: 5, visual: 0.3 }, { real: 4, visual: 1 }], 0, 4), false);
+});


### PR DESCRIPTION
## Summary

Added a disclosed piecewise nonlinear scale for Accuracy Trend while preserving raw percentages.



## Files Changed

DESIGN.md, README.md, extension/dashboard-charts.js, extension/dashboard.html, extension/dashboard.js, tests/dashboard-analytics.test.js, tests/dashboard-charts.test.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — node --check extension/dashboard-charts.js; node --check extension/dashboard.js; node --test tests/background-storage.test.js tests/dashboard-analytics.test.js tests/dashboard-charts.test.js tests/dashboard-summaries.test.js tests/time-percentage.test.js; git diff --check

Resolves #128


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.350 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-terra spent 4m and 108,105 tokens on this as a headless worker.