### PR TITLE
GH#136: fix: clarify accuracy trend summaries

### DIFF
--- a/extension/dashboard-summaries.js
+++ b/extension/dashboard-summaries.js
@@ -88,7 +88,7 @@ function _signed(value, digits = 1) {
 function _trendStatus(delta, threshold = 1.0, lowerIsBetter = false) {
   const improvement = lowerIsBetter ? -delta : delta;
   if (improvement > threshold) return { tone: 'positive', icon: '↑', label: 'Improving' };
-  if (improvement < -threshold) return { tone: 'negative', icon: '↓', label: 'Needs attention' };
+  if (improvement < -threshold) return { tone: 'negative', icon: '↓', label: 'Declining' };
   return { tone: 'neutral', icon: '→', label: 'Stable' };
 }
 
@@ -437,11 +437,11 @@ function _outcomeTiles(points, mode) {
       const average = _avg(values);
       const trend = _overallTrend(values);
       const status = trend ? _trendStatus(trend.delta, 1.0, lowerIsBetter) : null;
-      const thresholdNote = status?.label === 'Stable' ? ' · stable within ±1.0 pp' : '';
+      const thresholdNote = status?.label === 'Stable' ? ' · stable within ±1.0%' : '';
       tiles.push(_insightTile({
         label,
         value: `${average.toFixed(1)}%`,
-        comparison: trend ? `${_signed(trend.delta)} pp predicted change` : 'Trend needs at least 3 matches',
+        comparison: trend ? `${_signed(trend.delta)}% predicted change` : 'Trend needs at least 3 matches',
         meta: `Average reported hit-zone share · n=${values.length}${thresholdNote}`,
         status: status || _contextStatus('Not enough trend data', '…'),
       }));

--- a/tests/dashboard-summaries.test.js
+++ b/tests/dashboard-summaries.test.js
@@ -22,6 +22,7 @@ vm.runInContext(`${source};
   globalThis.placementTilesForTest = _placementTiles;
   globalThis.nonClassifierTilesForTest = _nonClassifierTiles;
   globalThis.classifierTilesForTest = _classifierTiles;
+  globalThis.outcomeTilesForTest = _outcomeTiles;
 `, context);
 
 test('performance classes include every boundary and decimal value', () => {
@@ -123,4 +124,22 @@ test('missing placement and non-classifier values remain unavailable rather than
   assert.doesNotMatch(nonClassifier, />0\.0%</);
   assert.match(placement, /Not enough data/);
   assert.match(nonClassifier, /Not enough data/);
+});
+
+test('outcome summaries show color-coded improving or declining percentage changes', () => {
+  context.leastSquaresRegression = samples => ({
+    start: { y: samples[0].y },
+    end: { y: samples.at(-1).y },
+  });
+
+  const improving = context.outcomeTilesForTest([{ c: 4 }, { c: 2 }, { c: 1 }], 'percentage').join('');
+  assert.match(improving, /insight-tile--positive/);
+  assert.match(improving, /Improving/);
+  assert.match(improving, /-3\.0% predicted change/);
+  assert.doesNotMatch(improving, /pp/);
+
+  const declining = context.outcomeTilesForTest([{ d: 1 }, { d: 2 }, { d: 4 }], 'percentage').join('');
+  assert.match(declining, /insight-tile--negative/);
+  assert.match(declining, /Declining/);
+  assert.match(declining, /\+3\.0% predicted change/);
 });


### PR DESCRIPTION
## Summary

Accuracy and hit-zone trend tiles now show Improving or Declining with existing positive/negative color treatments, and percentage changes use % instead of pp.



## Files Changed

extension/dashboard-summaries.js, tests/dashboard-summaries.test.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — node --test tests/background-storage.test.js tests/dashboard-analytics.test.js tests/dashboard-charts.test.js tests/dashboard-summaries.test.js tests/time-percentage.test.js

Resolves #136


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.350 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-terra spent 3m and 85,611 tokens on this as a headless worker.