### PR TITLE
GH#132: preserve Vivaldi toolbar action lifetime

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -59,8 +59,12 @@ async function openDashboard() {
   await chrome.tabs.create({ url: dashUrl });
 }
 
-chrome.action.onClicked.addListener(() => {
-  return openDashboard().catch(error => console.error('[HFC] Unable to open dashboard:', error));
+chrome.action.onClicked.addListener(async () => {
+  try {
+    await openDashboard();
+  } catch (error) {
+    console.error('[HFC] Unable to open dashboard:', error);
+  }
 });
 
 // ── Message handler ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Marks the toolbar action listener async so Vivaldi keeps the extension service worker alive until the dashboard action completes.



## Files Changed

extension/background.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — node --check extension/background.js; node --test tests/background-storage.test.js; git diff --check

Resolves #132


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.350 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-terra spent 4m and 89,949 tokens on this as a headless worker.