### PR TITLE
GH#134: show score metrics together

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -84,8 +84,8 @@ Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter
 - Repeated Classifiers Only toggles, filter changes, theme changes, and resizes must restore analytical canvases with unchanged geometry, sharp rendering, and aligned tooltips.
 - Non-classifier stage percentages are match-relative comparisons with each stage's top shooter. Present them on a linear 0–100% scale without USPSA classification bands, labels, colours, or warped geometry.
 - Keep same-day non-classifier matches as separate chart points and tooltips while rendering their shared date label only once.
-- Regular Score Over Time uses a linear percentage scale without classification bands, inferred class labels, class colours, or warped geometry. Division % and Adjusted % are match-performance signals, not official classifications.
-- Score Over Time, Adjusted % Only, Non-Classifier Stage Trend, and Classifier vs Match Score use neutral numeric reference guides at 40%, 60%, 75%, 85%, and 95%. Keep these guides linear, theme-aware, and unlabeled beyond their numeric axis ticks; never present them as classes or class-coloured regions.
+- Regular Score Over Time uses a linear percentage scale without classification bands, inferred class labels, class colours, or warped geometry. Division %, Adjusted %, and Time % are match-performance signals, not official classifications.
+- Score Over Time, Non-Classifier Stage Trend, and Classifier vs Match Score use neutral numeric reference guides at 40%, 60%, 75%, 85%, and 95%. Keep these guides linear, theme-aware, and unlabeled beyond their numeric axis ticks; never present them as classes or class-coloured regions.
 - Use one shared performance-band mapping: D below 40%, C 40–59.999%, B
   60–74.999%, A 75–84.999%, M 85–94.999%, and GM 95%+. Finite normalized
   higher-is-better match finish, Adjusted %, and non-classifier stage values may
@@ -102,9 +102,9 @@ Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter
   best/worst values remain unbadged field-beaten percentages; non-classifier
   best/worst values may use the explicitly unofficial performance shorthand.
 - A captured GM hit-factor comparison is a separate, neutrally styled performance metric. Label it as an actual GM benchmark and never use it to classify the reporting shooter or replace Adjusted %.
-- Place **Adjusted % Only** beside **Classifiers Only** as matching native-checkbox switches. Both controls expose visible keyboard focus, wrap together at narrow widths, and never create page-level overflow.
-- Adjusted-only and classifiers-only modes are mutually exclusive. Adjusted-only displays cached adjusted points without raw fallback and uses a clear multi-line empty state when fewer than two usable points exist.
-- **Time % Only (experimental)** is the default Score Over Time mode and is a high-contrast cyan dashed series on the same linear 0–100 scale. It uses only fastest valid combined-field raw stage time divided by shooter raw time, excludes classifiers, overrides, invalid or incomplete times, and unavailable benchmarks, and shows unavailable rather than a fabricated point. Like Adjusted % Only and Classifiers Only, it displays only its own series.
+- Place **Division performance**, **Adjusted %**, and **Time % (experimental)** beside **Classifiers Only** as matching native-checkbox switches. All controls expose visible keyboard focus, wrap together at narrow widths, and never create page-level overflow.
+- Division performance, Adjusted %, and Time % are independently selectable and shown together by default when each has at least two valid points. Omit an unavailable selected metric with a clear explanation; never substitute or fabricate points.
+- **Time % (experimental)** is a high-contrast cyan dashed series on the same linear 0–100 scale. It uses only fastest valid combined-field raw stage time divided by shooter raw time, excludes classifiers, overrides, invalid or incomplete times, and unavailable benchmarks. **Classifiers Only** is the sole exclusive alternate mode and restores the selected normal series when switched off.
 - Hit Zone Breakdown stores and exports raw reported counts only. Source-column availability is part of each refreshed stage record; legacy records without it are unknown, and combined M+NS data must never be split into invented M and NS values.
 - The hit-zone denominator is the reported A/B/C/D/M/NS or combined M+NS total. Procedural penalties remain outside it and are disclosed in chart help and tooltips.
 - Accuracy Trend uses that same valid reported hit-zone total as each match's percentage denominator; missing or zero-denominator matches are unavailable, never zero accuracy.

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -1741,15 +1741,22 @@
             <span class="toggle-track"><span class="toggle-thumb"></span></span>
           </span>
         </label>
-        <label id="adjustedToggleWrap" class="chart-mode-toggle">
-          <span class="toggle-lbl">Adjusted % Only</span>
+        <label id="divisionToggleWrap" class="chart-mode-toggle">
+          <span class="toggle-lbl">Division performance</span>
           <span class="toggle-switch">
-            <input type="checkbox" id="adjustedOnlyChk">
+            <input type="checkbox" id="divisionPctChk">
+            <span class="toggle-track"><span class="toggle-thumb"></span></span>
+          </span>
+        </label>
+        <label id="adjustedToggleWrap" class="chart-mode-toggle">
+          <span class="toggle-lbl">Adjusted %</span>
+          <span class="toggle-switch">
+            <input type="checkbox" id="adjustedPctChk">
             <span class="toggle-track"><span class="toggle-thumb"></span></span>
           </span>
         </label>
         <label id="timePctToggleWrap" class="chart-mode-toggle" title="Experimental raw-time comparison; excludes classifiers and stages without a valid combined-field time.">
