### PR TITLE
GH#144: classify accuracy trends directionally

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -73,6 +73,11 @@ Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter
   Higher A is positive; lower B/C/D/M/NS is positive. Hit-zone tiles pair
   average shares with least-squares percentage-point trends using the same
   semantic directions.
+- Accuracy Trend classifies every finite nonzero least-squares predicted change
+  directionally: higher A and lower B/C/D/M/NS/M+NS are **Improving**; their
+  inverse is **Needs attention**. Only an exact-zero change is **Stable**;
+  missing or insufficient data remains unavailable. Raw percentage values and
+  visible status text remain alongside tone and icon.
 - Accuracy Trend uses a disclosed piecewise-linear geometry only: raw 0%, 5%,
   10%, 20%, 40%, 50%, and 100% map to 0%, 30%, 45%, 62%, 84%, 90%, and 100%
   of visual height. Its raw ticks are 0%, 1%, 2%, 5%, 10%, 20%, 40%, 50%, and

--- a/extension/dashboard-summaries.js
+++ b/extension/dashboard-summaries.js
@@ -88,7 +88,7 @@ function _signed(value, digits = 1) {
 function _trendStatus(delta, threshold = 1.0, lowerIsBetter = false) {
   const improvement = lowerIsBetter ? -delta : delta;
   if (improvement > threshold) return { tone: 'positive', icon: '↑', label: 'Improving' };
-  if (improvement < -threshold) return { tone: 'negative', icon: '↓', label: 'Declining' };
+  if (improvement < -threshold) return { tone: 'negative', icon: '↓', label: 'Needs attention' };
   return { tone: 'neutral', icon: '→', label: 'Stable' };
 }
 
@@ -436,7 +436,8 @@ function _outcomeTiles(points, mode) {
     if (mode === 'share' || mode === 'percentage') {
       const average = _avg(values);
       const trend = _overallTrend(values);
-      const status = trend ? _trendStatus(trend.delta, 1.0, lowerIsBetter) : null;
+      const threshold = mode === 'percentage' ? 0 : 1.0;
+      const status = trend ? _trendStatus(trend.delta, threshold, lowerIsBetter) : null;
       const thresholdNote = status?.label === 'Stable' ? ' · stable within ±1.0%' : '';
       tiles.push(_insightTile({
         label,

--- a/tests/dashboard-summaries.test.js
+++ b/tests/dashboard-summaries.test.js
@@ -126,20 +126,24 @@ test('missing placement and non-classifier values remain unavailable rather than
   assert.match(nonClassifier, /Not enough data/);
 });
 
-test('outcome summaries show color-coded improving or declining percentage changes', () => {
+test('accuracy trends classify every nonzero percentage change directionally', () => {
   context.leastSquaresRegression = samples => ({
     start: { y: samples[0].y },
     end: { y: samples.at(-1).y },
   });
 
-  const improving = context.outcomeTilesForTest([{ c: 4 }, { c: 2 }, { c: 1 }], 'percentage').join('');
+  const improving = context.outcomeTilesForTest([{ ns: 4 }, { ns: 3.8 }, { ns: 3.6 }], 'percentage').join('');
   assert.match(improving, /insight-tile--positive/);
   assert.match(improving, /Improving/);
-  assert.match(improving, /-3\.0% predicted change/);
+  assert.match(improving, /-0\.4% predicted change/);
   assert.doesNotMatch(improving, /pp/);
 
-  const declining = context.outcomeTilesForTest([{ d: 1 }, { d: 2 }, { d: 4 }], 'percentage').join('');
-  assert.match(declining, /insight-tile--negative/);
-  assert.match(declining, /Declining/);
-  assert.match(declining, /\+3\.0% predicted change/);
+  const needsAttention = context.outcomeTilesForTest([{ a: 10 }, { a: 9.8 }, { a: 9.6 }], 'percentage').join('');
+  assert.match(needsAttention, /insight-tile--negative/);
+  assert.match(needsAttention, /Needs attention/);
+  assert.match(needsAttention, /-0\.4% predicted change/);
+
+  const stable = context.outcomeTilesForTest([{ a: 10 }, { a: 10 }, { a: 10 }], 'percentage').join('');
+  assert.match(stable, /insight-tile--neutral/);
+  assert.match(stable, /Stable/);
 });


### PR DESCRIPTION
## Summary

Classified every finite nonzero Accuracy Trend change by its beneficial direction while leaving shared score, placement, classifier, and Hit Zone thresholds unchanged.



## Files Changed

DESIGN.md, extension/dashboard-summaries.js, tests/dashboard-summaries.test.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — node --check extension/dashboard-summaries.js; node --test tests/dashboard-summaries.test.js; node --test repository test files; git diff --check

Resolves #144


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.360 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-terra spent 3m and 82,193 tokens on this as a headless worker.
