### PR TITLE
GH#143: add match finish trend

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -59,16 +59,17 @@ Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter
 - Every insight tile identifies its metric, primary value, comparison basis,
   and sample size. Directional tiles use **Improving**, **Stable**, or
   **Needs attention**; non-directional values use explicit labels such as
-  **Field context**, **Overall view**, or **Association only** instead of
+  **Field context**, **Overall view**, or **Match context** instead of
   implying progress.
 - Overall percentage trends report the least-squares predicted first-to-last
   change for the filtered view. Score, placement, non-classifier, accuracy,
   hit-zone, and classifier insights use the same final dataset and
   stage-inclusion rules as their charts.
-- Classifier correlation is Pearson `r` across per-match classifier averages
-  paired with that match score, requires at least three varying pairs,
-  displays `n`, and is described only as an association. Prefer official
-  `clf_pct`; label any match-relative fallback and never infer a class from it.
+- Classifier summaries include a Match finish trend: the least-squares predicted
+  first-to-last percentage change across the current filtered match finishes.
+  It requires at least three comparable match finishes, displays `n`, and uses
+  the standard directional status. Prefer official `clf_pct`; label any
+  match-relative fallback and never infer a class from it.
 - Accuracy share tiles compare the last three matches with the prior baseline.
   Higher A is positive; lower B/C/D/M/NS is positive. Hit-zone tiles pair
   average shares with least-squares percentage-point trends using the same
@@ -98,7 +99,7 @@ Hit Factor Charts is a data-dense browser dashboard. Preserve the existing Inter
   `Class`; the approximation mark and accessible label keep it visibly
   unofficial. Official `clf_pct` uses the same hierarchy without `≈` and
   identifies itself as official to assistive technology. Never badge counts,
-  placement/field-beaten, variance, correlation, or hit-zone shares. Badges
+  placement/field-beaten, variance, trend deltas, or hit-zone shares. Badges
   include readable text as well as a theme-safe color, wrap without overflow,
   and remain compact from 375px through wide layouts.
 - Placement Over Time and Non-Classifier Stage Trend each use four insight tiles