-          <span class="toggle-lbl">Time % Only <small>(experimental)</small></span>
+          <span class="toggle-lbl">Time % <small>(experimental)</small></span>
           <span class="toggle-switch">
             <input type="checkbox" id="timePctChk" aria-describedby="timePctHelp">
             <span class="toggle-track"><span class="toggle-thumb"></span></span>

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -240,8 +240,9 @@ let selectedDiv       = null;     // canonical division key (null = no selection
 let selectedDatePreset = '6m';   // analytics range; resets to six months on dashboard load
 let classificationData = null;  // data from uspsa.org/classification/[memberNumber]
 let classifiersOnly  = false;   // when true, charts show only classifier stage scores
-let adjustedOnly     = false;   // when true, Score Over Time shows only adjusted match points
-let showTimePct      = true;    // default Score Over Time mode: raw-time comparison
+let showDivisionPct  = true;    // normal Score Over Time series visibility
+let showAdjustedPct  = true;    // normal Score Over Time series visibility
+let showTimePct      = true;    // normal Score Over Time series visibility
 let selectedFetchTimeline = '6m'; // pre-fetch request scope; independent of analytics range
 let last8Matches = false;       // post-fetch analytics limit; never truncates cached history
 let matchTypeOverrides = {};    // match_id -> manual type for otherwise unconfirmed matches
@@ -910,8 +911,6 @@ function switchView(view) {
   document.querySelectorAll('.view-btn').forEach(b => b.classList.toggle('active', b.dataset.view === view));
   if (view !== 'ranked') {
     classifiersOnly = false;
-    adjustedOnly = false;
-    showTimePct = false;
   }
   syncChartModeControls();
 }
