### PR TITLE
chore: release v1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,34 @@ All notable user-facing changes are documented here. Update this file before pub
 
 ## Unreleased
 
-## v1.8.0 — 2026-09-09
+## v1.8.1 — 2026-09-09
 
 ### Added
 
 - Added familiar D, C, B, A, M, and GM equivalent badges to match finish and
   Adjusted % summaries while keeping them explicitly separate from official
   USPSA classifier classifications.
-- Added an opt-in experimental Time % series that compares valid raw stage times
-  with the fastest combined-field times without applying division or power-factor
-  weighting.
+- Added best and worst context to Placement Over Time and Non-Classifier Stage
+  Trend summaries.
+
+### Changed
+
+- Time % is now the default, high-contrast Score Over Time view and remains an
+  exclusive chart mode.
+- Accuracy Trend now uses a disclosed nonlinear scale that expands small C, D,
+  M, and NS percentages without changing raw labels, summaries, or exports.
+- The required USPSA division selection now includes accessible helper text and
+  synchronized theme-safe state before scores are fetched.
+
+### Fixed
+
+- The toolbar action now recovers when a dashboard tab closes during activation
+  and avoids creating duplicate dashboards when window focus fails.
+
+## v1.8.0 — 2026-09-09
+
+### Added
+
 - Added persistent light/dark brightness and blue, dark green, bright green, or
   purple accent controls that synchronize through Chrome storage.
 - Added the installed extension version to the dashboard header so the active

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hit Factor Charts",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Track your USPSA match performance: division %, adjusted field-strength scores, classifier trends, and placement over time.",
   "permissions": ["tabs", "scripting", "storage"],
   "host_permissions": ["https://practiscore.com/*", "https://s3.amazonaws.com/*", "https://api.github.com/*", "https://uspsa.org/*", "https://objects.githubusercontent.com/*"],


### PR DESCRIPTION
## Summary

- bump the extension manifest from 1.8.0 to 1.8.1
- publish all work merged after v1.8.0 from PRs #123, #124, #127, #129, and #130
- add accurate v1.8.1 release notes and move two not-yet-shipped entries out of the v1.8.0 section

## Verification

- `python3 -m json.tool extension/manifest.json`
- `node --check` for the background, dashboard, chart, and summary scripts
- `node --test` across all five test files: 37 passed
- `./build.sh`: created `dist/hitfactorcharts-v1.8.1.zip`
- `git diff --check`
- pre-commit and pre-push hooks passed

## Release behavior

Merging this PR triggers `.github/workflows/release.yml`, which builds
`HitFactorCharts.zip` and creates the immutable `v1.8.1` GitHub release.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.350 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-sol spent 1h 57m and 881,836 tokens on this with the user in an interactive session.
