### PR TITLE
GH#133: fix: align division selector controls

### DIFF
--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -152,6 +152,7 @@
       flex: 0 1 210px;
       gap: 4px;
       min-width: 180px;
+      transform: translateY(11px);
     }
     .division-control__label {
       color: #aab3c2;
@@ -165,6 +166,15 @@
       color: #d9b36c;
       font-size: 12px;
       font-weight: 600;
+    }
+    /* Preserve the help row after a selection so the select stays aligned with
+       adjacent controls in both required and valid states. */
+    .division-control__help[hidden] {
+      display: block;
+      visibility: hidden;
+    }
+    .division-control select {
+      min-height: 42px;
     }
     .division-control.is-required select {
       border: 2px solid #d9a441;

--- a/tests/dashboard-analytics.test.js
+++ b/tests/dashboard-analytics.test.js
@@ -37,6 +37,9 @@ test('dashboard exposes and synchronizes the required division affordance', () =
   assert.match(html, /Select division — required/);
   assert.match(html, /Select a division before fetching scores\./);
   assert.match(html, /\.division-control\.is-required select/);
+  assert.match(html, /\.division-control \{[\s\S]*?transform: translateY\(11px\);/);
+  assert.match(html, /\.division-control__help\[hidden\]/);
+  assert.match(html, /\.division-control select \{\s*min-height: 42px;/);
   assert.match(script, /function syncDivisionRequirement\(\)/);
   assert.match(script, /divisionControl\.classList\.toggle\('is-required', required\)/);
   assert.match(script, /syncDivisionRequirement\(\);/);


### PR DESCRIPTION
## Summary

Keeps the labelled division selector vertically aligned with adjacent controls before and after selection.



## Files Changed

extension/dashboard.html, tests/dashboard-analytics.test.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — node --check extension/dashboard.js; node --test tests/dashboard-analytics.test.js; visual inspection at 375px, 1920px, and 2560px in light and dark themes

Resolves #133


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.350 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-terra spent 10m and 182,653 tokens on this as a headless worker.