--- a/extension/dashboard-summaries.js
+++ b/extension/dashboard-summaries.js
@@ -60,25 +60,13 @@ function _overallTrend(values) {
   const samples = values
     .map((value, index) => ({ x: index, y: value }))
     .filter(sample => Number.isFinite(sample.y));
+  if (samples.length < 3) return null;
   const regression = leastSquaresRegression(samples);
   if (!regression) return null;
   return {
     delta: regression.end.y - regression.start.y,
     count: samples.length,
   };
-}
-
-function _pearsonCorrelation(pairs) {
-  const finite = pairs.filter(pair => Number.isFinite(pair.x) && Number.isFinite(pair.y));
-  if (finite.length < 3) return null;
-  const meanX = _avg(finite.map(pair => pair.x));
-  const meanY = _avg(finite.map(pair => pair.y));
-  const numerator = finite.reduce((sum, pair) => sum + (pair.x - meanX) * (pair.y - meanY), 0);
-  const spreadX = finite.reduce((sum, pair) => sum + Math.pow(pair.x - meanX, 2), 0);
-  const spreadY = finite.reduce((sum, pair) => sum + Math.pow(pair.y - meanY, 2), 0);
-  const denominator = Math.sqrt(spreadX * spreadY);
-  if (!denominator) return null;
-  return { r: numerator / denominator, count: finite.length };
 }
 
 function _signed(value, digits = 1) {
@@ -376,8 +364,6 @@ function _nonClassifierTiles(points) {
 function _classifierData(sorted) {
   const officialScores = [];
   const fallbackScores = [];
-  const officialPairs = [];
-  const mixedPairs = [];
   const matchScores = [];
 
   for (const record of sorted) {
@@ -391,28 +377,15 @@ function _classifierData(sorted) {
     const matchScore = effectiveOverallPct(record);
     if (!Number.isFinite(matchScore)) continue;
     matchScores.push(matchScore);
-    if (official.length) officialPairs.push({ x: _avg(official), y: matchScore });
-    if (fallback.length) mixedPairs.push({ x: _avg(official.length ? official : fallback), y: matchScore });
   }
 
   const useOfficial = officialScores.length > 0;
   const scores = useOfficial ? officialScores : fallbackScores;
-  const useOfficialPairs = officialPairs.length >= 3;
   return {
     scores,
     basis: useOfficial ? 'Official USPSA national HHF' : 'Match-relative classifier fallback',
-    pairs: useOfficialPairs ? officialPairs : mixedPairs,
-    pairBasis: useOfficialPairs ? 'Official classifier % only' : 'Mixed basis, explicitly labelled',
     matchScores,
   };
-}
-
-function _correlationDescription(r) {
-  const magnitude = Math.abs(r);
-  if (magnitude >= 0.7) return 'Strong association';
-  if (magnitude >= 0.4) return 'Moderate association';
-  if (magnitude >= 0.2) return 'Weak association';
-  return 'Little association';
 }
 
 function _classifierTiles(sorted) {
@@ -422,7 +395,6 @@ function _classifierTiles(sorted) {
     ? _recentComparison(data.scores, recentSize)
     : null;
   const averageMatchScore = _avg(data.matchScores);
-  const correlation = _pearsonCorrelation(data.pairs);
 
   return [
     recent
@@ -455,15 +427,7 @@ function _classifierTiles(sorted) {
         meta: `Unofficial match-performance equivalent · n=${data.matchScores.length}`,
         status: _contextStatus('Match context', '◎'),
       }),
-    correlation
-      ? _insightTile({
-        label: 'Classifier correlation',
-        value: `r ${correlation.r.toFixed(2)}`,
-        comparison: `${_correlationDescription(correlation.r)} · association only`,
-        meta: `${data.pairBasis} · n=${correlation.count}`,
-        status: _contextStatus('Context, not causation', '↔'),
-      })
-      : _unavailableTile('Classifier correlation', 'At least 3 paired matches with variation are required.'),
+    _overallTrendTile('Match finish trend', data.matchScores),
   ];
 }
 

--- a/tests/dashboard-summaries.test.js
+++ b/tests/dashboard-summaries.test.js
@@ -104,6 +104,10 @@ test('non-classifier summaries add badged finite best and worst values', () => {
 });
 
 test('classifier fallback stays unbadged while official percentages receive official badges', () => {
+  context.leastSquaresRegression = samples => ({
+    start: { y: samples[0].y },
+    end: { y: samples.at(-1).y },
+  });
   const fallbackTiles = context.classifierTilesForTest([
     { stages: [{ isClassifier: true, pct: 45 }], overallPct: 55 },
     { stages: [{ isClassifier: true, pct: 50 }], overallPct: 60 },
@@ -114,6 +118,10 @@ test('classifier fallback stays unbadged while official percentages receive offi
   ]);
   assert.doesNotMatch(fallbackTiles[0], /performance-badge/);
   assert.doesNotMatch(fallbackTiles[1], /performance-badge/);
+  assert.match(fallbackTiles[3], /Match finish trend/);
+  assert.match(fallbackTiles[3], /\+25\.0%/);
+  assert.match(fallbackTiles[3], /Improving/);
+  assert.doesNotMatch(fallbackTiles.join(''), /(?:correlation|association)/i);
 
   const officialTiles = context.classifierTilesForTest([
     { stages: [{ isClassifier: true, clf_pct: 75 }], overallPct: 70 },
@@ -125,6 +133,17 @@ test('classifier fallback stays unbadged while official percentages receive offi
   ]);
   assert.match(officialTiles[0], /A Class, official classifier percentage/);
   assert.doesNotMatch(officialTiles[0], />≈</);
+});
+
+test('classifier match finish trend is unavailable with fewer than three match scores', () => {
+  const tiles = context.classifierTilesForTest([
+    { stages: [{ isClassifier: true, clf_pct: 75 }], overallPct: 70 },
+    { stages: [{ isClassifier: true, clf_pct: 76 }], overallPct: 71 },
+  ]);
+
+  assert.match(tiles[3], /Match finish trend/);
+  assert.match(tiles[3], /At least 3 comparable results are required/);
+  assert.match(tiles[3], /Not enough data/);
 });
 
 test('missing placement and non-classifier values remain unavailable rather than zero', () => {


### PR DESCRIPTION
## Summary

Replaced the Classifier correlation tile with a least-squares Match finish trend, preserving existing official and fallback classifier semantics.



## Files Changed

DESIGN.md, extension/dashboard-summaries.js, tests/dashboard-summaries.test.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — node --check extension/dashboard-summaries.js; node --test tests/dashboard-summaries.test.js; node --test tests/background-storage.test.js tests/dashboard-analytics.test.js tests/dashboard-charts.test.js tests/dashboard-summaries.test.js tests/time-percentage.test.js; git diff --check

Resolves #143


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.360 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-terra spent 6m and 194,884 tokens on this as a headless worker.