@@ -919,7 +918,8 @@ function switchView(view) {
 function syncChartModeControls() {
   const modes = [
     ['classifiersOnlyChk', 'classifiersToggleWrap', classifiersOnly],
-    ['adjustedOnlyChk', 'adjustedToggleWrap', adjustedOnly],
+    ['divisionPctChk', 'divisionToggleWrap', showDivisionPct],
+    ['adjustedPctChk', 'adjustedToggleWrap', showAdjustedPct],
     ['timePctChk', 'timePctToggleWrap', showTimePct],
   ];
   modes.forEach(([inputId, wrapId, active]) => {
@@ -933,16 +933,15 @@ function syncChartModeControls() {
 function setChartMode(mode, enabled) {
   if (mode === 'classifiers') {
     classifiersOnly = enabled;
-    if (enabled) adjustedOnly = false;
-    if (enabled) showTimePct = false;
+  } else if (mode === 'division') {
+    showDivisionPct = enabled;
+    classifiersOnly = false;
   } else if (mode === 'adjusted') {
-    adjustedOnly = enabled;
-    if (enabled) classifiersOnly = false;
-    if (enabled) showTimePct = false;
+    showAdjustedPct = enabled;
+    classifiersOnly = false;
   } else {
     showTimePct = enabled;
-    if (enabled) classifiersOnly = false;
-    if (enabled) adjustedOnly = false;
+    classifiersOnly = false;
   }
   syncChartModeControls();
   renderAll();
@@ -959,7 +958,10 @@ document.getElementById('classifiersOnlyChk').addEventListener('change', e => {
   setChartMode('classifiers', e.target.checked);
 });
 
-document.getElementById('adjustedOnlyChk').addEventListener('change', e => {
+document.getElementById('divisionPctChk').addEventListener('change', e => {
+  setChartMode('division', e.target.checked);
+});
+document.getElementById('adjustedPctChk').addEventListener('change', e => {
   setChartMode('adjusted', e.target.checked);
 });
 document.getElementById('timePctChk').addEventListener('change', e => {
@@ -1332,8 +1334,6 @@ function renderAll() {
     document.getElementById('statAdjAvgBox').style.display = 'none';
     document.getElementById('chartTimeTitle').textContent = classifiersOnly
       ? 'Classifier Scores Over Time'
-      : adjustedOnly
-      ? 'Adjusted % Over Time'
       : 'Score Over Time';
     renderClassBox(selectedDiv);
     return;
@@ -1360,8 +1360,6 @@ function renderAll() {
     document.getElementById('statAdjAvgBox').style.display = 'none';
     document.getElementById('chartTimeTitle').textContent = classifiersOnly
       ? 'Classifier Scores Over Time'
-      : adjustedOnly
-      ? 'Adjusted % Over Time'
       : 'Score Over Time';
     renderClassBox(selectedDiv);
     return;
@@ -1654,29 +1652,32 @@ function renderAll() {
     })),
   };
 
-  if (adjustedOnly || showTimePct) {
-    const onlySeries = adjustedOnly ? adjustedSeries : timeSeries;
-    const onlyPoints = adjustedOnly ? adjPoints : timeSeries.points.filter(point => point.y != null);
-    const metric = adjustedOnly ? 'Adjusted %' : 'Time %';
-    document.getElementById('chartTimeTitle').textContent = `${metric} Over Time`;
-    if (onlyPoints.length >= 2) {
-      drawMultiSeriesChart(document.getElementById('chartTime'), [onlySeries], onlySeries.points.map(point => point.date), {
-        yLabel: `${adjustedOnly ? 'Adjusted' : 'Time'} match %`, yMin: 0, yMax: 100, invertY: false,
-        trend: true, valueUnit: 'match%', preserveDuplicateDates: true, showPercentageReferenceGuides: true,
-      });
-    } else {
-      drawMessage(document.getElementById('chartTime'), adjustedOnly
-        ? 'Adjusted % needs 2 usable matches.\nRefresh older matches for non-classifier\ncross-division benchmark data.'
-        : 'Time % needs 2 usable matches.\nRefresh older matches for valid\ncombined-field raw-time benchmarks.');
-    }
-  } else {
-    // Add adjusted series if we have data (dashed line, distinct color)
-    if (adjPoints.length >= 2) scoreSeries.push(adjustedSeries);
-    drawMultiSeriesChart(document.getElementById('chartTime'), scoreSeries, allDates, {
+  const selectedSeries = [];
+  const unavailableMetrics = [];
+  if (showDivisionPct) {
+    const divisionSeries = scoreSeries.filter(series => series.points.filter(point => point.y != null).length >= 2);
+    if (divisionSeries.length) selectedSeries.push(...divisionSeries);
+    else unavailableMetrics.push('Division performance needs 2 usable matches.');
+  }
+  if (showAdjustedPct) {
+    if (adjPoints.length >= 2) selectedSeries.push(adjustedSeries);
+    else unavailableMetrics.push('Adjusted % needs 2 usable matches with non-classifier cross-division benchmarks.');
+  }
+  if (showTimePct) {
+    if (timeSeries.points.filter(point => point.y != null).length >= 2) selectedSeries.push(timeSeries);
+    else unavailableMetrics.push('Time % needs 2 usable matches with valid combined-field raw-time benchmarks.');
+  }
+
+  if (selectedSeries.length) {
+    drawMultiSeriesChart(document.getElementById('chartTime'), selectedSeries, allDates, {
       yLabel: 'Match performance %', yMin: 0, yMax: 100, invertY: false,
-      trend: true, valueUnit: 'match%',
+      trend: true, valueUnit: 'match%', preserveDuplicateDates: true,
       showPercentageReferenceGuides: true,
     });
+  } else {
+    drawMessage(document.getElementById('chartTime'), unavailableMetrics.length
+      ? unavailableMetrics.join('\n')
+      : 'Select a Score Over Time metric to display.');
   }
 
   const placeSeries = Object.entries(byDiv).map(([div, matches], i) => {

--- a/tests/time-percentage.test.js
+++ b/tests/time-percentage.test.js
@@ -34,13 +34,20 @@ test('match Time % averages usable stages and is unavailable with none', () => {
   assert.equal(matchTimePct([{ time: 0, fastest_combined_time: 10 }]), null);
 });
 
-test('Time % is the default exclusive Score Over Time mode', () => {
+test('Score Over Time defaults to independently visible performance series', () => {
   const html = fs.readFileSync('extension/dashboard.html', 'utf8');
   const script = fs.readFileSync('extension/dashboard.js', 'utf8');
 
-  assert.match(html, /Time % Only <small>\(experimental\)<\/small>/);
+  assert.match(html, /Division performance/);
+  assert.match(html, /Adjusted %<\/span>/);
+  assert.match(html, /Time % <small>\(experimental\)<\/small>/);
+  assert.doesNotMatch(html, /Adjusted % Only|Time % Only/);
+  assert.match(script, /let showDivisionPct\s*=\s*true/);
+  assert.match(script, /let showAdjustedPct\s*=\s*true/);
   assert.match(script, /let showTimePct\s*=\s*true/);
-  assert.match(script, /if \(adjustedOnly \|\| showTimePct\) \{/);
-  assert.match(script, /adjustedOnly \? adjustedSeries : timeSeries/);
-  assert.doesNotMatch(script, /if \(showTimePct\) scoreSeries\.push\(timeSeries\)/);
+  assert.match(script, /if \(showAdjustedPct\) \{/);
+  assert.match(script, /if \(showTimePct\) \{/);
+  assert.match(script, /selectedSeries\.push\(adjustedSeries\)/);
+  assert.match(script, /selectedSeries\.push\(timeSeries\)/);
+  assert.doesNotMatch(script, /adjustedOnly/);
 });


### PR DESCRIPTION
## Summary

Shows Division performance, Adjusted %, and Time % together by default with independent visibility controls and a classifier-only alternate mode.



## Files Changed

DESIGN.md, extension/dashboard.html, extension/dashboard.js, tests/time-percentage.test.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — node --check extension/dashboard.js; node --check extension/dashboard-charts.js; node --test tests/time-percentage.test.js tests/dashboard-charts.test.js tests/dashboard-analytics.test.js; git diff --check

Resolves #134


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.350 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-terra spent 3m and 103,460 tokens on this as a headless worker.
